### PR TITLE
feat(foreach): fine-grained diff in full-recompute fallback

### DIFF
--- a/src/org/replikativ/spindel/dom/foreach.cljc
+++ b/src/org/replikativ/spindel/dom/foreach.cljc
@@ -214,6 +214,56 @@
 ;; For-Each Implementation
 ;; =============================================================================
 
+(defn- compute-fine-grained-deltas
+  "When the new order differs from prev-order but common keys preserve
+  their relative order, emit per-item :update / :remove / :add deltas
+  rather than a brutal :replace-all.
+
+  Returns nil if relative order of common keys changed (caller should
+  fall back to :replace-all). The discharge layer applies the deltas
+  in emission order, so we emit:
+    1. :update deltas first (paths in OLD positions; updates don't shift)
+    2. :remove deltas in reverse-idx order (paths in OLD positions)
+    3. :add deltas in forward-idx order (paths in NEW positions)
+  This sequence keeps each delta's index valid against the live state
+  as the parent applies them."
+  [order prev-order by-key prev-by-key]
+  (let [old-keyset (set prev-order)
+        new-keyset (set order)
+        added-keys (clojure.set/difference new-keyset old-keyset)
+        removed-keys (clojure.set/difference old-keyset new-keyset)
+        common-keys (clojure.set/intersection old-keyset new-keyset)
+        common-in-old (filterv common-keys prev-order)
+        common-in-new (filterv common-keys order)
+        order-preserved? (= common-in-old common-in-new)]
+    (when order-preserved?
+      (let [old-positions (zipmap prev-order (range))
+            new-positions (zipmap order (range))
+            update-deltas (->> common-keys
+                               (keep (fn [k]
+                                       (let [old-vn (get prev-by-key k)
+                                             new-vn (get by-key k)]
+                                         (when-not (vnode-value-equal? old-vn new-vn)
+                                           {:delta :update
+                                            :path [(old-positions k)]
+                                            :old-value old-vn
+                                            :value new-vn}))))
+                               vec)
+            remove-deltas (->> removed-keys
+                               (map (fn [k] {:delta :remove
+                                             :path [(old-positions k)]
+                                             :old-value (get prev-by-key k)}))
+                               (sort-by #(- (first (:path %))))
+                               vec)
+            add-deltas (->> added-keys
+                            (map (fn [k] {:delta :add
+                                          :path [(new-positions k)]
+                                          :value (get by-key k)}))
+                            (sort-by #(first (:path %)))
+                            vec)
+            all (vec (concat update-deltas remove-deltas add-deltas))]
+        (when (seq all) all)))))
+
 (defn- build-fragment-result
   "Build the KeyedFragment result from resolved items.
 
@@ -238,11 +288,16 @@
                    ;; Empty - no deltas
                    nil)
 
-                 ;; Order changed - need structural update
+                 ;; Order changed - try fine-grained add/remove/update before
+                 ;; falling back to a wholesale :replace-all. The fine-grained
+                 ;; path emits O(diff) deltas; :replace-all unmounts and remounts
+                 ;; every keyed item which is O(n) DOM work for any single change.
                  (not= order prev-order)
-                 [{:delta :replace-all
-                   :old-items (mapv #(get prev-by-key %) prev-order)
-                   :items items}]
+                 (or (compute-fine-grained-deltas order prev-order by-key prev-by-key)
+                     ;; Common keys reordered relative to each other — bail out.
+                     [{:delta :replace-all
+                       :old-items (mapv #(get prev-by-key %) prev-order)
+                       :items items}])
 
                  ;; Same order - check if any items changed by comparing vnodes
                  :else


### PR DESCRIPTION
## Summary

When \`ifor-each\` falls into the full-recompute path — typically because the caller didn't wire deltas through the upstream interval — \`build-fragment-result\` previously emitted a single \`:replace-all\` delta whenever \`(not= order prev-order)\`. For \"added one item to a list of N\", that produces N+1 unmounts and N+1 mounts. In one UIx app I instrumented, adding a single block to a 17-element keyed list produced 94 DOM mutations (full unmount + full remount of every block).

This patch keeps \`:replace-all\` as a last-resort fallback but tries fine-grained per-item deltas first, when the relative order of common keys is preserved between renders.

## What changed

New helper \`compute-fine-grained-deltas\` in \`build-fragment-result\`. When common keys keep the same relative order:

1. **\`:update\`** for each common key whose vnode value differs (paths in OLD positions — updates don't shift)
2. **\`:remove\`** for keys that disappeared, in **reverse-index order** (paths in OLD positions; descending so earlier removes don't invalidate later indices)
3. **\`:add\`** for keys that appeared, in **forward-index order** (paths in NEW positions; ascending so each insert sees the post-insert state of earlier ones)

When the relative order of common keys changed (e.g. \`[a b c d]\` → \`[c b a d]\`), \`compute-fine-grained-deltas\` returns nil and we fall back to \`:replace-all\`. Truly handling reorders would require move-aware diff plus extending \`cache/adjust-delta-paths\` to handle \`:move\`'s \`:from-path\`/\`:to-path\`; that's a follow-up.

## Test plan

Validated against five edge cases at the function level (REPL):

- [x] Add at end: \`[a b c]\` → \`[a b c d]\` ⇒ one \`{:delta :add :path [3] :value vd}\`
- [x] Remove from middle: \`[a b c d]\` → \`[a c d]\` ⇒ one \`{:delta :remove :path [1] :old-value vb}\`
- [x] Insert in middle: \`[a b c]\` → \`[a x b c]\` ⇒ one \`{:delta :add :path [1] :value vx}\`
- [x] Mixed adds/removes preserving relative order: \`[a b c d e]\` → \`[a x c y e]\` ⇒ \`[:remove [3], :remove [1], :add [1], :add [3]]\` (applied in this order leaves DOM at the right state)
- [x] Reorder of common keys: \`[a b c d]\` → \`[c b a d]\` ⇒ \`nil\` (falls back to \`:replace-all\`)
- [x] Same order, value change in one item: handled by the existing same-order branch (untouched)

End-to-end in a real app: with this patch, adding one item to a 17-element list emits exactly one \`:add\` delta from \`build-fragment-result\`, vs the previous \`:replace-all\` that triggered N+1 unmounts.