### PR TITLE
fix(dom): keyed ifor-each DOM duplication on re-render

### DIFF
--- a/src/org/replikativ/spindel/dom/addressing.cljc
+++ b/src/org/replikativ/spindel/dom/addressing.cljc
@@ -34,15 +34,18 @@
   #?(:cljs (:require-macros [org.replikativ.spindel.dom.addressing])))
 
 ;; =============================================================================
-;; Ephemeral key registration
+;; Spin scope key registration
 ;; =============================================================================
 ;;
-;; DOM parent-addr and current-slot are per-render-pass scope. They must be
-;; cleared when a track continuation resumes (= start of a new render pass),
-;; but preserved across await resumes (= resuming mid-body in the same pass).
+;; :dom/parent-addr and :dom/current-slot are lexical scope for element
+;; addressing — set by element macros around the point a spin is created.
+;; A spin's body must address its elements under that same scope on every
+;; re-run. Registering them as spin-scope keys (see engine.bindings) makes
+;; the engine snapshot them at spin construction and re-establish them on
+;; every body-entry path — without the engine ever naming a :dom/* key.
 
-(bindings/register-ephemeral-binding-key! :dom/parent-addr)
-(bindings/register-ephemeral-binding-key! :dom/current-slot)
+(bindings/register-spin-scope-key! :dom/parent-addr)
+(bindings/register-spin-scope-key! :dom/current-slot)
 
 ;; =============================================================================
 ;; Tree Address Computation

--- a/src/org/replikativ/spindel/dom/addressing.cljc
+++ b/src/org/replikativ/spindel/dom/addressing.cljc
@@ -15,7 +15,7 @@
 
   **CPS-Aware Design:**
 
-  The context binding helpers (with-parent-addr, with-slot, with-keyed-context)
+  The context binding helpers (with-parent-addr, with-slot, with-dom-context)
   are MACROS that expand to `binding` forms. This is critical for CPS/await
   support in element children:
 
@@ -71,14 +71,24 @@
     (keyword (str "el-" uuid))))
 
 (defn keyed-child-address
-  "Compute address for a keyed child (inside ifor-each).
+  "Compute address for a keyed child.
 
-  Uses the item's key instead of slot index for stable identity
-  across reorderings.
+  Uses the item's key instead of slot index, so identity is stable
+  across reorderings of the surrounding collection.
+
+  Two callers, two roles:
+  - `dom/foreach`'s `for-each*` passes the `ifor-each`'s own (stable)
+    address as `parent-addr` plus the item key — giving each item true
+    position-independent identity.
+  - `build-element` passes the element's own structural `my-addr` for a
+    keyed element — there the key only disambiguates multiple keyed
+    elements at the same source location (e.g. siblings from a `map`); it
+    does NOT confer position-independent identity, since `my-addr` itself
+    depends on slot. Position-independent identity is `ifor-each`'s job.
 
   Args:
-    parent-addr - Parent element's address (the ifor-each's address)
-    item-key - The key extracted from the item (via key-fn)
+    parent-addr - Address to scope the key under (see above)
+    item-key    - The key extracted from the item (via key-fn)
 
   Returns: Keyword address"
   [parent-addr item-key]
@@ -148,17 +158,6 @@
         (with-slot ~slot-index
           ~@body))))
 
-#?(:clj
-   (defmacro with-keyed-context
-     "Execute body with keyed child context (for ifor-each items).
-
-     Sets parent-addr to the keyed address and slot to 0
-     (keyed children typically have single root element)."
-     [parent-addr item-key & body]
-     `(let [keyed-addr# (keyed-child-address ~parent-addr ~item-key)]
-        (with-dom-context keyed-addr# 0
-          ~@body))))
-
 ;; =============================================================================
 ;; Function Versions (for programmatic/runtime use)
 ;; =============================================================================
@@ -188,10 +187,10 @@
     (thunk)))
 
 (defn with-keyed-context-fn
-  "Function version of with-keyed-context for runtime/programmatic use.
+  "Execute `thunk` with keyed child context — used for ifor-each items.
 
-  Executes thunk with keyed child context. Use the macro version in element
-  macros for CPS/await support.
+  Sets :dom/parent-addr to (keyed-child-address parent-addr item-key) and
+  :dom/current-slot to 0 (a keyed child is a single root element).
 
   In addition to the DOM bindings, this also forks the addressing chain-head
   by hashing the item-key into it for the duration of the thunk. That makes

--- a/src/org/replikativ/spindel/dom/discharge.cljc
+++ b/src/org/replikativ/spindel/dom/discharge.cljc
@@ -274,6 +274,32 @@
                       :hint "Two vnodes claim the same :addr in one render pass. Use ifor-each for cardinality-variable lists, or split the call site so each sibling has a distinct source-loc. (Logged once per process — see logged-collisions atom.)"}))
         (swap! *rendered-addrs* assoc addr vnode)))))
 
+;; Addresses whose per-element caches are slated for eviction because a
+;; vnode at that address was unmounted this render pass. Eviction is
+;; *deferred* to end-of-cycle: an unmount runs before the live subtree is
+;; render-initial!'d, so an address can sit in both a destroyed subtree and
+;; a live one within one pass (a churned parent whose keyed descendants
+;; survive). `flush-pending-evictions!` drops only the addresses absent
+;; from `*rendered-addrs*` once the pass is complete.
+(def ^:dynamic *pending-evictions* nil)
+
+(defn flush-pending-evictions!
+  "Evict the per-element caches of addresses unmounted this render pass
+  that no live element claimed. Call once, after the full discharge walk,
+  inside the `*pending-evictions*` / `*rendered-addrs*` binding.
+
+  Eager eviction on unmount is unsafe: unmount runs before the live
+  subtree is render-initial!'d, so it would wipe the cache of an address
+  that a still-live element (a surviving keyed descendant of a churned
+  parent) re-claims later in the same pass. By end-of-pass `*rendered-addrs*`
+  holds every live address, so (pending - live) is exactly the dead set."
+  []
+  (when (and *pending-evictions* *rendered-addrs*)
+    (let [live (set (keys @*rendered-addrs*))]
+      (doseq [addr @*pending-evictions*]
+        (when-not (contains? live addr)
+          (cache/evict-cache! addr))))))
+
 ;; =============================================================================
 ;; Attribute Delta Application
 ;; =============================================================================
@@ -862,13 +888,17 @@
   Returns the vdom with deltas cleared."
   [discharge vdom]
   (binding [*rendered-vnodes* (atom #{})
-            *rendered-addrs* (atom {})]
+            *rendered-addrs* (atom {})
+            *pending-evictions* (atom #{})]
     (let [nodes (collect-nodes-with-deltas vdom)]
       (log/debug ::discharge-all {:nodes-count (count nodes)
                                   :nodes-with-deltas (mapv (fn [n] {:tag (:tag n) :deltas (:deltas n)}) nodes)})
       (doseq [node nodes]
         (discharge-vnode! discharge node))
       (let [result (clear-deltas-deep vdom)]
+        ;; Evict caches of addresses unmounted this pass that no live
+        ;; element re-claimed (deferred — see flush-pending-evictions!).
+        (flush-pending-evictions!)
         ;; Advance the applied-vnodes generations so memory stays
         ;; bounded while cross-cycle cached-result protection holds.
         (rotate-applied! *applied-vnodes*)
@@ -924,10 +954,12 @@
                                          :error (str e)})))))
 
 (defn- call-refs-on-unmount!
-  "Recursively call ref callbacks with nil and evict per-element cache state
-  for a vnode and its descendants. Called on every unmount path so the
-  [:dom/cache addr] / [:dom/attr-cache addr] entries do not accumulate for
-  the lifetime of the context."
+  "Recursively call ref callbacks with nil for a vnode and its descendants,
+  and schedule their per-element caches for eviction. The eviction itself
+  is deferred to end-of-cycle (see `*pending-evictions*` /
+  `flush-pending-evictions!`) so it cannot wipe a cache that an address
+  still-live elsewhere in the same render pass re-claims. Outside a render
+  pass (no binding) eviction falls back to eager, as before."
   [vnode]
   (when vnode
     (cond
@@ -941,7 +973,10 @@
       (core/vnode? vnode)
       (do
         (call-ref! vnode nil)
-        (cache/evict-cache! (:addr vnode))
+        (if *pending-evictions*
+          (when-let [addr (:addr vnode)]
+            (swap! *pending-evictions* conj addr))
+          (cache/evict-cache! (:addr vnode)))
         (when-let [children (:children vnode)]
           (let [child-vec (if (d/deltaable? children) @children children)]
             (doseq [child child-vec]

--- a/src/org/replikativ/spindel/dom/discharge.cljc
+++ b/src/org/replikativ/spindel/dom/discharge.cljc
@@ -43,7 +43,7 @@
             [org.replikativ.spindel.incremental.deltaable :as d]
             [org.replikativ.spindel.incremental.permutation :as perm]
             [replikativ.logging :as log])
-  #?(:clj (:import [java.util Collections WeakHashMap])))
+  #?(:clj (:import [java.util Collections IdentityHashMap])))
 
 ;; =============================================================================
 ;; Discharge Protocol
@@ -141,58 +141,90 @@
 ;; this set, every time a parent re-emits and embeds the cached child
 ;; vnode, the same :deltas fire again, duplicating children in the DOM.
 ;;
-;; Identity comparison (`identical?` via a Java IdentityHashMap-backed
-;; set, or a regular Clojure set when the vnodes are persistent values)
-;; is the right granularity: a *new* vnode at the same addr with new
-;; deltas (e.g. a rebuild because the spin re-ran) is a different object
-;; and gets its deltas applied normally.
+;; Identity comparison is the WHOLE point: a *new* vnode at the same
+;; addr with new deltas (e.g. a rebuild because the spin re-ran, OR a
+;; fresh build-element output that just happens to be value-equal to a
+;; prior cycle's vnode) is a different object and MUST get its deltas
+;; applied. Value comparison here is a correctness bug — when a source
+;; oscillates back to an equal state, two distinct render cycles
+;; produce value-equal parent vnodes, and a value-keyed set silently
+;; drops the second cycle's deltas, leaving stale / duplicated DOM.
 (def ^:dynamic *applied-vnodes* nil)
 
 ;; ----------------------------------------------------------------------------
-;; Weak-set helpers for *applied-vnodes*
+;; Generational identity tracking for *applied-vnodes*
 ;; ----------------------------------------------------------------------------
 ;;
-;; *applied-vnodes* used to be `(atom #{})`. The atom held STRONG references
-;; to every vnode whose deltas had been applied during the render effect's
-;; lifetime. Each time a spin re-ran and produced a fresh cached result, the
-;; OLD vnode was no longer reachable via :nodes[id]:result but stayed pinned
-;; by this set — an unbounded leak in long-running apps that accumulate
-;; thousands of re-renders over a session.
+;; Requirements: (a) IDENTITY semantics — "have I seen THIS object?",
+;; never "an equal one"; (b) bounded memory — a naive identity set held
+;; for the render-effect's whole life pins every vnode ever discharged.
 ;;
-;; Weak-set semantics are exactly right here: we only need "have I seen
-;; THIS vnode object?" (identity, not value); when the vnode becomes
-;; otherwise unreachable, dropping it from the set is correct — the cached
-;; spin result that referenced it is gone, so no future cycle will encounter
-;; it again. CLJ uses Collections/newSetFromMap over WeakHashMap (the
-;; canonical recipe), wrapped in synchronizedSet because multiple
-;; async-dispatch threads can drive concurrent discharge passes against
-;; the same applied-set. CLJS is single-threaded so a bare js/WeakSet
-;; suffices.
+;; The JVM has no weak *identity* map in the stdlib (`WeakHashMap` is
+;; value-keyed; `IdentityHashMap` is strong). So instead of relying on
+;; GC we bound memory explicitly with two generations, :prev and :cur,
+;; rotated once per discharge cycle (`rotate-applied!`). A cached spin
+;; result that is still being re-embedded is re-touched into :cur every
+;; cycle, so it never ages out while live; once its spin re-runs and it
+;; stops being embedded, it falls out within two cycles. CLJS keeps a
+;; bare js/WeakSet — JS WeakSet is already weak AND identity-keyed — so
+;; the generational machinery is a CLJ-only no-op there.
+;;
+;; synchronizedSet because multiple async-dispatch threads can drive
+;; concurrent discharge passes against the same applied-set.
+
+#?(:clj
+   (defn- identity-vnode-set []
+     (Collections/synchronizedSet
+      (Collections/newSetFromMap (IdentityHashMap.)))))
 
 (defn make-applied-vnodes
-  "Create a fresh weak set for tracking applied vnodes (one per render-effect).
-   Returns an object with identity-based 'have I seen this?' semantics that
-   does NOT prevent the vnode from being GC'd when its cached spin result
-   is dropped."
+  "Create a fresh applied-vnodes tracker (one per render-effect).
+
+   CLJ: an atom holding `{:prev <identity-set> :cur <identity-set>}`.
+   CLJS: a js/WeakSet (already weak + identity-keyed).
+
+   Identity-based 'have I seen THIS object?' semantics; memory is
+   bounded to ~2 discharge cycles via `rotate-applied!`."
   []
-  #?(:clj  (Collections/synchronizedSet
-            (Collections/newSetFromMap (WeakHashMap.)))
+  #?(:clj  (atom {:prev (identity-vnode-set) :cur (identity-vnode-set)})
      :cljs (js/WeakSet.)))
 
-(defn- applied-contains?
-  "Has this vnode object been marked applied? Nil-safe on the set arg
-   (matches the existing `(and *applied-vnodes* …)` guards)."
+(defn- applied-seen?!
+  "Identity check: was this exact vnode object already discharged in
+   this cycle or the previous one? Nil-safe on the set arg.
+
+   Side effect: when the vnode is found only in the older (:prev)
+   generation, it is refreshed into :cur — so a cached spin result
+   that keeps being re-embedded never ages out across the rotation."
   [s vnode]
   (and s
-       #?(:clj  (.contains ^java.util.Set s vnode)
+       #?(:clj  (let [{:keys [prev cur]} @s]
+                  (cond
+                    (.contains ^java.util.Set cur vnode)  true
+                    (.contains ^java.util.Set prev vnode) (do (.add ^java.util.Set cur vnode)
+                                                              true)
+                    :else false))
           :cljs (.has s vnode))))
 
 (defn- applied-add!
-  "Mark this vnode object as applied. No-op when the set is nil."
+  "Mark this vnode object as applied in the current generation.
+   No-op when the set is nil."
   [s vnode]
   (when s
-    #?(:clj  (.add ^java.util.Set s vnode)
+    #?(:clj  (.add ^java.util.Set (:cur @s) vnode)
        :cljs (.add s vnode)))
+  nil)
+
+(defn- rotate-applied!
+  "Advance the applied-vnodes generations at a discharge-cycle
+   boundary: this cycle's :cur becomes :prev and a fresh empty :cur
+   starts. Bounds memory to the last two cycles' worth of applied
+   vnodes. CLJS's js/WeakSet is GC-managed, so this is a no-op there."
+  [s]
+  #?(:clj  (when s
+             (swap! s (fn [{:keys [cur]}]
+                        {:prev cur :cur (identity-vnode-set)})))
+     :cljs nil)
   nil)
 
 ;; Track addresses claimed during the current render pass. If two different
@@ -764,7 +796,7 @@
   [discharge vnode]
   (when vnode
     (let [is-rendered? (and *rendered-vnodes* (contains? @*rendered-vnodes* vnode))
-          is-applied?  (applied-contains? *applied-vnodes* vnode)]
+          is-applied?  (applied-seen?! *applied-vnodes* vnode)]
       (log/debug ::discharge-vnode {:tag (:tag vnode)
                                     :is-rendered? is-rendered?
                                     :is-applied? is-applied?
@@ -836,7 +868,11 @@
                                   :nodes-with-deltas (mapv (fn [n] {:tag (:tag n) :deltas (:deltas n)}) nodes)})
       (doseq [node nodes]
         (discharge-vnode! discharge node))
-      (clear-deltas-deep vdom))))
+      (let [result (clear-deltas-deep vdom)]
+        ;; Advance the applied-vnodes generations so memory stays
+        ;; bounded while cross-cycle cached-result protection holds.
+        (rotate-applied! *applied-vnodes*)
+        result))))
 
 ;; =============================================================================
 ;; Delta Clearing

--- a/src/org/replikativ/spindel/dom/foreach.cljc
+++ b/src/org/replikativ/spindel/dom/foreach.cljc
@@ -55,11 +55,11 @@
      was already correct, and dropping the incremental branch shrinks
      this file from ~680 to ~250 LOC."
   (:refer-clojure :exclude [await])
-  (:require [clojure.set :as set]
-            [org.replikativ.spindel.dom.fragment :as frag]
+  (:require [org.replikativ.spindel.dom.fragment :as frag]
             [org.replikativ.spindel.dom.addressing :as addr]
             [org.replikativ.spindel.incremental.interval :as iv]
             [org.replikativ.spindel.incremental.deltaable :as d]
+            [org.replikativ.spindel.incremental.sequence-algebra :as sa]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.spin.cps :refer [spin]]
             [org.replikativ.spindel.effects.await :refer [await]])
@@ -142,114 +142,27 @@
   (ec/swap-state! [:dom/keyed-cache addr] (constantly cache-data)))
 
 ;; =============================================================================
-;; Delta derivation — build a SequenceAlgebra diff from prev/new state
+;; Delta derivation — package the keyed SequenceAlgebra diff for discharge
 ;; =============================================================================
 
 (defn- build-seq-diff
-  "Build a SequenceAlgebra diff describing how to transform the prev
-   vnode list (in `prev-order`) into the new vnode list (in `order`).
+  "Build the discharge-layer `:seq-diff` delta for the fragment.
 
-   Returns either a single `:seq-diff` delta (in a wrapping vector) or
-   `nil` when nothing changed.
+   The keyed-sequence diff itself is computed by the incremental layer
+   (`sequence-algebra/keyed-seq-diff`) — identity is the item key, and
+   per-key change is detected with structural vnode equality. This
+   function only packages the resulting SequenceAlgebra diff as the
+   `:seq-diff` delta the discharge tree-walk consumes, attaching
+   `:prev-items` (the previous vnodes in DOM order) that `apply-seq-diff!`
+   needs.
 
-   Construction
-   ------------
-   Let n_old = (count prev-order), n_new = (count order).
-
-   - removed = prev keys absent from new
-   - added   = new keys absent from prev
-   - common  = intersection (whether or not their relative order
-               changes; the permutation handles reordering)
-
-   Layout in working space [0, n_old + grow):
-   - [0, n_old): the prev items at their original positions
-   - [n_old, n_old + grow): the appended grown slots (one per added key)
-
-   The permutation π sends:
-   - each surviving key from old-pos(k) to new-pos(k)
-   - each removed key from old-pos(k) to a doomed tail slot in
-     [n_new, n_new + shrink) — these are dropped by the shrink phase
-   - each added key from a grown slot in [n_old, n_old + grow) to its
-     new-pos(k)
-
-   :change covers two cases at new positions:
-   - added keys must populate their grown slots (which started as nil)
-   - surviving keys whose vnode value changed (vnode-value-equal? is
-     false) get their slot replaced (or reconciled in place if
-     tag+key+addr match; discharge decides)
-
-   Surviving keys whose vnode value is structurally equal contribute
-   *no* `:change` entry — the DOM element survives untouched."
+   Returns the delta in a wrapping vector, or nil when nothing changed."
   [order prev-order by-key prev-by-key]
-  (let [n-old (count prev-order)
-        n-new (count order)
-        old-keys (set prev-order)
-        new-keys (set order)
-        added (set/difference new-keys old-keys)
-        removed (set/difference old-keys new-keys)
-        shrink (count removed)
-        grow (count added)
-        degree (+ n-old grow)
-        old-pos (zipmap prev-order (range))
-        new-pos (zipmap order (range))
-        ;; Iterate added in `order` so the grown slots are assigned in
-        ;; the order they appear in the new sequence. This isn't
-        ;; required for correctness, but makes diffs deterministic and
-        ;; easier to inspect in logs.
-        added-in-order (filterv added order)
-        removed-in-order (filterv removed prev-order)
-        ;; Build the permutation.
-        permutation
-        (as-> {} π
-          ;; Surviving keys: old-pos(k) → new-pos(k).
-          (reduce (fn [acc k]
-                    (if (contains? removed k)
-                      acc
-                      (let [from (old-pos k)
-                            to (new-pos k)]
-                        (if (= from to) acc (assoc acc from to)))))
-                  π prev-order)
-          ;; Removed keys: send to doomed tail [n_new, n_new + shrink).
-          (first
-           (reduce (fn [[acc i] k]
-                     [(assoc acc (old-pos k) (+ n-new i))
-                      (inc i)])
-                   [π 0]
-                   removed-in-order))
-          ;; Added keys: grown slot [n_old, n_old + grow) → new-pos(k).
-          (first
-           (reduce (fn [[acc i] k]
-                     [(let [from (+ n-old i)
-                            to (new-pos k)]
-                        (if (= from to) acc (assoc acc from to)))
-                      (inc i)])
-                   [π 0]
-                   added-in-order)))
-        ;; Build :change in post-shrink space [0, n_new).
-        change (persistent!
-                (reduce (fn [acc k]
-                          (let [new-vn (get by-key k)]
-                            (cond
-                              (contains? added k)
-                              (assoc! acc (new-pos k) new-vn)
-
-                              (not (vnode-value-equal?
-                                    (get prev-by-key k) new-vn))
-                              (assoc! acc (new-pos k) new-vn)
-
-                              :else acc)))
-                        (transient {}) order))]
-    (if (and (zero? grow) (zero? shrink)
-             (empty? permutation) (empty? change))
-      nil
-      [{:delta :seq-diff
-        :diff {:degree degree
-               :grow grow
-               :shrink shrink
-               :permutation permutation
-               :change change
-               :freeze #{}}
-        :prev-items (mapv #(get prev-by-key %) prev-order)}])))
+  (when-let [diff (sa/keyed-seq-diff order prev-order by-key prev-by-key
+                                     vnode-value-equal?)]
+    [{:delta :seq-diff
+      :diff diff
+      :prev-items (mapv #(get prev-by-key %) prev-order)}]))
 
 ;; =============================================================================
 ;; Fragment build (sync and async paths)

--- a/src/org/replikativ/spindel/dom/render.cljc
+++ b/src/org/replikativ/spindel/dom/render.cljc
@@ -89,12 +89,14 @@
         ;; Discharge deltas directly - no diffing needed
         ;; DOM refs found by address, no transfer needed
         (binding [disch/*rendered-vnodes* (atom #{})
-                  disch/*rendered-addrs* (atom {})]
+                  disch/*rendered-addrs* (atom {})
+                  disch/*pending-evictions* (atom #{})]
           (let [nodes-with-deltas (disch/collect-nodes-with-deltas new-vdom)]
             (when (seq nodes-with-deltas)
               (log/trace :render/delta-update {:nodes-with-deltas (count nodes-with-deltas)})
               (doseq [node nodes-with-deltas]
-                (disch/discharge-vnode! discharge node)))))
+                (disch/discharge-vnode! discharge node))))
+          (disch/flush-pending-evictions!))
 
         ;; Clear deltas for next render cycle
         ;; No ref transfer needed — cleared vnodes carry same :addr values

--- a/src/org/replikativ/spindel/effects/await.cljc
+++ b/src/org/replikativ/spindel/effects/await.cljc
@@ -166,13 +166,13 @@
         ;; We need to execute child body (to create nested spins, register continuations)
         ;; but continue synchronously instead of suspending
         rebuild?
-        (let [;; Re-apply the awaited spin's captured DOM scope, same as the
+        (let [;; Re-apply the awaited spin's captured scope, same as the
               ;; slow path below. Rebuild executes the child body for side
               ;; effects (registering child continuations etc.); those spins
               ;; need to see their own scope, not the parent's.
-              spin-dom-scope (rtp/get-state ctx [:nodes awaited-spin-id :dom-scope])
-              child-ctx (if (seq spin-dom-scope)
-                          (update ctx :bindings merge spin-dom-scope)
+              spin-scope (rtp/get-state ctx [:nodes awaited-spin-id :spin-scope])
+              child-ctx (if (seq spin-scope)
+                          (update ctx :bindings merge spin-scope)
                           ctx)]
           ;; Execute child spin for side effects with child's scope applied
           (binding [ec/*execution-context* child-ctx
@@ -247,16 +247,16 @@
               ;; (Observer registration of parent in child.observers was done
               ;; at await-spin entry via `(ec/deps-track-spin! ...)` — see
               ;; the fast-path branch comment above.)
-              ;; Re-apply the awaited spin's captured DOM scope (snapshotted
-              ;; at construction in spin/core.cljc::make-spin). Without this,
+              ;; Re-apply the awaited spin's captured scope (snapshotted at
+              ;; construction in spin/core.cljc::make-spin). Without this,
               ;; the child body would inherit the parent's *execution-context*
-              ;; bindings — losing any keyed/scoped DOM context the child was
-              ;; constructed under (e.g. ifor-each per-item scope). This is
-              ;; the await-handler analogue of the :spin-execution-event fix
-              ;; in engine/impl/simple.cljc.
-              spin-dom-scope (rtp/get-state ctx [:nodes awaited-spin-id :dom-scope])
-              child-ctx (if (seq spin-dom-scope)
-                          (update ctx :bindings merge spin-dom-scope)
+              ;; bindings — losing any keyed/scoped context the child was
+              ;; constructed under (e.g. ifor-each per-item DOM scope). This
+              ;; is the await-handler analogue of the :spin-execution-event
+              ;; handling in engine/impl/simple.cljc.
+              spin-scope (rtp/get-state ctx [:nodes awaited-spin-id :spin-scope])
+              child-ctx (if (seq spin-scope)
+                          (update ctx :bindings merge spin-scope)
                           ctx)
               ;; Seed the child's per-spin chain-head slot before invoking
               ;; its body — exactly what `Spin`'s `-invoke` Case 2 does.

--- a/src/org/replikativ/spindel/engine/bindings.cljc
+++ b/src/org/replikativ/spindel/engine/bindings.cljc
@@ -17,41 +17,48 @@
   frame on the stack, and frames are properly cleaned up in LIFO order.")
 
 ;; =============================================================================
-;; Ephemeral Binding Keys
+;; Spin Scope Keys
 ;; =============================================================================
 ;;
 ;; The ExecutionContext's :bindings map carries fork-scoped values that
 ;; propagate to child spins and continuations (see engine.context). Most
 ;; entries are persistent — set at context/fork creation, inherited across
-;; every continuation resume.
+;; every continuation resume, never per-spin.
 ;;
-;; A few entries represent *per-render-pass* scope: values set by element
-;; macros (e.g. :dom/parent-addr, :dom/current-slot) that should NOT survive
-;; across a track continuation resume, because a track resume marks the start
-;; of a new render pass where the surrounding scope re-establishes them.
-;; They SHOULD survive await resumes, since those resume mid-body within
-;; the same render pass.
+;; A few entries instead represent a *spin's lexical scope*: values set by
+;; an enclosing construct around the point a spin is created (e.g. element
+;; macros set :dom/parent-addr / :dom/current-slot). Such a key must be
+;; re-established whenever the spin's body runs — on EVERY body-entry path —
+;; so the body addresses and behaves consistently no matter which engine
+;; path resumed it. `make-spin` snapshots these keys at construction onto
+;; the spin's node; the engine re-applies the snapshot on every body entry.
 ;;
-;; Libraries that introduce such keys register them here at ns load. The
-;; engine consults the registry when resuming track continuations (see
-;; engine.impl.simple/resume-single-observer!).
+;; Libraries that introduce such keys register them here at ns load. This
+;; registry is the engine's only knowledge of them: the engine itself never
+;; names a :dom/* (or any other domain) key — it just snapshots and restores
+;; whatever was registered.
 
-(defonce ^:private ephemeral-keys-atom (atom #{}))
+(defonce ^:private scope-keys-atom (atom #{}))
 
-(defn register-ephemeral-binding-key!
-  "Register a key in the ExecutionContext's :bindings map as ephemeral.
+(defn register-spin-scope-key!
+  "Register a key of the ExecutionContext's :bindings map as a *spin scope*
+  key.
 
-  Ephemeral keys are cleared when a track continuation resumes (new render
-  pass). Persistent keys survive all continuation resumes, as does every
-  unregistered key."
+  Spin scope keys are snapshotted by `make-spin` at construction and
+  re-established by the engine on every body-entry path (initial run,
+  track resume, await resume). Unregistered keys are not snapshotted —
+  persistent context bindings already flow through unchanged."
   [k]
-  (swap! ephemeral-keys-atom conj k)
+  (swap! scope-keys-atom conj k)
   nil)
 
-(defn ephemeral-binding-keys
-  "Return the current set of registered ephemeral binding keys."
+(defn spin-scope-keys
+  "Return the current set of registered spin scope keys.
+
+  Consumed by `make-spin` (spin/core.cljc) to decide which :bindings
+  entries make up a spin's captured construction scope."
   []
-  @ephemeral-keys-atom)
+  @scope-keys-atom)
 
 ;; =============================================================================
 ;; CLJS Var Registry

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -598,12 +598,13 @@
   :rng, app config. This is analogous to how Clojure's dynamic vars (*out*,
   *print-length*, ...) carry per-thread config.
 
-  A key can also be registered as **ephemeral** via
-  engine.bindings/register-ephemeral-binding-key!. Ephemeral keys represent
-  per-render-pass scope: they're cleared when a track continuation resumes
-  (start of a new render pass) but preserved when an await continuation
-  resumes (mid-body, same pass). DOM addressing (:dom/parent-addr,
-  :dom/current-slot) uses this.
+  A key can also be registered as a **spin scope key** via
+  engine.bindings/register-spin-scope-key!. Spin scope keys represent a
+  spin's lexical construction scope: `make-spin` snapshots them onto the
+  spin's node and the engine re-establishes them on every body-entry path
+  (initial run, track resume, await resume). DOM addressing
+  (:dom/parent-addr, :dom/current-slot) uses this so element addresses stay
+  stable across re-renders.
 
   Returns map of keys to values."
   [ctx]

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -664,9 +664,9 @@
 
   Also:
   - Resets engine draining flag.
-  - Drops :dom/cache and :dom/attr-cache, since slot/attribute reconciliation
-    state belongs to the previous render pass and would mismatch the DOM the
-    restored context renders into.
+  - Drops :dom/cache, :dom/attr-cache and :dom/keyed-cache, since slot,
+    attribute and keyed-list reconciliation state belongs to the previous
+    render pass and would mismatch the DOM the restored context renders into.
 
   NOTE: Continuations are preserved for in-memory snapshot/restore.
   They will be dropped during serialization (since closures can't be serialized).
@@ -681,7 +681,7 @@
       (assoc :engine/draining? false)
 
       ;; Drop render-pass-specific DOM caches; restored context re-renders.
-      (dissoc :dom/cache :dom/attr-cache)
+      (dissoc :dom/cache :dom/attr-cache :dom/keyed-cache)
 
       ;; Mark in-flight spins as dirty
       (update :nodes

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -500,6 +500,27 @@
                 (recur (first grandparents) (conj visited current))
                 current))))))))
 
+(defn- apply-spin-scope
+  "Merge spin `sid`'s captured scope onto `ctx`'s bindings.
+
+  `make-spin` (spin/core.cljc) snapshots the registered spin-scope binding
+  keys (see engine.bindings) at construction into `[:nodes sid :spin-scope]`.
+  That scope is intrinsic to the spin and must be re-established on EVERY
+  body-entry path so the body addresses and behaves consistently no matter
+  which engine path runs it.
+
+  Track-continuation resumes happen to restore it via the cont's
+  `:ctx-bindings` snapshot, but await-continuation resumes carry no
+  `:ctx-bindings` — so without this an awaiting spin (e.g. a keyed
+  `ifor-each` item-spin re-running because its awaited child re-completed)
+  would lose its construction scope, drifting any scope-derived addressing
+  and breaking discharge reconciliation."
+  [ctx sid]
+  (let [spin-scope (rtp/get-state ctx [:nodes sid :spin-scope])]
+    (if (seq spin-scope)
+      (update ctx :bindings merge spin-scope)
+      ctx)))
+
 (defn process-event!
   "Process a single event.
 
@@ -676,8 +697,15 @@
                 ;; merged onto the current context bindings.
                 ;; See resume-single-observer! for the chain-head atom rationale.
                 (let [ctx-bindings (:ctx-bindings cont)
-                      ctx-for-resume (cond-> context
-                                       ctx-bindings (update :bindings merge ctx-bindings))
+                      ctx-for-resume (-> (cond-> context
+                                           ctx-bindings (update :bindings merge ctx-bindings))
+                                         ;; Re-apply the resuming spin's intrinsic
+                                         ;; scope. Await continuations carry no
+                                         ;; :ctx-bindings, so this is the only thing
+                                         ;; that restores construction scope for a
+                                         ;; spin that re-runs because its awaited
+                                         ;; child re-completed.
+                                         (apply-spin-scope parent-id))
                       chain-head-start (or (:chain-head-snap cont)
                                            (addressing/body-start-chain-head parent-id))]
                   (addressing/seed-chain-head! context parent-id chain-head-start)
@@ -766,15 +794,16 @@
         ;; CRITICAL: Bind *in-trampoline* to false when re-entering from event handler
         ;; This ensures invoke-continuation establishes a new trampoline loop
         ;; If execution-context is provided (e.g., from SMC), bind it; otherwise use context
-        ;; Apply this spin's captured DOM scope (see make-spin in spin/core.cljc)
+        ;; Apply this spin's captured scope (see make-spin in spin/core.cljc)
         ;; on top of the chosen context's bindings, so the body's initial
         ;; synchronous code (before any track/await) sees the spin's lexical
-        ;; DOM scope. Without this, only continuation resumes restore scope —
-        ;; elements built before the first effect would use runtime bindings.
+        ;; construction scope. Without this, only continuation resumes restore
+        ;; scope — elements built before the first effect would use runtime
+        ;; bindings.
         (let [base-ctx (or execution-context context)
-              spin-dom-scope (rtp/get-state context [:nodes tid :dom-scope])
-              effective-ctx (if (seq spin-dom-scope)
-                              (update base-ctx :bindings merge spin-dom-scope)
+              spin-scope (rtp/get-state context [:nodes tid :spin-scope])
+              effective-ctx (if (seq spin-scope)
+                              (update base-ctx :bindings merge spin-scope)
                               base-ctx)]
           (binding [ec/*execution-context* effective-ctx
                     ec/*spin-id* tid

--- a/src/org/replikativ/spindel/incremental/combinators.cljc
+++ b/src/org/replikativ/spindel/incremental/combinators.cljc
@@ -228,7 +228,14 @@
 (defn ^:no-doc for-each*
   "Apply `transform-fn` to every element of the source sequence,
    memoising results by `key-fn`. Input-equal items at the same key
-   reuse the prior `transform-fn` output. Output algebra: sequence."
+   reuse the prior `transform-fn` output. Output algebra: sequence.
+
+   Note: `key-fn` is used for memoisation only. The output `:deltas`
+   come from `state-diff` on the transformed vectors — a *value-based*
+   sequence diff that does not recognise reorders (a reorder degrades to
+   change-everything). A consumer that needs a reorder-aware keyed diff
+   should use `sequence-algebra/keyed-seq-diff` — which is what the DOM
+   `dom/foreach` layer does."
   [source-loc key-fn transform-fn source]
   (with-cache source-loc
     (fn [prev]

--- a/src/org/replikativ/spindel/incremental/sequence_algebra.cljc
+++ b/src/org/replikativ/spindel/incremental/sequence_algebra.cljc
@@ -271,6 +271,119 @@
       (naive-state-diff a b))))
 
 ;; =============================================================================
+;; Keyed state diff
+;;
+;; `linear-state-diff` matches elements by *value* (longest common
+;; prefix/suffix). That is the right diff when elements have no identity
+;; of their own — but when each element carries a stable key, a value-
+;; based diff cannot recognise a reorder (it degrades to change-everything)
+;; and cannot tell an unchanged-but-moved element from a replaced one.
+;;
+;; `keyed-seq-diff` diffs two *keyed* sequences: the caller supplies the
+;; key order of each state plus key→value maps. Identity is the key;
+;; `eq-fn` decides, for a key present in both states, whether its value
+;; changed. The result is the same SequenceAlgebra diff record the other
+;; state-diffs produce, so it flows through `apply-deltas` /
+;; `compose-deltas` / discharge unchanged.
+;; =============================================================================
+
+(defn keyed-seq-diff
+  "Compute a SequenceAlgebra diff between two *keyed* sequences.
+
+  Where `linear-state-diff` matches elements by value, `keyed-seq-diff`
+  matches by key: it recognises reorders as permutations and emits a
+  `:change` only for a surviving key whose value actually changed.
+
+  Args:
+    order        - vector of keys in the new state's order
+    prev-order   - vector of keys in the previous state's order
+    by-key       - map {key -> new value}
+    prev-by-key  - map {key -> previous value}
+    eq-fn        - (eq-fn prev-value new-value) -> truthy when a key
+                   present in both states did NOT change. Keys whose
+                   values differ get a `:change` entry. Callers pass the
+                   equality appropriate to their element type (e.g.
+                   structural vnode equality for DOM).
+
+  Returns the 5-field SequenceAlgebra diff map, or nil when nothing
+  changed.
+
+  Working space [0, n-old + grow):
+   - [0, n-old):            previous items at their original positions
+   - [n-old, n-old + grow): appended grown slots, one per added key
+  The permutation sends each surviving key old-pos -> new-pos, each
+  removed key to a doomed tail slot in [n-new, n-new + shrink) (dropped
+  by :shrink), and each added key from its grown slot to its new-pos.
+  :change populates the added keys' grown slots and replaces surviving
+  keys whose value changed."
+  [order prev-order by-key prev-by-key eq-fn]
+  (let [n-old (count prev-order)
+        n-new (count order)
+        old-keys (set prev-order)
+        new-keys (set order)
+        added (set/difference new-keys old-keys)
+        removed (set/difference old-keys new-keys)
+        shrink (count removed)
+        grow (count added)
+        degree (+ n-old grow)
+        old-pos (zipmap prev-order (range))
+        new-pos (zipmap order (range))
+        ;; Iterate added in `order` so grown slots are assigned in the
+        ;; order they appear in the new sequence — not required for
+        ;; correctness, but makes diffs deterministic and log-friendly.
+        added-in-order (filterv added order)
+        removed-in-order (filterv removed prev-order)
+        permutation
+        (as-> {} π
+          ;; Surviving keys: old-pos(k) -> new-pos(k).
+          (reduce (fn [acc k]
+                    (if (contains? removed k)
+                      acc
+                      (let [from (old-pos k)
+                            to (new-pos k)]
+                        (if (= from to) acc (assoc acc from to)))))
+                  π prev-order)
+          ;; Removed keys: send to the doomed tail [n-new, n-new + shrink).
+          (first
+           (reduce (fn [[acc i] k]
+                     [(assoc acc (old-pos k) (+ n-new i))
+                      (inc i)])
+                   [π 0]
+                   removed-in-order))
+          ;; Added keys: grown slot [n-old, n-old + grow) -> new-pos(k).
+          (first
+           (reduce (fn [[acc i] k]
+                     [(let [from (+ n-old i)
+                            to (new-pos k)]
+                        (if (= from to) acc (assoc acc from to)))
+                      (inc i)])
+                   [π 0]
+                   added-in-order)))
+        ;; :change in post-shrink space [0, n-new): added keys populate
+        ;; their grown slots; surviving keys whose value changed get
+        ;; replaced. Surviving, value-equal keys contribute nothing.
+        change (persistent!
+                (reduce (fn [acc k]
+                          (let [new-v (get by-key k)]
+                            (cond
+                              (contains? added k)
+                              (assoc! acc (new-pos k) new-v)
+
+                              (not (eq-fn (get prev-by-key k) new-v))
+                              (assoc! acc (new-pos k) new-v)
+
+                              :else acc)))
+                        (transient {}) order))]
+    (when-not (and (zero? grow) (zero? shrink)
+                   (empty? permutation) (empty? change))
+      {:degree degree
+       :grow grow
+       :shrink shrink
+       :permutation permutation
+       :change change
+       :freeze #{}})))
+
+;; =============================================================================
 ;; Algebra instance
 ;; =============================================================================
 

--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -8,6 +8,7 @@
             [org.replikativ.spindel.engine.context :as ctx]
             [org.replikativ.spindel.engine.protocols :as rtp]
             [org.replikativ.spindel.engine.addressing :as addressing]
+            [org.replikativ.spindel.engine.bindings :as bindings]
             [replikativ.logging :as log]
             [is.simm.partial-cps.async :as pcps-async]
             [is.simm.partial-cps.runtime])
@@ -430,21 +431,22 @@
      ;; Register spin with runtime via protocol (uses dynamic *execution-context*)
      (ec/spin-register! spin-id {:provides #{}})
 
-     ;; Snapshot DOM ephemeral bindings (:dom/parent-addr, :dom/current-slot)
-     ;; from the construction-time execution context, and store them on this
-     ;; spin's node. The engine re-applies them on every continuation entry
-     ;; (see resume-single-observer! in engine/impl/simple.cljc). This gives
-     ;; spins closure semantics over their lexical DOM scope: an inner spin
-     ;; constructed under a keyed/scoped context restores that scope on each
-     ;; track/await resume, even though the engine strips ephemeral keys.
-     ;; Root spins (no surrounding element macro at construction) capture an
-     ;; empty scope, so this is a no-op there.
+     ;; Snapshot this spin's lexical scope — the registered spin-scope
+     ;; binding keys (see engine.bindings) — from the construction-time
+     ;; execution context onto the spin's node. The engine re-applies the
+     ;; snapshot on every body-entry path (see apply-spin-scope in
+     ;; engine/impl/simple.cljc), giving spins closure semantics over the
+     ;; scope they were constructed under. Which keys count as scope is
+     ;; supplied entirely by the registry — e.g. dom.addressing registers
+     ;; :dom/parent-addr / :dom/current-slot — so spin/core stays domain-
+     ;; agnostic. Spins constructed at root scope capture nothing, so this
+     ;; is a no-op there.
      (when-let [ctx (ec/current-execution-context)]
-       (let [dom-scope (select-keys (:bindings ctx)
-                                    [:dom/parent-addr :dom/current-slot])]
-         (when (seq dom-scope)
-           (rtp/swap-state! ctx [:nodes spin-id :dom-scope]
-                            (constantly dom-scope)))))
+       (let [spin-scope (select-keys (:bindings ctx)
+                                     (bindings/spin-scope-keys))]
+         (when (seq spin-scope)
+           (rtp/swap-state! ctx [:nodes spin-id :spin-scope]
+                            (constantly spin-scope)))))
 
      ;; Register automatic cleanup when spin is GC'd
      ;; Both platforms: capture a WeakRef to the ExecutionContext so cleanup

--- a/test/org/replikativ/spindel/dom/deferred_eviction_test.clj
+++ b/test/org/replikativ/spindel/dom/deferred_eviction_test.clj
@@ -1,0 +1,50 @@
+(ns org.replikativ.spindel.dom.deferred-eviction-test
+  "Regression: per-element cache eviction on unmount must be DEFERRED to
+  end-of-cycle and must spare any address still claimed by a live element
+  in the same render pass.
+
+  Eager evict-on-unmount is unsafe — unmount runs before the live subtree
+  is render-initial!'d, so an address can appear in both a destroyed
+  subtree and a live one within one pass (a churned parent whose keyed
+  descendants survive). Evicting eagerly would wipe the live descendant's
+  cache; its next reconcile then diffs against an empty cache and emits
+  :add-only deltas, duplicating the DOM subtree."
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.dom.discharge :as disch]
+            [org.replikativ.spindel.dom.cache :as cache]
+            [org.replikativ.spindel.test-helpers :refer [with-ctx]]))
+
+(deftest deferred-eviction-spares-live-addresses
+  (testing "call-refs-on-unmount! defers eviction; flush spares *rendered-addrs*"
+    (with-ctx [_ctx]
+      ;; Two cached addresses: one whose element is genuinely gone, one
+      ;; that a live element re-claims this pass.
+      (cache/set-slot-cache! :el-dead [{:type :nil :value nil}])
+      (cache/set-slot-cache! :el-live [{:type :nil :value nil}])
+      (binding [disch/*pending-evictions* (atom #{})
+                disch/*rendered-addrs*    (atom {:el-live {:tag :div :addr :el-live}})]
+        ;; Unmount a vnode at each address.
+        (#'disch/call-refs-on-unmount! {:tag :div :addr :el-dead})
+        (#'disch/call-refs-on-unmount! {:tag :div :addr :el-live})
+
+        ;; Eviction is DEFERRED — both caches still present mid-pass.
+        (is (some? (cache/get-slot-cache :el-dead))
+            "eviction is deferred, not eager")
+        (is (some? (cache/get-slot-cache :el-live))
+            "eviction is deferred, not eager")
+
+        ;; End-of-cycle flush.
+        (disch/flush-pending-evictions!)
+        (is (nil? (cache/get-slot-cache :el-dead))
+            "address with no live claimant is evicted")
+        (is (some? (cache/get-slot-cache :el-live))
+            "address still claimed in *rendered-addrs* is spared")))))
+
+(deftest eager-eviction-fallback-without-render-pass
+  (testing "Outside a render pass (no *pending-evictions* binding) eviction is eager"
+    (with-ctx [_ctx]
+      (cache/set-slot-cache! :el-x [{:type :nil :value nil}])
+      ;; No *pending-evictions* binding → fall back to eager evict-cache!.
+      (#'disch/call-refs-on-unmount! {:tag :div :addr :el-x})
+      (is (nil? (cache/get-slot-cache :el-x))
+          "with no render pass active, unmount evicts immediately"))))

--- a/test/org/replikativ/spindel/dom/ifor_each_oscillation_test.clj
+++ b/test/org/replikativ/spindel/dom/ifor_each_oscillation_test.clj
@@ -1,0 +1,148 @@
+(ns org.replikativ.spindel.dom.ifor-each-oscillation-test
+  "Regression test for `ifor-each` against an *oscillating source* — a
+  key that is added, then removed, then added again across successive
+  renders.
+
+  Why this matters: `ifor-each` is delta-driven. Its producer
+  (`build-seq-diff`) is authoritative on `:new` and emits a typed
+  `:seq-diff` (grow / shrink / permutation / change). The discharge
+  layer (`apply-seq-diff!`) realises that diff onto real DOM children.
+  If a source briefly drops a key and brings it back — e.g. an
+  optimistic-overlay db value that flickers, a network reorder, a
+  re-query race — the foreach must emit a clean shrink followed by a
+  clean grow, and the discharge must remove exactly the dropped node
+  and insert exactly one fresh node. A mismatch leaves a *duplicated*
+  DOM child (the classic symptom: the same block rendered twice).
+
+  This guards the spindel side of that contract end-to-end:
+  `for-each*` → KeyedFragment `:seq-diff` → `apply-seq-diff!`."
+  (:refer-clojure :exclude [await])
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [org.replikativ.spindel.dom.elements :as el]
+            [org.replikativ.spindel.dom.discharge :as disch]
+            [org.replikativ.spindel.dom.foreach :as foreach]
+            [org.replikativ.spindel.dom.render :as render]
+            [org.replikativ.spindel.signal :as sig]
+            [org.replikativ.spindel.effects.track :refer [track]]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.test-helpers :refer [with-ctx]]
+            [org.replikativ.spindel.test-async :refer [await-drain]]))
+
+(defn clean-context-fixture [f]
+  (binding [ec/*execution-context* nil]
+    (f)))
+
+(use-fixtures :each clean-context-fixture)
+
+(defn- net-children
+  "Net child count of `parent-id` from a MockDischarge op log:
+  append/insert add a child, remove drops one, replace is neutral."
+  [log parent-id]
+  (reduce (fn [n {:keys [op parent]}]
+            (if (= parent parent-id)
+              (case op
+                (:append-child :insert-child) (inc n)
+                :remove-child (dec n)
+                n)
+              n))
+          0
+          log))
+
+(defn- count-ops [log parent-id op-kw]
+  (count (filter #(and (= op-kw (:op %)) (= parent-id (:parent %))) log)))
+
+(deftest test-ifor-each-add-remove-add-no-duplication
+  (testing "A key added, removed, then re-added across renders must leave
+            exactly one DOM node for it — never a duplicate."
+    (with-ctx [ctx]
+      (let [source     (sig/signal [{:id "a"} {:id "b"} {:id "c"}])
+            ;; Plain-vnode render-fn → for-each* sync path, mirroring the
+            ;; real wiki block list (render-block returns a plain vnode).
+            render-fn  (fn [item] (el/li {:key (:id item)} (:id item)))
+            parent-spin (spin
+                         (let [{:keys [new]} (track source)]
+                           (el/ul {:class "items"}
+                                  (foreach/for-each*
+                                   {:file "test" :line 1 :column 1}
+                                   :id render-fn new))))
+            {:keys [discharge log]} (disch/make-mock-discharge)]
+        (render/render-spin! nil parent-spin discharge)
+        @parent-spin
+        (await-drain ctx)
+
+        (let [ul-id (->> @log
+                         (filter #(and (= :create-element (:op %))
+                                       (= :ul (:tag %))))
+                         first :id)]
+          (is (some? ul-id) "a <ul> element was created")
+          (is (= 3 (net-children @log ul-id)) "initial mount: 3 children")
+
+          ;; (1) add d
+          (reset! source [{:id "a"} {:id "b"} {:id "c"} {:id "d"}])
+          (await-drain ctx)
+          (is (= 4 (net-children @log ul-id)) "after add d: 4 children")
+
+          ;; (2) remove d — the source momentarily drops the key
+          (reset! source [{:id "a"} {:id "b"} {:id "c"}])
+          (await-drain ctx)
+          (is (= 3 (net-children @log ul-id)) "after remove d: 3 children")
+
+          ;; (3) re-add d — the key comes back
+          (reset! source [{:id "a"} {:id "b"} {:id "c"} {:id "d"}])
+          (await-drain ctx)
+          (is (= 4 (net-children @log ul-id))
+              (str "after re-add d the <ul> must have exactly 4 children — "
+                   "a duplicated node would push this to 5. Got "
+                   (net-children @log ul-id)))
+
+          ;; Exactly one <ul> across the whole sequence — the parent spin
+          ;; re-completes but must reuse its element.
+          (is (= 1 (->> @log
+                        (filter #(and (= :create-element (:op %))
+                                      (= :ul (:tag %))))
+                        count))
+              "exactly one <ul> created across all renders")
+
+          ;; Op-level shape: the oscillation is one remove (step 2) and
+          ;; two post-mount inserts (steps 1 and 3). A duplication bug
+          ;; shows up as an extra insert with no matching remove.
+          (is (= 1 (count-ops @log ul-id :remove-child))
+              "exactly one remove emitted (the dropped d)")
+          (is (= 2 (count-ops @log ul-id :insert-child))
+              "exactly two post-mount inserts emitted (add d, re-add d)"))))))
+
+(deftest test-ifor-each-repeated-oscillation-stays-bounded
+  (testing "Many add/remove cycles of the same key never accumulate
+            stale DOM children."
+    (with-ctx [ctx]
+      (let [base       [{:id "a"} {:id "b"}]
+            with-x     (conj base {:id "x"})
+            source     (sig/signal base)
+            render-fn  (fn [item] (el/li {:key (:id item)} (:id item)))
+            parent-spin (spin
+                         (let [{:keys [new]} (track source)]
+                           (el/ul {}
+                                  (foreach/for-each*
+                                   {:file "test" :line 2 :column 1}
+                                   :id render-fn new))))
+            {:keys [discharge log]} (disch/make-mock-discharge)]
+        (render/render-spin! nil parent-spin discharge)
+        @parent-spin
+        (await-drain ctx)
+        (let [ul-id (->> @log
+                         (filter #(and (= :create-element (:op %))
+                                       (= :ul (:tag %))))
+                         first :id)]
+          (dotimes [_ 6]
+            (reset! source with-x)
+            (await-drain ctx)
+            (is (= 3 (net-children @log ul-id)) "with x: 3 children")
+            (reset! source base)
+            (await-drain ctx)
+            (is (= 2 (net-children @log ul-id)) "without x: 2 children"))
+          ;; Land on the with-x state and confirm a clean final count.
+          (reset! source with-x)
+          (await-drain ctx)
+          (is (= 3 (net-children @log ul-id))
+              "after 6 oscillation cycles the list is still exactly 3 long"))))))

--- a/test/org/replikativ/spindel/dom/keyed_item_spin_rerender_test.clj
+++ b/test/org/replikativ/spindel/dom/keyed_item_spin_rerender_test.clj
@@ -1,0 +1,142 @@
+(ns org.replikativ.spindel.dom.keyed-item-spin-rerender-test
+  "Regression: an `ifor-each` item whose `render-fn` returns a *spin* must
+  keep its keyed element address stable when the PARENT re-renders — e.g. a
+  sibling signal change escalates a re-run of the for-each's parent spin.
+
+  This is the property-box DOM-duplication bug. `render-column` is a keyed
+  `ifor-each` item-spin; on a parent re-render its column `el/div` addressed
+  structurally (`:dom/parent-addr` nil) instead of keyed, drifting the
+  address -> `reconcilable?` fails -> destroy+recreate -> shared keyed
+  caches evicted -> duplicated DOM.
+
+  The item-spin's keyed DOM scope must be intrinsic to the spin and
+  re-established on every body run, not snapshotted from a transient
+  dynamic-scope extent that only covers construction."
+  (:refer-clojure :exclude [await])
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.dom.elements :as el]
+            [org.replikativ.spindel.dom.fragment :as frag]
+            [org.replikativ.spindel.dom.foreach :as foreach]
+            [org.replikativ.spindel.incremental.deltaable :as d]
+            [org.replikativ.spindel.signal :as sig]
+            [org.replikativ.spindel.effects.track :refer [track]]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.incremental.interval :as iv]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.spin.cps :refer [spin]]))
+
+(defn- class-addrs
+  "Walk a vnode / KeyedFragment tree -> {class-string -> :addr}."
+  [node]
+  (cond
+    (nil? node) {}
+    (frag/keyed-fragment? node)
+    (apply merge (map class-addrs (frag/fragment-items node)))
+    (and (map? node) (:tag node))
+    (let [attrs    (let [a (:attrs node)] (if (d/deltaable? a) @a a))
+          cls      (:class attrs)
+          children (let [c (:children node)] (if (d/deltaable? c) @c c))
+          kids     (apply merge (map class-addrs
+                                     (when (sequential? children) children)))]
+      (merge (if cls {cls (:addr node)} {}) kids))
+    :else {}))
+
+(defn- await-count [a expected timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (cond
+        (>= @a expected)                          true
+        (>= (System/currentTimeMillis) deadline)  false
+        :else (do (Thread/sleep 20) (recur))))))
+
+(deftest test-keyed-item-spin-address-stable-across-parent-rerender
+  (testing "keyed ifor-each item-spin keeps its keyed element address when the parent re-renders"
+    (let [test-ctx (ctx/create-execution-context)]
+      (binding [ec/*execution-context* test-ctx]
+        (let [trigger       (sig/signal test-ctx 0)
+              columns       [{:id "col-1" :title "Column 1"}
+                             {:id "col-2" :title "Column 2"}]
+              render-column (fn [col]
+                              (spin
+                               (el/div {:key   (:id col)
+                                        :class (str "column-" (:id col))}
+                                       (el/span {} (:title col)))))
+              results       (atom {})
+              render-count  (atom 0)
+              parent        (spin
+                             (let [t-iv (track trigger)
+                                   _t   (iv/get-new t-iv)
+                                   fr   (await (foreach/for-each*
+                                                {:file "kis" :line 1 :column 1}
+                                                :id render-column columns))
+                                   vdom (el/div {:class "columns-container"} fr)
+                                   rid  (inc @render-count)
+                                   _    (swap! results assoc rid (class-addrs vdom))
+                                   _    (swap! render-count inc)]
+                               vdom))]
+          (parent
+           (fn [_] (when (= 1 @render-count) (reset! trigger 1)))
+           (fn [err] (throw (ex-info "parent spin failed" {:err err}))))
+          (is (await-count render-count 2 3000) "two renders completed")
+          (let [r1 (get @results 1)
+                r2 (get @results 2)]
+            (is (some? r1) "render 1 collected")
+            (is (some? r2) "render 2 collected")
+            (doseq [cls ["columns-container" "column-col-1" "column-col-2"]]
+              (is (= (get r1 cls) (get r2 cls))
+                  (str cls " address must be stable across parent re-render: "
+                       "render1=" (get r1 cls) " render2=" (get r2 cls)))))
+          (ctx/stop-context! test-ctx))))))
+
+(deftest test-keyed-item-spin-address-stable-across-escalated-rerender
+  (testing "keyed ifor-each item-spin keeps its keyed address when a signal
+            tracked DEEP inside the item escalates a re-run of the for-each's
+            parent (the property-box DOM-duplication path)"
+    (let [test-ctx (ctx/create-execution-context)]
+      (binding [ec/*execution-context* test-ctx]
+        (let [trigger       (sig/signal test-ctx 0)
+              columns       [{:id "col-1" :title "Column 1"}
+                             {:id "col-2" :title "Column 2"}]
+              ;; property-box analog: a spin nested inside the column that
+              ;; tracks `trigger`. Toggling `trigger` escalates a re-run up
+              ;; to columns-container, which re-runs for-each*.
+              render-inner  (fn [col]
+                              (spin
+                               (let [iv-t (track trigger)
+                                     v    (iv/get-new iv-t)]
+                                 (el/div {:class (str "inner-" (:id col))}
+                                         (str (:title col) "-" v)))))
+              render-column (fn [col]
+                              (spin
+                               (let [inner (await (render-inner col))]
+                                 (el/div {:key   (:id col)
+                                          :class (str "column-" (:id col))}
+                                         inner))))
+              results       (atom {})
+              render-count  (atom 0)
+              columns-container
+              (spin
+               (let [fr   (await (foreach/for-each*
+                                  {:file "kis" :line 2 :column 1}
+                                  :id render-column columns))
+                     vdom (el/div {:class "columns-container"} fr)
+                     rid  (inc @render-count)
+                     _    (swap! results assoc rid (class-addrs vdom))
+                     _    (swap! render-count inc)]
+                 vdom))]
+          (columns-container
+           (fn [_] (when (= 1 @render-count) (reset! trigger 1)))
+           (fn [err] (throw (ex-info "columns-container failed" {:err err}))))
+          (is (await-count render-count 2 3000) "two renders completed")
+          (let [r1 (get @results 1)
+                r2 (get @results 2)]
+            (is (some? r1) "render 1 collected")
+            (is (some? r2) "render 2 collected")
+            (doseq [cls ["columns-container"
+                         "column-col-1" "column-col-2"
+                         "inner-col-1" "inner-col-2"]]
+              (is (= (get r1 cls) (get r2 cls))
+                  (str cls " address must be stable across escalated re-render: "
+                       "render1=" (get r1 cls) " render2=" (get r2 cls)))))
+          (ctx/stop-context! test-ctx))))))

--- a/test/org/replikativ/spindel/engine/spin_scope_keys_test.clj
+++ b/test/org/replikativ/spindel/engine/spin_scope_keys_test.clj
@@ -1,14 +1,15 @@
-(ns org.replikativ.spindel.engine.ephemeral-bindings-test
-  "Tests for the historical ephemeral binding keys mechanism.
+(ns org.replikativ.spindel.engine.spin-scope-keys-test
+  "Tests for the spin-scope-key mechanism.
 
-  This mechanism is being phased out: continuations now snapshot full
-  :bindings at suspend time and restore them at resume time, so the
-  per-key ephemerality category is no longer needed. Keys registered via
-  register-ephemeral-binding-key! are now preserved across both track and
-  await resumes — the suspend-time scope is what the body sees on resume,
-  the same way lexical bindings flow into a continuation's closure.
+  A spin-scope key is a :bindings entry that represents a spin's lexical
+  construction scope. `make-spin` snapshots the registered scope keys onto
+  the spin's node and the engine re-establishes them on every body-entry
+  path — initial run, track resume, and await resume — so the body always
+  runs under the scope it was constructed in, the same way lexical bindings
+  flow into a continuation's closure.
 
-  These tests document the post-snapshot behavior."
+  The registry (engine.bindings) is the engine's only knowledge of these
+  keys: the engine never names a :dom/* (or any domain) key itself."
   (:require [clojure.test :refer [deftest is testing]]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.bindings :as bindings]
@@ -19,20 +20,21 @@
             [org.replikativ.spindel.effects.await :refer [await]]
             [org.replikativ.spindel.effects.track :refer [track]]))
 
-;; Register a test-only key so this test doesn't depend on DOM registration.
-(bindings/register-ephemeral-binding-key! ::ephemeral)
+;; Register a test-only scope key so this test doesn't depend on DOM registration.
+(bindings/register-spin-scope-key! ::scoped)
 
 (defn- observe-bindings
-  "Read the current context's :bindings for both ephemeral and persistent keys."
+  "Read the current context's :bindings for both a scope key and a
+  persistent (unregistered) key."
   []
   (let [b (:bindings ec/*execution-context*)]
-    {:ephemeral  (get b ::ephemeral)
+    {:scoped     (get b ::scoped)
      :persistent (get b ::persistent)}))
 
-(deftest ephemeral-key-preserved-on-track-resume
-  (testing "Ephemeral key is preserved on track resume (new snapshot model)"
+(deftest scope-key-preserved-on-track-resume
+  (testing "Scope key is preserved when a spin resumes from a track continuation"
     (let [ctx-root (ctx/create-execution-context
-                    :bindings {::ephemeral  :set
+                    :bindings {::scoped     :set
                                ::persistent :set})]
       (try
         (binding [ec/*execution-context* ctx-root]
@@ -46,24 +48,23 @@
             (is (= 0 @s))
             (simple/await-drain-complete! ctx-root :timeout-ms 2000)
 
-            ;; Second pass — signal change forces track resume. Body resumes
-            ;; with the bindings that were active at the track suspend point.
+            ;; Second pass — signal change forces a track resume.
             (swap! counter inc)
             (simple/await-drain-complete! ctx-root :timeout-ms 2000)
 
             (is (= 2 (count @observed)) "spin body should execute twice")
             (let [[p1 p2] @observed]
-              (is (= :set (:ephemeral p1))  "pass 1: ephemeral visible")
+              (is (= :set (:scoped p1))     "pass 1: scope key visible")
               (is (= :set (:persistent p1)) "pass 1: persistent visible")
-              (is (= :set (:ephemeral p2))  "pass 2 (track resume): ephemeral preserved via snapshot")
+              (is (= :set (:scoped p2))     "pass 2 (track resume): scope key preserved")
               (is (= :set (:persistent p2)) "pass 2 (track resume): persistent preserved"))))
         (finally
           (ctx/stop-context! ctx-root))))))
 
-(deftest ephemeral-key-preserved-across-await-resume
-  (testing "Ephemeral key survives an await resume (same render pass)"
+(deftest scope-key-preserved-across-await-resume
+  (testing "Scope key survives an await resume (re-applied from the spin's snapshot)"
     (let [ctx-root (ctx/create-execution-context
-                    :bindings {::ephemeral  :set
+                    :bindings {::scoped     :set
                                ::persistent :set})]
       (try
         (binding [ec/*execution-context* ctx-root]
@@ -74,15 +75,15 @@
                           (reset! observed (observe-bindings))))]
             @parent
             (simple/await-drain-complete! ctx-root :timeout-ms 2000)
-            (is (= {:ephemeral :set :persistent :set} @observed)
+            (is (= {:scoped :set :persistent :set} @observed)
                 "both bindings visible after await resume")))
         (finally
           (ctx/stop-context! ctx-root))))))
 
-(deftest ephemeral-registry-is-global
-  (testing "Ephemeral keys registered earlier are returned by the accessor"
-    (is (contains? (bindings/ephemeral-binding-keys) ::ephemeral)))
+(deftest scope-key-registry-is-global
+  (testing "Scope keys registered earlier are returned by the accessor"
+    (is (contains? (bindings/spin-scope-keys) ::scoped)))
   (testing "DOM keys are pre-registered by dom.addressing"
     (require 'org.replikativ.spindel.dom.addressing)
-    (is (contains? (bindings/ephemeral-binding-keys) :dom/parent-addr))
-    (is (contains? (bindings/ephemeral-binding-keys) :dom/current-slot))))
+    (is (contains? (bindings/spin-scope-keys) :dom/parent-addr))
+    (is (contains? (bindings/spin-scope-keys) :dom/current-slot))))


### PR DESCRIPTION
## Summary

Fixes DOM subtree duplication when a keyed `ifor-each` re-renders. Two distinct root causes in the keyed-reconciliation path, each with regression coverage.

## 1. Item-spin loses construction scope on re-render (`c60145c`)

A keyed `ifor-each` item-spin that re-runs because its awaited child re-completed lost its construction scope: the `:spin-completion` handler rebuilt the resume context only from the continuation's `:ctx-bindings`, and await continuations (unlike track continuations) capture none. The item's elements then addressed under a `nil` parent-addr — addresses drifted, discharge reconciliation failed, and the subtree duplicated.

- Engine: `:spin-completion` re-applies the resuming spin's captured scope via a shared `apply-spin-scope` helper, covering the body-entry path that previously had no scope restoration.
- Decoupled the engine from DOM: captured-scope is now generic — `engine.bindings` exposes a `register-spin-scope-key!` registry that `make-spin` consumes; the engine no longer hardcodes `:dom/*` keys. The `:dom-scope` node slot is renamed `:spin-scope`.
- Relocated the keyed-sequence diff: `dom/foreach`'s `build-seq-diff` moves to `incremental/sequence-algebra` as a parameterized `keyed-seq-diff`; `dom/foreach` keeps only the discharge-layer packaging.
- Discharge: `*applied-vnodes*` tracking is now identity-based (generational identity set), so an oscillating source cannot drop a render cycle's deltas via spurious value-equality.

## 2. Eager cache eviction wipes live shared subtrees (`7afed7e`)

`call-refs-on-unmount!` evicted the per-element caches of every descendant of a destroyed vnode immediately. But unmount runs before the live subtree is `render-initial!`'d, so an address can sit in both a destroyed subtree and a live one within one pass (a churned parent whose keyed descendants survive). Eager eviction then wiped the live descendant's cache; its next reconcile diffed against an empty cache and emitted `:add-only` deltas, duplicating the subtree.

- `call-refs-on-unmount!` now collects addresses into `*pending-evictions*` (still firing `:ref` callbacks); after the full discharge walk, `flush-pending-evictions!` evicts only `(pending − *rendered-addrs*)`, sparing shared survivors. Outside a render pass, eviction stays eager.
- Snapshot/restore now also drops `:dom/keyed-cache` — a physical-DOM cache like `:dom/cache`.
- Removed the dead `with-keyed-context` macro (zero callers; it omitted the chain-head fork, so it was a trap).

## Tests

New regression tests: keyed-item-spin re-render addressing, `ifor-each` oscillation, spin-scope-key preservation, and deferred-eviction shared-address sparing. Both commit messages report the full JVM suite green (759 / 761 tests).

## Diff

15 files, +758 / −270.