### PR TITLE
fix(engine): stale lexical scope on await-cascade spin re-execution

### DIFF
--- a/src/org/replikativ/spindel/engine/free_vars.clj
+++ b/src/org/replikativ/spindel/engine/free_vars.clj
@@ -1,0 +1,124 @@
+(ns org.replikativ.spindel.engine.free-vars
+  "Free-variable analysis for spin bodies — compile-time only.
+
+   `free-variables` returns the set of enclosing lexical locals a body
+   actually references: the variables a spin's closure captures. The
+   `spin` macro records this set so the engine can detect, on
+   re-registration, whether a spin's captured environment changed.
+
+   This is a real analysis, not the empty-env unresolvable-symbol hack
+   (`distributed-scope`'s `free-variables`). That hack analyses with an
+   *empty* environment and collects symbols the analyzer cannot resolve,
+   which
+
+     - silently MISSES a local whose name shadows a var — `name`,
+       `count`, `type`, `val`, … resolve to clojure.core and are
+       dropped; a spin capturing one would go stale, and
+     - THROWS when a captured local is in function position — the
+       unresolved symbol is replaced by `nil` and `(nil x)` fails the
+       analyzer's validation pass.
+
+   Here the enclosing locals (the keys of `&env`) are registered WITH
+   the analyzer. tools.analyzer.jvm (CLJ) then resolves them as locals —
+   shadowing a var correctly, never throwing in call position — and
+   performs the macroexpansion and lexical scope resolution, so a
+   body-internal binding form that shadows an enclosing local is handled.
+   CLJ body-internal locals are uniquified by the analyzer, so
+   intersecting the referenced `:local` names with the enclosing set is
+   exact.
+
+   Runs at macro-expansion time only. `cljs.analyzer` is required lazily
+   (it is heavy and only needed when expanding for a CLJS target), the
+   same pattern partial-cps's ioc.clj uses."
+  (:require [clojure.set :as set]
+            [clojure.tools.analyzer.jvm :as ana.jvm]
+            [clojure.tools.analyzer.ast :as ana.ast]))
+
+;; =============================================================================
+;; CLJ — tools.analyzer.jvm
+;; =============================================================================
+
+(defn- clj-free-variables
+  "Analyse `body` with `enclosing` locals registered as `:binding` nodes;
+   return the subset of `enclosing` referenced as `:op :local` in the AST.
+   Body-internal locals are uniquified by the analyzer and so fall
+   outside `enclosing` — the intersection is exact."
+  [enclosing body]
+  (let [base   (ana.jvm/empty-env)
+        locals (into {}
+                     (map (fn [s]
+                            [s {:op :binding :name s :form s
+                                :local :let :env base :children []}]))
+                     enclosing)
+        ast    (ana.jvm/analyze body (assoc base :locals locals))]
+    (into #{}
+          (comp (filter #(= :local (:op %)))
+                (map :name)
+                (filter enclosing))
+          (ana.ast/nodes ast))))
+
+;; =============================================================================
+;; CLJS — cljs.analyzer (lazily resolved)
+;; =============================================================================
+
+(defn- cljs-local-names
+  "Names referenced by `:op :local` nodes anywhere in a cljs.analyzer AST."
+  [node]
+  (if-not (map? node)
+    #{}
+    (reduce (fn [acc k]
+              (let [c (get node k)]
+                (set/union acc
+                           (if (sequential? c)
+                             (reduce #(set/union %1 (cljs-local-names %2)) #{} c)
+                             (cljs-local-names c)))))
+            (if (= :local (:op node)) #{(:name node)} #{})
+            (:children node))))
+
+(defn- cljs-free-variables
+  "The CLJS analyzer `&env` already carries `:locals` for the enclosing
+   scope. Analyse `body` and return the subset of those locals referenced
+   as `:op :local`. A body-internal local that shadows an enclosing name
+   can over-include it — harmless (a needless equality check)."
+  [env body]
+  (let [analyze       (requiring-resolve 'cljs.analyzer/analyze)
+        warn-handlers (requiring-resolve 'cljs.analyzer/*cljs-warning-handlers*)
+        enclosing     (set (keys (:locals env)))
+        ast           (with-bindings {warn-handlers []}
+                        (analyze env body))]
+    (set/intersection (cljs-local-names ast) enclosing)))
+
+;; =============================================================================
+;; Public API
+;; =============================================================================
+
+(defn enclosing-locals
+  "The full set of enclosing lexical locals visible at the macro site."
+  [env]
+  (if (:js-globals env)
+    (set (keys (:locals env)))
+    (set (keys env))))
+
+(defn free-variables
+  "Set of enclosing lexical locals referenced by `body`.
+
+   `env`  — the macro `&env` (CLJ: sym→LocalBinding; CLJS: analyzer env
+            carrying `:locals`).
+   `body` — body forms wrapped in one form, e.g. `(do …)`.
+
+   Result ⊆ the enclosing locals. May throw if the analyzer cannot
+   handle `body`; callers wanting resilience use `free-variables-or-all`."
+  [env body]
+  (if (:js-globals env)
+    (cljs-free-variables env body)
+    (clj-free-variables (set (keys env)) body)))
+
+(defn free-variables-or-all
+  "Like `free-variables` but never throws: on any analyzer failure, fall
+   back to ALL enclosing locals — a correct, less-precise
+   over-approximation (an unchanged spin may re-run, but it is never
+   wrongly skipped)."
+  [env body]
+  (try
+    (free-variables env body)
+    (catch Throwable _ (enclosing-locals env))))

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -1487,6 +1487,19 @@
 ;; Spin Lifecycle (shared across all context implementations)
 ;; =============================================================================
 
+(defn- captures-changed?
+  "True when a spin's captured environment differs from the previous one.
+
+  The key set is fixed per `(spin …)` form (the macro bakes in the free
+  variables), so this reduces to: is any captured value not `identical?`
+  to its prior value. `identical?` — not `=` — because it is O(1), never
+  throws, and Clojure's structural sharing keeps an unchanged persistent
+  value `identical?`; the only cost is an occasional needless re-run when
+  a value is rebuilt `=`-equal but not `identical?`."
+  [old new]
+  (or (not= (set (keys old)) (set (keys new)))
+      (boolean (some (fn [[k v]] (not (identical? v (get old k)))) new))))
+
 (defn register-spin!
   "Register a spin's metadata in the context.
 
@@ -1511,18 +1524,27 @@
     ;; Create or update SpinNode in :nodes
     (rtp/swap-state! context [:nodes spin-id]
                      (fn [existing-node]
-                       (if existing-node
+                       (let [new-caps (:captured-locals spin-meta)]
+                         (if existing-node
           ;; Re-registration: the (spin …) form was re-evaluated by a
-          ;; re-running enclosing scope → a fresh closure with possibly
-          ;; fresh captures. Mark the node dirty so the fresh cps-fn
-          ;; actually runs, instead of `await`/`deref` serving the stale
-          ;; cached result computed by the previous closure. :result is
-          ;; kept as the previous value (needed for value-change diffing).
-                         (-> existing-node
-                             (assoc :created-by creator-id :completed? false)
-                             (nodes/mark-dirty))
-          ;; Create new SpinNode with creator tracking
-                         (nodes/->spin-node nil :clean false false #{} {} creator-id #{}))))
+          ;; re-running enclosing scope → a fresh closure. Mark the node
+          ;; dirty — so the fresh cps-fn runs instead of await/deref
+          ;; serving the stale cached result — but ONLY when the captured
+          ;; environment actually changed (identical?-compared). When no
+          ;; capture info was supplied (a non-macro spin: new-caps nil)
+          ;; fall back to dirtying unconditionally. :result is kept as the
+          ;; previous value (needed for value-change diffing).
+                           (let [base (assoc existing-node
+                                             :created-by creator-id
+                                             :captured-locals new-caps)]
+                             (if (or (nil? new-caps)
+                                     (captures-changed? (:captured-locals existing-node)
+                                                        new-caps))
+                               (-> base (assoc :completed? false) (nodes/mark-dirty))
+                               base))
+          ;; First registration: new node, record the captured environment.
+                           (assoc (nodes/->spin-node nil :clean false false #{} {} creator-id #{})
+                                  :captured-locals new-caps)))))
 
     ;; If there's a creator (other than ourselves), add this spin to its
     ;; created-spins set. Self-add could occur on CLJS if a stale async

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -1512,8 +1512,15 @@
     (rtp/swap-state! context [:nodes spin-id]
                      (fn [existing-node]
                        (if existing-node
-          ;; Spin already exists - update created-by (closure may have changed)
-                         (assoc existing-node :created-by creator-id)
+          ;; Re-registration: the (spin …) form was re-evaluated by a
+          ;; re-running enclosing scope → a fresh closure with possibly
+          ;; fresh captures. Mark the node dirty so the fresh cps-fn
+          ;; actually runs, instead of `await`/`deref` serving the stale
+          ;; cached result computed by the previous closure. :result is
+          ;; kept as the previous value (needed for value-change diffing).
+                         (-> existing-node
+                             (assoc :created-by creator-id :completed? false)
+                             (nodes/mark-dirty))
           ;; Create new SpinNode with creator tracking
                          (nodes/->spin-node nil :clean false false #{} {} creator-id #{}))))
 

--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -424,12 +424,17 @@
 
    The spin-id is used to track dependencies in the runtime's graph."
   ([spin-fn]
-   (make-spin spin-fn (keyword (gensym "spin-"))))
+   (make-spin spin-fn (keyword (gensym "spin-")) nil))
   ([spin-fn spin-id]
+   (make-spin spin-fn spin-id nil))
+  ([spin-fn spin-id captured-locals]
    (let [reactive-spin (->Spin spin-id spin-fn)]
 
-     ;; Register spin with runtime via protocol (uses dynamic *execution-context*)
-     (ec/spin-register! spin-id {:provides #{}})
+     ;; Register spin with runtime via protocol (uses dynamic *execution-context*).
+     ;; captured-locals — {sym value} of the body's free variables — lets
+     ;; register-spin! detect (identical?) whether a re-registered spin's
+     ;; captured environment changed. nil for non-macro callers.
+     (ec/spin-register! spin-id {:provides #{} :captured-locals captured-locals})
 
      ;; Snapshot this spin's lexical scope — the registered spin-scope
      ;; binding keys (see engine.bindings) — from the construction-time

--- a/src/org/replikativ/spindel/spin/cps.cljc
+++ b/src/org/replikativ/spindel/spin/cps.cljc
@@ -8,6 +8,7 @@
             [is.simm.partial-cps.async :as async]
             [is.simm.partial-cps.runtime]            ;; Loads Thunk into the runtime ns
             #?(:clj [is.simm.partial-cps.ioc :as ioc])
+            #?(:clj [org.replikativ.spindel.engine.free-vars :as free-vars])
             [org.replikativ.spindel.spin.core :as spin-core])
   ;; Make the spin macro available to CLJS via require-macros
   ;; Note: effect is not included here because it's defined in #?(:clj ...) only and
@@ -139,6 +140,20 @@
             (catch ~(if is-cljs? :default `Throwable) t# (~e t#)))))))
 
 #?(:clj
+   (defn- captured-locals-form
+     "Build a `{'sym sym …}` form snapshotting the runtime values of the
+      body's free variables. register-spin! `identical?`-compares this map
+      across re-registrations to decide whether a spin's captured
+      environment changed — and so whether the re-evaluated form must
+      re-run rather than serve its cached result. Free vars are found by
+      a proper analysis (engine.free-vars); on analyzer failure it falls
+      back to all enclosing locals (a safe over-approximation)."
+     [env body]
+     (into {}
+           (map (fn [s] [(list 'quote s) s]))
+           (free-vars/free-variables-or-all env (cons 'do body)))))
+
+#?(:clj
    (defmacro spin
      "Create a cached, reactive spin that automatically tracks dependencies and re-executes when dependencies change.
 
@@ -170,6 +185,9 @@
      [& body]
      (let [execution-context-expr `(ec/current-execution-context)
            cps-fn (build-cps-fn body (build-breakpoints) &env)
+           ;; Free variables the body captures, snapshotted as {'sym sym}
+           ;; so register-spin! can identical?-detect a changed environment.
+           captured (captured-locals-form &env body)
            ;; Capture source location at macro expansion time
            source-loc {:file *file*
                        :line (:line (meta &form))
@@ -178,7 +196,7 @@
           (ec/with-context ctx#
             ;; Generate deterministic spin ID via hash-chain addressing
             (let [spin-id# (addressing/next-address! ctx# "spin" ~source-loc)]
-              (spin-core/make-spin ~cps-fn spin-id#))))))
+              (spin-core/make-spin ~cps-fn spin-id# ~captured))))))
 
    #?(:clj
       (defmacro effect
@@ -218,6 +236,8 @@
            ;; Wrap body to return nil after executing
               body-with-nil (concat body [nil])
               cps-fn (build-cps-fn body-with-nil (build-breakpoints) &env)
+           ;; Free variables the body captures (see `spin`).
+              captured (captured-locals-form &env body)
            ;; Capture source location at macro expansion time
               source-loc {:file *file*
                           :line (:line (meta &form))
@@ -226,4 +246,4 @@
              (ec/with-context ctx#
             ;; Generate deterministic effect ID via hash-chain addressing
                (let [spin-id# (addressing/next-address! ctx# "effect" ~source-loc)]
-                 (spin-core/make-spin ~cps-fn spin-id#))))))))
+                 (spin-core/make-spin ~cps-fn spin-id# ~captured))))))))

--- a/test/org/replikativ/spindel/stale_lexical_scope_test.clj
+++ b/test/org/replikativ/spindel/stale_lexical_scope_test.clj
@@ -1,0 +1,191 @@
+(ns org.replikativ.spindel.stale-lexical-scope-test
+  "REGRESSION SPEC for the stale-lexical-scope engine bug.
+
+   A `(spin …)` form captures lexical values from its enclosing scope.
+   When the enclosing scope re-runs, the form is re-evaluated → a fresh
+   closure with fresh captures, but the SAME deterministic id. The engine
+   keeps the old node's cached result; whether the stale cache is served
+   or the fresh closure runs depends on WHICH re-execution path fired.
+
+   `invalidate-created-spins!` papers over this on the track-resume and
+   direct-invoke paths. These tests probe the same closure-capture gap
+   across different re-execution forms — notably the await-cascade resume
+   path, where `invalidate-created-spins!` is not reached.
+
+   Tests that fail here are the target of the engine redesign. They are
+   tagged ^:stale-scope-spec so the default suite can exclude them until
+   the redesign lands."
+  (:refer-clojure :exclude [await])
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.signal :as sig]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.effects.track :refer [track]]
+            [org.replikativ.spindel.test-async :refer [await-drain]]
+            [org.replikativ.spindel.test-helpers :as th]))
+
+;; =============================================================================
+;; Form 1 — baseline: nested spin over a track-derived local, parent re-runs
+;; via track-resume. This is the form `invalidate-created-spins!` covers
+;; (same as nested-spin-invalidation-test). Expected: PASS.
+;; =============================================================================
+
+(deftest ^:stale-scope-spec form-1-track-resume-baseline
+  (testing "nested spin over track-derived local; parent re-runs via track-resume"
+    (th/with-ctx [ctx]
+      (let [s (sig/signal 2)
+            outer (spin
+                   (let [{m :new} (track s)]
+                     (let [inner (spin (* 10 m))]
+                       (await inner))))]
+        (is (= 20 @outer) "first run: 10 * 2")
+        (reset! s 3)
+        (await-drain ctx)
+        (is (= 30 @outer) "after s change — inner must see m=3")))))
+
+;; =============================================================================
+;; Form 2 — nested spin captures an AWAIT-derived local; the parent re-runs
+;; because an awaited reactive child re-completes (await-cascade resume).
+;; This path does not go through `invalidate-created-spins!`.
+;; =============================================================================
+
+(deftest ^:stale-scope-spec form-2-await-cascade-nested
+  (testing "nested spin over await-result; parent re-runs via await-cascade"
+    (th/with-ctx [ctx]
+      (let [s (sig/signal 2)
+            data (spin (let [{v :new} (track s)] v))
+            parent (spin
+                    (let [r (await data)]
+                      (let [inner (spin (* 10 r))]
+                        (await inner))))]
+        (is (= 20 @parent) "first run: 10 * 2")
+        (reset! s 3)
+        (await-drain ctx)
+        (is (= 30 @parent) "after s change — inner must see r=3")))))
+
+;; =============================================================================
+;; Form 3 — two nesting levels under an await-cascade resume.
+;; =============================================================================
+
+(deftest ^:stale-scope-spec form-3-await-cascade-deep
+  (testing "two nesting levels under an await-cascade resume"
+    (th/with-ctx [ctx]
+      (let [s (sig/signal 2)
+            data (spin (let [{v :new} (track s)] v))
+            parent (spin
+                    (let [r (await data)]
+                      (let [mid (spin
+                                 (let [inner (spin (* 10 r))]
+                                   (await inner)))]
+                        (await mid))))]
+        (is (= 20 @parent) "first run: 10 * 2")
+        (reset! s 3)
+        (await-drain ctx)
+        (is (= 30 @parent) "after s change — deep inner must see r=3")))))
+
+;; =============================================================================
+;; Form 4 — two sibling nested spins each capturing the same track-derived
+;; local; track-resume. Probes whether sibling created-spins are all updated.
+;; =============================================================================
+
+(deftest ^:stale-scope-spec form-4-sibling-spins-track
+  (testing "two sibling nested spins capture an outer local; track-resume"
+    (th/with-ctx [ctx]
+      (let [s (sig/signal 2)
+            parent (spin
+                    (let [{m :new} (track s)
+                          a (spin (* 10 m))
+                          b (spin (* 100 m))]
+                      [(await a) (await b)]))]
+        (is (= [20 200] @parent) "first run")
+        (reset! s 3)
+        (await-drain ctx)
+        (is (= [30 300] @parent) "after s change — both siblings must see m=3")))))
+
+;; =============================================================================
+;; Form 5 — inner spin tracks its OWN signal AND captures an outer local.
+;; After the outer re-runs (re-creating inner with a fresh capture), the
+;; inner's own signal fires: does the inner's own re-run see the fresh
+;; outer capture, or a stale one?
+;; =============================================================================
+
+(deftest ^:stale-scope-spec form-5-reactive-inner-captures-outer
+  (testing "inner spin tracks its own signal AND captures an outer local"
+    (th/with-ctx [ctx]
+      (let [s (sig/signal 10)
+            t (sig/signal 1)
+            outer (spin
+                   (let [{v :new} (track s)]
+                     (let [inner (spin (let [{w :new} (track t)] (+ v w)))]
+                       (await inner))))]
+        (is (= 11 @outer) "first run: 10 + 1")
+        (reset! s 20)
+        (await-drain ctx)
+        (is (= 21 @outer) "after s change: 20 + 1")
+        (reset! t 5)
+        (await-drain ctx)
+        (is (= 25 @outer)
+            "after t change — inner re-runs on its own signal; must use v=20")))))
+
+;; =============================================================================
+;; Form 6 — under await-cascade, prove the stale nested spin's BODY never
+;; re-runs (not merely that the value is wrong) via an execution counter.
+;; =============================================================================
+
+(deftest ^:stale-scope-spec form-6-await-cascade-body-not-rerun
+  (testing "under await-cascade, the stale nested spin's body must re-run"
+    (th/with-ctx [ctx]
+      (let [s (sig/signal 2)
+            runs (atom 0)
+            data (spin (let [{v :new} (track s)] v))
+            parent (spin
+                    (let [r (await data)]
+                      (let [inner (spin (swap! runs inc) (* 10 r))]
+                        (await inner))))]
+        @parent
+        (is (= 1 @runs) "inner ran once")
+        (reset! s 3)
+        (await-drain ctx)
+        @parent
+        (is (= 2 @runs) "inner must re-run with fresh r")))))
+
+;; =============================================================================
+;; Form 7 — nested spin under await-cascade that ALSO tracks its own signal.
+;; Its own reactivity must not mask a stale await-derived capture.
+;; =============================================================================
+
+(deftest ^:stale-scope-spec form-7-await-cascade-reactive-inner
+  (testing "nested reactive spin under await-cascade captures await-result"
+    (th/with-ctx [ctx]
+      (let [s (sig/signal 2)
+            t (sig/signal 1)
+            data (spin (let [{v :new} (track s)] v))
+            parent (spin
+                    (let [r (await data)]
+                      (let [inner (spin (let [{w :new} (track t)]
+                                          (+ (* 10 r) w)))]
+                        (await inner))))]
+        (is (= 21 @parent) "first run: 10*2 + 1")
+        (reset! s 3)
+        (await-drain ctx)
+        (is (= 31 @parent) "after s change: 10*3 + 1 — inner must see r=3")))))
+
+;; =============================================================================
+;; Form 8 — sibling nested spins under an await-cascade resume.
+;; =============================================================================
+
+(deftest ^:stale-scope-spec form-8-await-cascade-siblings
+  (testing "sibling nested spins under await-cascade"
+    (th/with-ctx [ctx]
+      (let [s (sig/signal 2)
+            data (spin (let [{v :new} (track s)] v))
+            parent (spin
+                    (let [r (await data)
+                          a (spin (* 10 r))
+                          b (spin (* 100 r))]
+                      [(await a) (await b)]))]
+        (is (= [20 200] @parent) "first run")
+        (reset! s 3)
+        (await-drain ctx)
+        (is (= [30 300] @parent) "after change — both siblings must see r=3")))))

--- a/test/org/replikativ/spindel/stale_lexical_scope_test.cljc
+++ b/test/org/replikativ/spindel/stale_lexical_scope_test.cljc
@@ -3,74 +3,88 @@
 
    A `(spin …)` form captures lexical values from its enclosing scope.
    When the enclosing scope re-runs, the form is re-evaluated → a fresh
-   closure with fresh captures, but the SAME deterministic id. The engine
-   keeps the old node's cached result; whether the stale cache is served
-   or the fresh closure runs depends on WHICH re-execution path fired.
+   closure with fresh captures, but the SAME deterministic id. The bug:
+   the engine kept the old node `:clean` and served the stale cached
+   result instead of running the fresh closure — most visibly on the
+   await-cascade resume path, which `invalidate-created-spins!` never
+   covered.
 
-   `invalidate-created-spins!` papers over this on the track-resume and
-   direct-invoke paths. These tests probe the same closure-capture gap
-   across different re-execution forms — notably the await-cascade resume
-   path, where `invalidate-created-spins!` is not reached.
+   The fix (engine.free-vars + register-spin!): the `spin` macro records
+   the body's captured free variables; on re-registration the engine
+   `identical?`-compares them and re-runs only when the captured
+   environment actually changed.
 
-   Tests that fail here are the target of the engine redesign. They are
-   tagged ^:stale-scope-spec so the default suite can exclude them until
-   the redesign lands."
+   Runs on both CLJ and CLJS — the engine is shared `.cljc`, and
+   `free-variables` has a per-platform analyzer path (tools.analyzer.jvm
+   / cljs.analyzer), so the CLJS run exercises the CLJS analyzer path.
+
+   A spin invoked via `run-spin!` is a reactive subscription: its
+   callback fires on *every* completion. Each test therefore drives one
+   `run-spin!` and matches on a completion counter — completion 1 is the
+   first run, completion 2 is the re-run after the signal mutation."
   (:refer-clojure :exclude [await])
-  (:require [clojure.test :refer [deftest is testing]]
-            [org.replikativ.spindel.engine.context :as ctx]
+  (:require #?(:clj  [clojure.test :refer [deftest is]]
+               :cljs [cljs.test :refer-macros [deftest is]])
             [org.replikativ.spindel.spin.cps :refer [spin]]
             [org.replikativ.spindel.signal :as sig]
             [org.replikativ.spindel.effects.await :refer [await]]
             [org.replikativ.spindel.effects.track :refer [track]]
-            [org.replikativ.spindel.test-async :refer [await-drain]]
-            [org.replikativ.spindel.test-helpers :as th]))
+            [org.replikativ.spindel.test-helpers :refer [async with-ctx run-spin!]])
+  #?(:cljs (:require-macros [org.replikativ.spindel.spin.cps :refer [spin]])))
+
+(defn- check-rerun
+  "Drive one `run-spin!` on the reactive `spin`. Completion 1 → assert
+   `expected-1`, apply `mutate!` (which triggers a re-completion);
+   completion 2 → assert `expected-2`, finish via `done`."
+  [done spin expected-1 mutate! expected-2]
+  (let [stage (atom 0)
+        fail  (fn [e] (is false (str "unexpected spin error: " e)) (done))]
+    (run-spin! spin
+               (fn [r]
+                 (case (swap! stage inc)
+                   1 (do (is (= expected-1 r) "first run") (mutate!))
+                   2 (do (is (= expected-2 r) "after change") (done))
+                   nil))
+               fail)))
 
 ;; =============================================================================
 ;; Form 1 — baseline: nested spin over a track-derived local, parent re-runs
-;; via track-resume. This is the form `invalidate-created-spins!` covers
-;; (same as nested-spin-invalidation-test). Expected: PASS.
+;; via track-resume.
 ;; =============================================================================
 
 (deftest ^:stale-scope-spec form-1-track-resume-baseline
-  (testing "nested spin over track-derived local; parent re-runs via track-resume"
-    (th/with-ctx [ctx]
+  (async done
+    (with-ctx [_ctx]
       (let [s (sig/signal 2)
             outer (spin
                    (let [{m :new} (track s)]
                      (let [inner (spin (* 10 m))]
                        (await inner))))]
-        (is (= 20 @outer) "first run: 10 * 2")
-        (reset! s 3)
-        (await-drain ctx)
-        (is (= 30 @outer) "after s change — inner must see m=3")))))
+        (check-rerun done outer 20 #(reset! s 3) 30)))))
 
 ;; =============================================================================
 ;; Form 2 — nested spin captures an AWAIT-derived local; the parent re-runs
 ;; because an awaited reactive child re-completes (await-cascade resume).
-;; This path does not go through `invalidate-created-spins!`.
 ;; =============================================================================
 
 (deftest ^:stale-scope-spec form-2-await-cascade-nested
-  (testing "nested spin over await-result; parent re-runs via await-cascade"
-    (th/with-ctx [ctx]
+  (async done
+    (with-ctx [_ctx]
       (let [s (sig/signal 2)
             data (spin (let [{v :new} (track s)] v))
             parent (spin
                     (let [r (await data)]
                       (let [inner (spin (* 10 r))]
                         (await inner))))]
-        (is (= 20 @parent) "first run: 10 * 2")
-        (reset! s 3)
-        (await-drain ctx)
-        (is (= 30 @parent) "after s change — inner must see r=3")))))
+        (check-rerun done parent 20 #(reset! s 3) 30)))))
 
 ;; =============================================================================
 ;; Form 3 — two nesting levels under an await-cascade resume.
 ;; =============================================================================
 
 (deftest ^:stale-scope-spec form-3-await-cascade-deep
-  (testing "two nesting levels under an await-cascade resume"
-    (th/with-ctx [ctx]
+  (async done
+    (with-ctx [_ctx]
       (let [s (sig/signal 2)
             data (spin (let [{v :new} (track s)] v))
             parent (spin
@@ -79,85 +93,84 @@
                                  (let [inner (spin (* 10 r))]
                                    (await inner)))]
                         (await mid))))]
-        (is (= 20 @parent) "first run: 10 * 2")
-        (reset! s 3)
-        (await-drain ctx)
-        (is (= 30 @parent) "after s change — deep inner must see r=3")))))
+        (check-rerun done parent 20 #(reset! s 3) 30)))))
 
 ;; =============================================================================
 ;; Form 4 — two sibling nested spins each capturing the same track-derived
-;; local; track-resume. Probes whether sibling created-spins are all updated.
+;; local; track-resume.
 ;; =============================================================================
 
 (deftest ^:stale-scope-spec form-4-sibling-spins-track
-  (testing "two sibling nested spins capture an outer local; track-resume"
-    (th/with-ctx [ctx]
+  (async done
+    (with-ctx [_ctx]
       (let [s (sig/signal 2)
             parent (spin
                     (let [{m :new} (track s)
                           a (spin (* 10 m))
                           b (spin (* 100 m))]
                       [(await a) (await b)]))]
-        (is (= [20 200] @parent) "first run")
-        (reset! s 3)
-        (await-drain ctx)
-        (is (= [30 300] @parent) "after s change — both siblings must see m=3")))))
+        (check-rerun done parent [20 200] #(reset! s 3) [30 300])))))
 
 ;; =============================================================================
 ;; Form 5 — inner spin tracks its OWN signal AND captures an outer local.
 ;; After the outer re-runs (re-creating inner with a fresh capture), the
-;; inner's own signal fires: does the inner's own re-run see the fresh
-;; outer capture, or a stale one?
+;; inner's own signal fires: it must use the fresh outer capture.
 ;; =============================================================================
 
 (deftest ^:stale-scope-spec form-5-reactive-inner-captures-outer
-  (testing "inner spin tracks its own signal AND captures an outer local"
-    (th/with-ctx [ctx]
+  (async done
+    (with-ctx [_ctx]
       (let [s (sig/signal 10)
             t (sig/signal 1)
             outer (spin
                    (let [{v :new} (track s)]
                      (let [inner (spin (let [{w :new} (track t)] (+ v w)))]
-                       (await inner))))]
-        (is (= 11 @outer) "first run: 10 + 1")
-        (reset! s 20)
-        (await-drain ctx)
-        (is (= 21 @outer) "after s change: 20 + 1")
-        (reset! t 5)
-        (await-drain ctx)
-        (is (= 25 @outer)
-            "after t change — inner re-runs on its own signal; must use v=20")))))
+                       (await inner))))
+            stage (atom 0)
+            fail (fn [e] (is false (str "unexpected spin error: " e)) (done))]
+        (run-spin! outer
+                   (fn [r]
+                     (case (swap! stage inc)
+                       1 (do (is (= 11 r) "first run: 10 + 1") (reset! s 20))
+                       2 (do (is (= 21 r) "after s change: 20 + 1") (reset! t 5))
+                       3 (do (is (= 25 r)
+                                 "after t change — inner re-runs on its own signal; must use v=20")
+                             (done))
+                       nil))
+                   fail)))))
 
 ;; =============================================================================
-;; Form 6 — under await-cascade, prove the stale nested spin's BODY never
-;; re-runs (not merely that the value is wrong) via an execution counter.
+;; Form 6 — under await-cascade, prove the stale nested spin's BODY re-runs
+;; (not merely that the value is wrong) via an execution counter.
 ;; =============================================================================
 
 (deftest ^:stale-scope-spec form-6-await-cascade-body-not-rerun
-  (testing "under await-cascade, the stale nested spin's body must re-run"
-    (th/with-ctx [ctx]
+  (async done
+    (with-ctx [_ctx]
       (let [s (sig/signal 2)
             runs (atom 0)
             data (spin (let [{v :new} (track s)] v))
             parent (spin
                     (let [r (await data)]
                       (let [inner (spin (swap! runs inc) (* 10 r))]
-                        (await inner))))]
-        @parent
-        (is (= 1 @runs) "inner ran once")
-        (reset! s 3)
-        (await-drain ctx)
-        @parent
-        (is (= 2 @runs) "inner must re-run with fresh r")))))
+                        (await inner))))
+            stage (atom 0)
+            fail (fn [e] (is false (str "unexpected spin error: " e)) (done))]
+        (run-spin! parent
+                   (fn [_]
+                     (case (swap! stage inc)
+                       1 (do (is (= 1 @runs) "inner ran once") (reset! s 3))
+                       2 (do (is (= 2 @runs) "inner must re-run with fresh r") (done))
+                       nil))
+                   fail)))))
 
 ;; =============================================================================
 ;; Form 7 — nested spin under await-cascade that ALSO tracks its own signal.
-;; Its own reactivity must not mask a stale await-derived capture.
 ;; =============================================================================
 
 (deftest ^:stale-scope-spec form-7-await-cascade-reactive-inner
-  (testing "nested reactive spin under await-cascade captures await-result"
-    (th/with-ctx [ctx]
+  (async done
+    (with-ctx [_ctx]
       (let [s (sig/signal 2)
             t (sig/signal 1)
             data (spin (let [{v :new} (track s)] v))
@@ -166,18 +179,15 @@
                       (let [inner (spin (let [{w :new} (track t)]
                                           (+ (* 10 r) w)))]
                         (await inner))))]
-        (is (= 21 @parent) "first run: 10*2 + 1")
-        (reset! s 3)
-        (await-drain ctx)
-        (is (= 31 @parent) "after s change: 10*3 + 1 — inner must see r=3")))))
+        (check-rerun done parent 21 #(reset! s 3) 31)))))
 
 ;; =============================================================================
 ;; Form 8 — sibling nested spins under an await-cascade resume.
 ;; =============================================================================
 
 (deftest ^:stale-scope-spec form-8-await-cascade-siblings
-  (testing "sibling nested spins under await-cascade"
-    (th/with-ctx [ctx]
+  (async done
+    (with-ctx [_ctx]
       (let [s (sig/signal 2)
             data (spin (let [{v :new} (track s)] v))
             parent (spin
@@ -185,7 +195,4 @@
                           a (spin (* 10 r))
                           b (spin (* 100 r))]
                       [(await a) (await b)]))]
-        (is (= [20 200] @parent) "first run")
-        (reset! s 3)
-        (await-drain ctx)
-        (is (= [30 300] @parent) "after change — both siblings must see r=3")))))
+        (check-rerun done parent [20 200] #(reset! s 3) [30 300])))))


### PR DESCRIPTION
## Problem

A `(spin …)` form re-evaluated by a re-running enclosing scope builds a
fresh closure (fresh captured values) but keeps the same deterministic
spin id. The engine kept the existing node `:clean` and served the
**stale cached result** computed by the *previous* closure.

`invalidate-created-spins!` papered over this on the track-resume and
direct-invoke paths, but **not** the await-cascade resume path — so a
spin nested under an `(await …)` whose parent re-runs because an awaited
reactive child re-completed would silently serve a stale result.

`test/.../stale_lexical_scope_test.cljc` reproduces it — 8 forms, 5 of
which failed before this branch.

## Fix

1. **`engine.free-vars`** — a proper free-variable analysis. The
   enclosing `&env` locals are *registered* with `tools.analyzer.jvm` /
   `cljs.analyzer`, so a local shadowing a core var resolves as a local
   (not silently missed — `name`, `count`, `type`, …) and a captured fn
   in call position resolves (no nil-substitution throw). Replaces the
   empty-env unresolvable-symbol hack.
2. **`identical?`-gated re-registration** — the `spin`/`effect` macros
   snapshot the body's free variables; `register-spin!` `identical?`-
   compares them on re-registration and re-runs the spin only when the
   captured environment actually changed. O(1), never throws, no
   structural `=`, no contract flip (an unchanged spin still serves its
   cache).

## Verification

- Regression spec — 8 forms, cross-platform (`.cljc`).
- **CLJ:** full suite 772 tests, 2650 assertions, 0 failures.
- **CLJS:** full suite 360 tests, 1373 assertions, 0 failures — the
  await-cascade forms pass on CLJS too, confirming the `cljs.analyzer`
  free-variable path.

## Follow-up (not in this PR)

`invalidate-created-spins!` is now redundant for *dirtying* —
`register-spin!`'s identical?-gate covers every re-registration path.
It is **not**, however, safely removable on its own: its `clear-deps!`
of re-run children is still load-bearing (removing it stalls an async
rate-control test on CLJS). Proper removal belongs with the explicit
spin-lifecycle redesign, where dependency/continuation teardown is
handled coherently.