### PR TITLE
test: pin glitch-freedom for dynamic dependency rediscovery

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -143,6 +143,23 @@ Resume each observer's track-cont (parallel on JVM for >1)
 Completions enqueue on :engine/pending, drained FIFO (no glitches)
 ```
 
+### Dynamic Dependencies
+
+The diamond above is a *static* graph. But a spin can change which dependencies it has from one run to the next:
+
+```clojure
+(spin
+  (if (= 42 (:new (track x)))
+    (await k)   ;; depends on `k` — but only when x = 42
+    0))         ;; otherwise, no dependency on `k`
+```
+
+When `x` ≠ 42 the edge to `k` does not exist. A topological sort built from that graph cannot order `k` before this spin — the edge only appears *after* the spin re-runs and takes the other branch.
+
+Spindel stays glitch-free here because `await` is a **pull**: awaiting a dirty dependency re-executes it rather than returning its (stale) cache. The dependency chain is walked in the data-flow order of the *current* run, not a precomputed one — so a dependency discovered mid-flight is always read fresh. The topological sort is an optimization layered on top; it is not what makes this case correct.
+
+This is the reactive-systems failure mode Kenny Tilton (Cells) named the "Pentagram of Death". See `test/org/replikativ/spindel/continuation_glitch_test.clj` for the regression tests.
+
 ### Batching Multiple Signals
 
 Use `batch` to group signal changes into a single propagation:

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -156,6 +156,27 @@ While observer bodies execute, they may produce more events: `:spin-completion` 
 
 The descendant-filtering + ancestor-escalation step preserves the no-glitch guarantee without a per-batch barrier: within one `:signal-change` dispatch all directly-affected observers resume against the fresh signal value, and downstream completions propagate via the same drain in FIFO order — no spin ever sees a partially-updated graph.
 
+### Dynamically-discovered dependencies
+
+Topological dispatch orders the graph *as it exists when the signal changes*. But a spin re-tracks its dependencies on every run (see [Dependency Tracking](#dependency-tracking-and-the-graph) below), so a conditional branch can establish a brand-new edge that only appears *after* the spin re-runs:
+
+```clojure
+(spin (if (= 42 (:new (track x)))
+        (await k)   ;; edge to `k` exists only when x = 42
+        0))
+```
+
+A topological sort built before re-execution cannot order `k` ahead of this spin — that edge did not exist yet. Correctness in this case does not come from the sort; it comes from `await` being demand-driven.
+
+`await-spin` (`effects/await.cljc`) takes the **fast path** — return the child's cached result — only when the child has a cached result, is **not dirty**, and either we are not inside a `:signal-change` batch *or* the child was already processed in this batch (`:processed` set). Otherwise it takes the **slow path**: re-execute the child's body, which re-reads the child's own `track` / `await` dependencies recursively; the awaiting spin suspends on a continuation and resumes with the freshly-computed value.
+
+Two independent guards keep this robust mid-propagation:
+
+- **Dirty flag** — `mark-dirty!` BFS-marks the changed signal's transitive observers dirty, so awaiting any of them refuses the fast path.
+- **Batch `:processed` set** — a spin newly pulled into the graph by a conditional `await` was never marked dirty, but it is also not in `:processed`, so the fast path is refused and the child is re-executed anyway.
+
+So a dependency chain — including edges discovered *during* this propagation — is always walked in the true data-flow order of the current computation. The topological sort is a scheduling optimization that avoids redundant re-runs for the common static graph; it is not the correctness mechanism for dynamic dependencies. See `test/org/replikativ/spindel/continuation_glitch_test.clj` and [`concepts.md`](concepts.md#dynamic-dependencies).
+
 ## Dependency Tracking and the Graph
 
 Spindel tracks dependencies automatically at runtime, on a **unified-subscription** model: observer registration happens *eagerly* at the moment the body calls `track` or `await`, not deferred to body completion.

--- a/test/org/replikativ/spindel/continuation_glitch_test.clj
+++ b/test/org/replikativ/spindel/continuation_glitch_test.clj
@@ -208,3 +208,110 @@
         (is (= 25 @t1))
         (is (= 9 @t2))  ; unchanged
         (is (= 39 @combined) "combined should see consistent s1 and t1 values (no glitch!)")))))
+
+;; =============================================================================
+;; Dynamic Dependency Rediscovery — the "Pentagram of Death"
+;;
+;; Credit: Kenny Tilton (Cells), who named this failure mode and built the
+;; original `df-interference` test for it.
+;;
+;; The topological sort is computed from the dependency graph that exists
+;; BEFORE re-execution. But a conditional branch inside a spin body can
+;; establish a brand-new dependency edge only AFTER the spin re-runs — an
+;; edge the old topo sort never saw and could not have ordered. A scheduler
+;; that trusted the topo sort alone would let a spin read a stale cache
+;; through that new edge.
+;;
+;; Spindel is immune because `await` is a demand-driven pull: awaiting a
+;; dirty / not-yet-processed child re-executes that child rather than
+;; returning its cache (see effects/await.cljc `await-spin`, the
+;; `allow-fast-path?` gate). The dependency chain is therefore walked in
+;; the true data-flow order of the CURRENT computation, not a precomputed
+;; one. These tests pin that behavior so a future scheduler change cannot
+;; silently reintroduce the glitch.
+;; =============================================================================
+
+(deftest test-pentagram-dynamic-dependency-no-glitch
+  (testing "Conditionally-discovered dependency: no stale read through a new edge"
+    (th/with-ctx [ctx]
+      ;; Kenny Tilton's example:
+      ;;   X = 0
+      ;;   A = X + B
+      ;;   B = if X == 42 then K else 0
+      ;;   K = X
+      ;;
+      ;; At X=0, B takes the `else` branch and NEVER awaits K, so the edge
+      ;; B->K does not exist. At X->42, B re-runs, takes the `then` branch,
+      ;; and NEWLY awaits K. The topo sort built from the X=0 graph cannot
+      ;; know "K before B". If B read K's stale cache (0), A would be 42.
+      (let [x (sig/signal 0)
+            k (spin (:new (track x)))
+            b (spin (if (= 42 (:new (track x)))
+                      (await k)
+                      0))
+            a (spin (+ (:new (track x)) (await b)))]
+
+        ;; X = 0: else branch taken, no B->K edge exists yet
+        (is (= 0 @k))
+        (is (= 0 @b))
+        (is (= 0 @a))
+
+        ;; X -> 42: B re-runs and discovers its dependency on K
+        (swap! x (constantly 42))
+        (await-drain ctx)
+
+        (is (= 42 @k) "K = X = 42")
+        (is (= 42 @b) "B took the then-branch and awaited fresh K")
+        (is (= 84 @a) "A = X + B = 42 + 42; would be 42 if B read stale K")))))
+
+(deftest test-newly-discovered-dependency-chain-no-glitch
+  (testing "A multi-hop sub-path discovered entirely during re-execution"
+    (th/with-ctx [ctx]
+      ;;   X = 0
+      ;;   O = X            (tracks X)
+      ;;   K = 10 * O       (awaits O; does NOT track X)
+      ;;   B = if X == 42 then K else 0
+      ;;   A = X + B
+      ;;
+      ;; At X=0, neither K nor O is on B's path, and K is not an observer
+      ;; of X at all. At X->42 the whole B->K->O sub-path is discovered
+      ;; while B re-executes — each hop resolved by a recursive await-pull.
+      (let [x (sig/signal 0)
+            o (spin (:new (track x)))
+            k (spin (* 10 (await o)))
+            b (spin (if (= 42 (:new (track x)))
+                      (await k)
+                      0))
+            a (spin (+ (:new (track x)) (await b)))]
+
+        (is (= 0 @a) "X=0: B short-circuits, K and O never enter the graph")
+
+        (swap! x (constantly 42))
+        (await-drain ctx)
+
+        (is (= 42 @o) "O = X = 42")
+        (is (= 420 @k) "K = 10 * O")
+        (is (= 420 @b) "B awaited the newly-discovered K")
+        (is (= 462 @a) "A = X + B = 42 + 420; full B->K->O chain rediscovered")))))
+
+(deftest test-dynamic-dependency-add-and-prune
+  (testing "The conditional B->K edge is added and pruned cleanly across toggles"
+    (th/with-ctx [ctx]
+      ;; Same graph as the Pentagram test, toggled repeatedly. Verifies the
+      ;; B->K edge is established when X=42 and pruned when X leaves 42 —
+      ;; no stale dependency accumulates, no stale value leaks through.
+      (let [x (sig/signal 0)
+            k (spin (:new (track x)))
+            b (spin (if (= 42 (:new (track x)))
+                      (await k)
+                      0))
+            a (spin (+ (:new (track x)) (await b)))]
+
+        (is (= 0 @a))
+
+        (doseq [[v expected] [[42 84] [0 0] [42 84] [7 7] [42 84] [0 0]]]
+          (swap! x (constantly v))
+          (await-drain ctx)
+          (is (= expected @a)
+              (str "X=" v " => A should be " expected
+                   " (B->K edge " (if (= v 42) "active" "pruned") ")")))))))


### PR DESCRIPTION
## Summary

Adds regression tests and documentation for **dynamic dependency rediscovery** — the case where a conditional branch inside a spin body establishes a brand-new dependency edge only *after* the spin re-runs, an edge no topological sort could have ordered (Kenny Tilton's "Pentagram of Death" from Cells).

Spindel is already glitch-free here, because `await` is a demand-driven pull: awaiting a dirty / not-yet-processed child re-executes it rather than returning a stale cache, so the dependency chain is walked in the true data-flow order of the current computation. The topological sort is an optimization layered on top, not the correctness mechanism for this case. This PR **pins that behavior** so a future scheduler change cannot silently regress it, and closes a documentation gap.

## Changes

**Tests** (`test/org/replikativ/spindel/continuation_glitch_test.clj`)
- `test-pentagram-dynamic-dependency-no-glitch` — Tilton's exact example (`B = if X==42 then K else 0`); the `B→K` edge appears only after re-execution
- `test-newly-discovered-dependency-chain-no-glitch` — a multi-hop `B→K→O` sub-path discovered entirely during re-execution
- `test-dynamic-dependency-add-and-prune` — the conditional edge is added and pruned cleanly across repeated toggles

**Docs**
- `concepts.md` — new "Dynamic Dependencies" subsection (conceptual: conditional `await`, why topo sort can't order an edge that doesn't exist yet)
- `scheduling.md` — new "Dynamically-discovered dependencies" subsection (mechanism: the `await-spin` fast/slow-path gate, the dirty flag and batch `:processed` set as the two guards)

## Verification

```
clj -X:test :nses '[org.replikativ.spindel.continuation-glitch-test]'
Ran 8 tests containing 57 assertions. 0 failures, 0 errors.
```

The doc commits touch no code.

## Context

Raised in feedback from Kenny Tilton (creator of Cells): does Spindel handle the case where topological sort over the *old* graph is wrong for the *new* graph? It does — these tests and docs make that explicit and regression-proof.