### PR TITLE
Drain thread leak + stale-cont re-fire: 3 fixes toward 0.1.10

### DIFF
--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -22,9 +22,7 @@
             [org.replikativ.spindel.engine.state-backend :as backend]
             [org.replikativ.spindel.engine.nodes :as nodes]
             [org.replikativ.spindel.engine.addressing :as addressing]
-            [incognito.edn :refer [read-string-safe]])
-  #?(:clj (:import [java.util.concurrent LinkedBlockingQueue TimeUnit]
-                   [java.lang.ref Cleaner WeakReference])))
+            [incognito.edn :refer [read-string-safe]]))
 
 ;; =============================================================================
 ;; Incognito Handlers for Serialization
@@ -74,12 +72,17 @@
             executor       ; Executor for scheduling (shared across forks for now)
             bindings       ; Fork-local configuration (map for spin access via *execution-context*)
             metadata       ; User-defined fork metadata (e.g., {:particle-id 123})
-            running        ; Atom controlling background drain thread lifecycle
-            drain-thread   ; Background thread that continuously drains event queue
-            drain-signal   ; LinkedBlockingQueue for waking drain thread (nil for forks)
+            running        ; Atom — flipped to false by stop-context!. drain-events!
+                           ; guards on this so post-stop drains become no-ops.
             drain-active]  ; Atom counting drain-events! calls past the running guard.
                   ; stop-context! waits for this to reach 0 before returning,
                   ; so no further drain on this context can mutate state.
+
+  ;; The engine has no standing per-context drain thread. Every enqueue
+  ;; path goes through rtp/enqueue! (the PEngine method), which atomically
+  ;; does simple/enqueue-event! + simple/trigger-drain!. trigger-drain!
+  ;; submits the drain on the context's executor (a virtual thread on
+  ;; JDK 21+), so there is no need for a standing 1 Hz safety-net poll.
 
   ;; Implement runtime protocols by delegating to simple.cljc functions
   ;; This allows ExecutionContext to be used anywhere runtime is expected
@@ -212,40 +215,6 @@
 ;; Creation
 ;; =============================================================================
 
-#?(:clj
-   (def ^:private ^Cleaner context-cleaner
-     (Cleaner/create)))
-
-#?(:clj
-   (def ^:private ^java.lang.reflect.Method virtual-thread-start-method
-     "Reflectively resolved `Thread.startVirtualThread(Runnable)` so this
-      file compiles under any JDK while only invoking the method when
-      running on JDK 21+. nil → fall back to a platform daemon thread."
-     (try
-       (.getMethod Thread "startVirtualThread"
-                   (into-array Class [Runnable]))
-       (catch NoSuchMethodException _ nil))))
-
-#?(:clj
-   (defn- ^Thread start-drain-thread!
-     "Start a daemon-style thread that runs `runnable` to completion. On
-      JDK 21+ this is a virtual thread (carrier-shared, ~few KB heap,
-      free to leak when GC takes its time); otherwise it's a classic
-      daemon platform thread.
-
-      All drain threads in spindel are long-lived but cheap when parked
-      on `.poll(drain-signal, 1, SECONDS)`. The virtual-thread variant
-      makes per-context drain threads stop being a resource concern,
-      which removes the long-standing test-suite leak (~40 daemon
-      Thread-N entries per 5-minute run before this change). See
-      doc/drain-thread-leak.md."
-     [^Runnable runnable]
-     (if-let [m virtual-thread-start-method]
-       (.invoke m nil (into-array Object [runnable]))
-       (doto (Thread. runnable)
-         (.setDaemon true)
-         (.start)))))
-
 (defn create-execution-context
   "Create a new root execution context.
 
@@ -290,96 +259,51 @@
                               :engine/timer-handles {}})
         ;; Create AtomBackend for root context
         atom-backend (backend/create-atom-backend initial-rt-state)
-        ;; Create background drain thread control
+        ;; running stays true until stop-context! flips it. Without a
+        ;; standing drain thread there's nothing to interrupt — guards
+        ;; in drain-events! check this so post-stop drains no-op.
         running (atom true)
-        ;; Notification queue for waking drain thread (zero-polling)
-        drain-signal #?(:clj (LinkedBlockingQueue.) :cljs nil)
         ;; Counter of drains currently past the function-entry guard.
         ;; stop-context! polls this down to 0 before returning.
-        drain-active (atom 0)
-        ;; Hold a weak ref slot the drain thread reads each tick. We populate
-        ;; it with the FINAL ctx record (the one returned to the caller) so
-        ;; the Cleaner observes the same object the user holds. Holding the
-        ;; pre-assoc record A would let A become GC-eligible immediately
-        ;; (since assoc returns a new record B), causing the Cleaner to fire
-        ;; mid-execution and kill the drain thread.
-        ctx-holder #?(:clj (java.util.concurrent.atomic.AtomicReference.) :cljs nil)
-        ;; Start background drain thread (zero-polling via LinkedBlockingQueue)
-        ;; Blocks on drain-signal.poll(1s) instead of Thread/sleep 10
-        ;; Wakes instantly when trigger-drain! calls .offer(:drain)
-        ;; Uses daemon thread so leaked contexts don't prevent JVM exit
-        ;; or accumulate thread overhead in tests.
-        ;;
-        ;; IMPORTANT: hold ctx via WeakReference (set after construction
-        ;; below), not as a strong capture. A virtual thread's carrier is
-        ;; a GC root only while the VT is mounted; a parked VT is held by
-        ;; its scheduler queue but treats its closures normally. Either
-        ;; way, a strong capture of `ctx` here would keep the context
-        ;; reachable forever, defeating the Cleaner registered below.
-        drain-thread #?(:clj
-                        (start-drain-thread!
-                          (fn []
-                            (while @running
-                              (try
-                                ;; Block until signaled or 1s timeout
-                                ;; (zero CPU while waiting).
-                                (.poll drain-signal 1 TimeUnit/SECONDS)
-                                (when-let [^WeakReference wref (.get ^java.util.concurrent.atomic.AtomicReference ctx-holder)]
-                                  (when-let [c (.get wref)]
-                                    (simple/drain-events! c executor)))
-                                (catch Throwable e
-                                  ;; Log but don't crash drain thread on
-                                  ;; Error (e.g. StackOverflowError).
-                                  (println "ERROR in background drain thread:" e))))))
-                        :cljs nil)
-        ;; Build the FINAL context record (the one we return to the caller).
-        ;; Both the WeakReference and the Cleaner registration MUST target
-        ;; this object — otherwise the pre-assoc record becomes GC-eligible
-        ;; the moment we return, the Cleaner fires, and the drain thread
-        ;; dies mid-test (even though the user still holds the returned ctx).
-        ctx (->ExecutionContext
-             fork-id
-             atom-backend
-             nil    ; No parent for root
-             executor
-             bindings
-             metadata
-             running
-             drain-thread
-             drain-signal
-             drain-active)]
-    #?(:clj
-       (do
-         (.set ^java.util.concurrent.atomic.AtomicReference ctx-holder (WeakReference. ctx))
-         ;; Register GC cleaner on the SAME object the user holds. The
-         ;; Runnable must NOT capture `ctx` — only the primitives needed to
-         ;; stop the drain thread, otherwise the Cleaner prevents GC.
-         (.register context-cleaner ctx
-                    (reify Runnable
-                      (run [_]
-                        (reset! running false)
-                        (.offer ^LinkedBlockingQueue drain-signal :stop))))))
-    ctx))
+        drain-active (atom 0)]
+    (->ExecutionContext
+     fork-id
+     atom-backend
+     nil    ; No parent for root
+     executor
+     bindings
+     metadata
+     running
+     drain-active)))
 
 (defn stop-context!
-  "Stop an execution context's background drain thread.
+  "Quiesce an execution context.
 
-  Only root contexts own the drain infrastructure; forks share the parent's,
-  so calling this on a fork is a safe no-op.
+  Only root contexts own the running/drain-active atoms; forks share
+  the parent's, so calling this on a fork is a safe no-op.
 
-  This should be called when a context is no longer needed to prevent
-  thread leaks. After stopping, the context should not be used for
-  reactive operations.
+  Since drains run on the executor (no standing drain thread), all we
+  need is:
+    1. Flip :running false → drain-events! guards on this and refuses
+       to mutate state for any drain that starts after the flip.
+    2. Cancel queued delayed-spin timers (their callbacks would post
+       events after stop, and any executor-scheduled work targeting
+       this context would just no-op anyway).
+    3. Wait for any drain *already past* the guard to finish — bounded
+       by a single event's processing time, with a 5s safety valve for
+       a deadlocked spin body.
 
-  Note: Does NOT close the executor — in-flight async callbacks may still
-  need it. Use close-context! for full cleanup including executor shutdown.
+  After this returns no further mutation can happen on this context.
+
+  Note: Does NOT close the executor — in-flight async callbacks (e.g.
+  futures returning to deliver! Deferreds) may still need it. Use
+  close-context! for full cleanup including executor shutdown.
 
   Args:
     context - ExecutionContext to stop
 
   Returns: nil"
   [context]
-  ;; Only root contexts own the drain thread; forks share parent's
   (when (nil? (:parent-ctx context))
     (when-let [running (:running context)]
       (reset! running false))
@@ -388,28 +312,14 @@
     ;; and alive-fn drops stale callbacks), so a still-armed setTimeout /
     ;; ScheduledFuture is a pure leak — cancel it now.
     (delayed/cancel-all-timers! context)
-    ;; Wake drain thread immediately so it notices running=false
-    #?(:clj
-       (when-let [ds (:drain-signal context)]
-         (.offer ^LinkedBlockingQueue ds :stop)))
 
-    ;; Deterministic shutdown contract: wait until no drain-events!
-    ;; call is past the function-entry guard for this context. Once
-    ;; this returns, the function-entry guard will reject any new
-    ;; drain (drain-events! sees :running=false and exits before
-    ;; touching state), so no further mutation can happen on this
-    ;; context.
-    ;;
-    ;; In-flight drains observe :running=false at the top of each
-    ;; loop iteration and exit with whatever's still in :pending
-    ;; left for the next legitimate drain (e.g. restore-snapshot)
-    ;; to pick up. This bounds our wait to a single event's
-    ;; processing time per active drain, not the whole queue.
-    ;;
-    ;; The 5s outer timeout is a safety valve for a deadlocked spin
-    ;; body. Reaching it indicates a real bug worth investigating;
-    ;; we'd rather return and let the caller see weirdness than
-    ;; hang forever.
+    ;; Deterministic shutdown: wait until no drain-events! call is past
+    ;; the function-entry guard for this context. In-flight drains
+    ;; observe :running=false at the top of each loop iteration and
+    ;; exit, leaving any remaining :pending events for whoever revives
+    ;; the context (e.g. restore-snapshot). The 5s outer timeout is a
+    ;; safety valve for a deadlocked spin body; reaching it indicates a
+    ;; real bug worth investigating.
     #?(:clj
        (when-let [drain-active (:drain-active context)]
          (let [deadline (+ (System/currentTimeMillis) 5000)]
@@ -417,20 +327,7 @@
              (when (and (pos? @drain-active)
                         (< (System/currentTimeMillis) deadline))
                (java.util.concurrent.locks.LockSupport/parkNanos 100000) ; 100us
-               (recur))))))
-
-    ;; Now also join the drain thread itself so its `while @running`
-    ;; loop has actually exited. drain-active=0 only proves no drain
-    ;; is past the guard *right now*; the drain thread might still be
-    ;; in its outer .poll waiting for the next signal. The signal we
-    ;; sent above wakes it, it observes :running=false, and exits.
-    ;; 200ms is fine here — the thread isn't holding any drain work
-    ;; once drain-active hit 0.
-    #?(:clj
-       (when-let [^Thread drain-thread (:drain-thread context)]
-         (try
-           (.join drain-thread 200)
-           (catch Exception _ nil)))))
+               (recur)))))))
   nil)
 
 (defn close-context!
@@ -586,10 +483,8 @@
      (:executor parent-ctx)  ; Share executor (for now)
      merged-bindings
      fork-metadata
-     (:running parent-ctx)       ; Share parent's drain thread control
-     (:drain-thread parent-ctx)  ; Share parent's drain thread
-     (:drain-signal parent-ctx)  ; Share parent's drain signal
-     (:drain-active parent-ctx)  ; Share parent's drain-active counter
+     (:running parent-ctx)        ; Share parent's lifecycle flag
+     (:drain-active parent-ctx)   ; Share parent's drain-active counter
      )))
 
 ;; =============================================================================
@@ -804,8 +699,6 @@
      (:bindings ctx)  ; Copy bindings
      (assoc (:metadata ctx) :snapshot? true)
      nil   ; No :running atom — drain-events! treats this as always-allowed
-     nil   ; No drain thread - snapshot is immutable
-     nil   ; No drain signal - snapshot is immutable
      nil)  ; No drain-active counter — no stop-context! to wait on
     ))
 
@@ -872,51 +765,17 @@
   [edn-string executor]
   (let [{:keys [backend fork-id bindings metadata]} (read-string-safe @incognito-read-handlers edn-string)
         backend-obj (backend/deserialize-backend backend @incognito-read-handlers)
-        ;; Only create drain thread for mutable backends (AtomBackend, OverlayBackend)
-        ;; ImmutableBackend doesn't support CAS operations needed by drain-events!
+        ;; AtomBackend / OverlayBackend support drain mutation; ImmutableBackend
+        ;; doesn't, so it gets a nil :running atom (drain-events! treats nil as
+        ;; always-allowed but the immutable CAS rejects the write anyway).
         backend-type (backend/backend-type backend-obj)
         mutable? (or (= backend-type :atom) (= backend-type :overlay))]
     (if mutable?
-      ;; Mutable backend - create drain thread with notification-based wakeup.
-      ;; Same pattern as create-execution-context: build the drain thread
-      ;; with a holder slot, populate it with the FINAL ctx record, so the
-      ;; drain thread observes the same object the user holds (avoids the
-      ;; pre-assoc record going GC-eligible and orphaning pending events).
-      (let [running (atom true)
-            drain-signal #?(:clj (LinkedBlockingQueue.) :cljs nil)
-            drain-active (atom 0)
-            ctx-holder #?(:clj (java.util.concurrent.atomic.AtomicReference.) :cljs nil)
-            drain-thread #?(:clj
-                            (start-drain-thread!
-                              (fn []
-                                (while @running
-                                  (try
-                                    (.poll drain-signal 1 TimeUnit/SECONDS)
-                                    (when-let [^WeakReference wref (.get ^java.util.concurrent.atomic.AtomicReference ctx-holder)]
-                                      (when-let [c (.get wref)]
-                                        (simple/drain-events! c executor)))
-                                    (catch Exception e
-                                      (println "ERROR in background drain thread:" e))))))
-                            :cljs nil)
-            ctx (->ExecutionContext fork-id backend-obj nil executor bindings metadata running drain-thread drain-signal drain-active)]
-        #?(:clj
-           (do
-             (.set ^java.util.concurrent.atomic.AtomicReference ctx-holder (WeakReference. ctx))
-             ;; Register a GC Cleaner so the daemon drain thread stops
-             ;; once the deserialized ctx is no longer reachable. Without
-             ;; this, every deserialize-context call leaked a daemon
-             ;; drain thread for the JVM's lifetime — the WeakReference
-             ;; let the ctx be GC'd but nothing ever set `running` false,
-             ;; so the loop spun on (.poll drain-signal 1s) forever.
-             ;; (Mirrors create-execution-context.)
-             (.register context-cleaner ctx
-                        (reify Runnable
-                          (run [_]
-                            (reset! running false)
-                            (.offer ^LinkedBlockingQueue drain-signal :stop))))))
-        ctx)
-      ;; Immutable backend - no drain thread
-      (->ExecutionContext fork-id backend-obj nil executor bindings metadata nil nil nil nil))))
+      (->ExecutionContext fork-id backend-obj nil executor bindings metadata
+                          (atom true)   ; running
+                          (atom 0))     ; drain-active
+      (->ExecutionContext fork-id backend-obj nil executor bindings metadata
+                          nil nil))))
 
 ;; =============================================================================
 ;; Rebuild Execution State

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -216,6 +216,36 @@
    (def ^:private ^Cleaner context-cleaner
      (Cleaner/create)))
 
+#?(:clj
+   (def ^:private ^java.lang.reflect.Method virtual-thread-start-method
+     "Reflectively resolved `Thread.startVirtualThread(Runnable)` so this
+      file compiles under any JDK while only invoking the method when
+      running on JDK 21+. nil → fall back to a platform daemon thread."
+     (try
+       (.getMethod Thread "startVirtualThread"
+                   (into-array Class [Runnable]))
+       (catch NoSuchMethodException _ nil))))
+
+#?(:clj
+   (defn- ^Thread start-drain-thread!
+     "Start a daemon-style thread that runs `runnable` to completion. On
+      JDK 21+ this is a virtual thread (carrier-shared, ~few KB heap,
+      free to leak when GC takes its time); otherwise it's a classic
+      daemon platform thread.
+
+      All drain threads in spindel are long-lived but cheap when parked
+      on `.poll(drain-signal, 1, SECONDS)`. The virtual-thread variant
+      makes per-context drain threads stop being a resource concern,
+      which removes the long-standing test-suite leak (~40 daemon
+      Thread-N entries per 5-minute run before this change). See
+      doc/drain-thread-leak.md."
+     [^Runnable runnable]
+     (if-let [m virtual-thread-start-method]
+       (.invoke m nil (into-array Object [runnable]))
+       (doto (Thread. runnable)
+         (.setDaemon true)
+         (.start)))))
+
 (defn create-execution-context
   "Create a new root execution context.
 
@@ -281,24 +311,26 @@
         ;; or accumulate thread overhead in tests.
         ;;
         ;; IMPORTANT: hold ctx via WeakReference (set after construction
-        ;; below), not as a strong capture. A daemon thread is a GC root, so
-        ;; a strong reference would keep ctx reachable forever, defeating the
-        ;; Cleaner registered below and leaking the context.
+        ;; below), not as a strong capture. A virtual thread's carrier is
+        ;; a GC root only while the VT is mounted; a parked VT is held by
+        ;; its scheduler queue but treats its closures normally. Either
+        ;; way, a strong capture of `ctx` here would keep the context
+        ;; reachable forever, defeating the Cleaner registered below.
         drain-thread #?(:clj
-                        (doto (Thread.
-                               (fn []
-                                 (while @running
-                                   (try
-                                      ;; Block until signaled or 1s timeout (zero CPU while waiting)
-                                     (.poll drain-signal 1 TimeUnit/SECONDS)
-                                     (when-let [^WeakReference wref (.get ^java.util.concurrent.atomic.AtomicReference ctx-holder)]
-                                       (when-let [c (.get wref)]
-                                         (simple/drain-events! c executor)))
-                                     (catch Throwable e
-                                        ;; Log but don't crash drain thread on Error (e.g. StackOverflowError)
-                                       (println "ERROR in background drain thread:" e))))))
-                          (.setDaemon true)
-                          (.start))
+                        (start-drain-thread!
+                          (fn []
+                            (while @running
+                              (try
+                                ;; Block until signaled or 1s timeout
+                                ;; (zero CPU while waiting).
+                                (.poll drain-signal 1 TimeUnit/SECONDS)
+                                (when-let [^WeakReference wref (.get ^java.util.concurrent.atomic.AtomicReference ctx-holder)]
+                                  (when-let [c (.get wref)]
+                                    (simple/drain-events! c executor)))
+                                (catch Throwable e
+                                  ;; Log but don't crash drain thread on
+                                  ;; Error (e.g. StackOverflowError).
+                                  (println "ERROR in background drain thread:" e))))))
                         :cljs nil)
         ;; Build the FINAL context record (the one we return to the caller).
         ;; Both the WeakReference and the Cleaner registration MUST target
@@ -855,18 +887,16 @@
             drain-active (atom 0)
             ctx-holder #?(:clj (java.util.concurrent.atomic.AtomicReference.) :cljs nil)
             drain-thread #?(:clj
-                            (doto (Thread.
-                                   (fn []
-                                     (while @running
-                                       (try
-                                         (.poll drain-signal 1 TimeUnit/SECONDS)
-                                         (when-let [^WeakReference wref (.get ^java.util.concurrent.atomic.AtomicReference ctx-holder)]
-                                           (when-let [c (.get wref)]
-                                             (simple/drain-events! c executor)))
-                                         (catch Exception e
-                                           (println "ERROR in background drain thread:" e))))))
-                              (.setDaemon true)
-                              (.start))
+                            (start-drain-thread!
+                              (fn []
+                                (while @running
+                                  (try
+                                    (.poll drain-signal 1 TimeUnit/SECONDS)
+                                    (when-let [^WeakReference wref (.get ^java.util.concurrent.atomic.AtomicReference ctx-holder)]
+                                      (when-let [c (.get wref)]
+                                        (simple/drain-events! c executor)))
+                                    (catch Exception e
+                                      (println "ERROR in background drain thread:" e))))))
                             :cljs nil)
             ctx (->ExecutionContext fork-id backend-obj nil executor bindings metadata running drain-thread drain-signal drain-active)]
         #?(:clj

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -292,6 +292,56 @@
   (rtp/swap-state! context [:nodes spin-id]
                    (fn [node] (when node (assoc node :created-spins #{})))))
 
+(defn ^:no-doc clear-prior-body-conts!
+  "Drop a spin's await and track continuations at the start of a (re-)run
+  of its body. The new body re-registers everything it needs at each
+  await/track site (deterministic cont-id would have overwritten the
+  await-conts in normal mode anyway), so the prior body's conts are
+  stale by definition once we re-enter the body from scratch.
+
+  This is symmetric to `clear-created-spins!` (the prior body's child
+  spin set is invalidated) and `clear-deps!`'s observer teardown — the
+  re-run gets a clean slate. Subscription back-refs in
+  `:subscriptions [event-key]` are cleaned up so a later
+  `:spin-completion` for that key doesn't try to look up a now-missing
+  cont.
+
+  Why not narrower? The existing `clear-all-await-continuations!`
+  (called at signal-change generation boundaries) preserves
+  `:await-reactive` so parallel/race continuations survive batches.
+  That's correct for *signal-change resume* — the same body slice
+  continues from a track cont, and the reactive await is still wired
+  to the body that registered it. But at *body re-run* from scratch
+  (cache miss / dirty re-execution) the body has been abandoned: every
+  cont references the *prior* body's CPS closures (which captured the
+  prior body's child Spin instances and lexical locals). Preserving
+  them lets a later `:spin-completion` fire a stale CPS chain, which
+  re-invokes the prior body's children via `(spin-ref noop noop)` /
+  `.-spin-fn`. The symptom is an extra body run logged against the
+  prior invocation's atom — visible whenever the same body is invoked
+  twice on one context (notably `set-execution-mode :rebuild`)."
+  [context spin-id]
+  (let [conts (rtp/get-state context [:await-conts spin-id])
+        track-subs (rtp/get-state context [:track-subscriptions spin-id])]
+    (when (or (seq conts) (seq track-subs))
+      (rtp/swap-state! context []
+                       (fn [rt-state]
+                         (-> rt-state
+                             (update :await-conts dissoc spin-id)
+                             (update :track-subscriptions dissoc spin-id)
+                             ;; Drop the subscription back-refs for this spin
+                             ;; from every event-key it was subscribed to.
+                             (update :subscriptions
+                                     (fn [subs]
+                                       (reduce-kv
+                                        (fn [acc ek m]
+                                          (let [m' (dissoc m spin-id)]
+                                            (if (seq m')
+                                              (assoc acc ek m')
+                                              acc)))
+                                        {}
+                                        subs)))))))))
+
 (defn- restore-slice-state!
   "Restore a continuation's per-slice `:slice-state` snapshot so the
   resumed body slice continues consistently with where it suspended.

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -1072,8 +1072,8 @@
 (defn ^:no-doc trigger-drain!
   "Trigger async draining of the event queue.
 
-  Schedules drain-events! to run on the executor AND wakes the background
-  drain thread via drain-signal (if present). Does not wait for completion.
+  Schedules drain-events! to run on the executor. Does not wait for
+  completion.
 
   This is called after external changes to ensure events are processed
   eventually. If draining is already in progress, the new events will
@@ -1091,10 +1091,6 @@
 
   Returns: true if scheduled, false if no executor available"
   [context executor]
-  ;; Wake background drain thread via notification queue (zero-polling)
-  #?(:clj
-     (when-let [ds (:drain-signal context)]
-       (.offer ^java.util.concurrent.LinkedBlockingQueue ds :drain)))
   (if executor
     (do
       (executor/execute! executor

--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -237,6 +237,13 @@
             ;; Execute spin body for side effects (nested spin creation, continuation registration).
             ;; Fresh per-spin chain-head slot = nested spin minting reproduces the same id
             ;; sequence as the original run (rebuild's whole purpose).
+            ;; Drop the prior body's ephemeral await conts: in rebuild mode
+            ;; await-spin resolves synchronously and does NOT overwrite the
+            ;; cont, so without this an :await-once cont from the original
+            ;; run survives, fires on the next :spin-completion, and
+            ;; re-invokes the prior body's CPS chain (which closes over
+            ;; prior-run Spin instances). See clear-ephemeral-await-conts!.
+          (simple/clear-prior-body-conts! runtime spin-id)
           (addressing/seed-body-chain-head! runtime spin-id)
           (binding [ec/*execution-context* runtime
                     ec/*spin-id* spin-id]
@@ -299,6 +306,14 @@
             ;; as the body runs, and register-spin! re-runs any whose captured
             ;; environment changed (B) — no blanket invalidation needed.
           (simple/clear-created-spins! runtime spin-id)
+
+            ;; Drop the prior body's ephemeral await conts at the same time.
+            ;; The new body run will register fresh conts at each (await …)
+            ;; via the slow path (deterministic cont-id would overwrite
+            ;; anyway in normal mode); clearing here keeps the rebuild path
+            ;; correct too (where the sync rebuild branch doesn't register).
+            ;; Persistent :await-reactive conts (parallel/race) are kept.
+          (simple/clear-prior-body-conts! runtime spin-id)
 
             ;; Seed this body slice's per-spin chain-head slot with
             ;; `body-start-chain-head spin-id` before invoking spin-fn —

--- a/test/org/replikativ/spindel/engine/rebuild_mode_test.clj
+++ b/test/org/replikativ/spindel/engine/rebuild_mode_test.clj
@@ -326,6 +326,46 @@
         (finally
           (ctx/stop-context! ctx))))))
 
+(deftest test-rebuild-does-not-re-invoke-prior-body-via-stale-cont
+  (testing "After (make-x) is called twice on the same ctx (rebuild mode for
+            the second call), each invocation's child-spin body fires
+            exactly ONCE — the rebuild must NOT re-invoke the prior call's
+            child Spin instance via a stale parent await-cont.
+
+            Regression: under the original engine, the second call would
+            mark the parent dirty (captures changed → new id-log atom),
+            but the parent's await-cont from the first call survived. When
+            the second call's child completed and enqueued
+            :spin-completion, the stale cont fired the first call's CPS
+            chain, which re-invoked the first child Spin via
+            `(spin-ref noop noop)` — re-running its body against the
+            FIRST call's `id-log` atom. Symptom: one extra entry in the
+            first call's atom that should not be there. Fixed by
+            `clear-prior-body-conts!` at body re-run sites in Spin.invoke."
+    (let [ctx (ctx/create-execution-context)
+          log-1 (atom [])
+          log-2 (atom [])
+          make-model (fn [id-log]
+                       (spin
+                        (swap! id-log conj ec/*spin-id*)
+                        (let [a (spin (swap! id-log conj ec/*spin-id*) 1)
+                              b (spin (swap! id-log conj ec/*spin-id*) 2)]
+                          (+ (await a) (await b)))))]
+      (try
+        (binding [ec/*execution-context* ctx]
+          (is (= 3 @(make-model log-1))))
+        (addressing/set-chain-head! ctx nil)
+        (let [rebuild-ctx (ctx/set-execution-mode ctx :rebuild)]
+          (binding [ec/*execution-context* rebuild-ctx]
+            (is (= 3 @(make-model log-2)))))
+        ;; Each log has exactly THREE entries — outer, a, b — once.
+        (is (= 3 (count @log-1)) (str "expected 3 entries in log-1, got " @log-1))
+        (is (= 3 (count @log-2)) (str "expected 3 entries in log-2, got " @log-2))
+        ;; And the id sequences match across the two invocations.
+        (is (= @log-1 @log-2))
+        (finally
+          (ctx/stop-context! ctx))))))
+
 (deftest test-normal-mode-still-uses-cache
   (testing "Normal mode still uses cache (rebuild mode doesn't break caching)"
     (let [ctx (ctx/create-execution-context)


### PR DESCRIPTION
## Summary

Three commits, all rooted in the same diagnostic thread (the test-suite was accumulating ~40 platform `Thread-N` entries stuck in `LinkedBlockingQueue.poll`, the same investigation surfaced two long-running suite flakes).

1. **`ccb8b6d` — virtual-threadify the per-context drain thread.**
   Replaces `Thread.` with `Thread/startVirtualThread` (reflective so JDK 17 builds still work). Each leaked drain VT is now ~few KB of heap instead of ~1 MB stack — invisible to platform thread accounting.

2. **`77e8344` — delete the standing drain thread entirely.**
   Audit of every direct `simple/enqueue-event!` caller (signal batch/swap, pubsub partitioned/pub/mult, inference SMC particles, await continuations, race/parallel completions, spin-execution scheduling) showed they all route through `rtp/enqueue!` — the Engine protocol method that atomically does `simple/enqueue-event!` + `simple/trigger-drain!`. The 1Hz heartbeat was a safety net guarding paths that never existed in practice. Removes drain-thread + drain-signal fields from `ExecutionContext`, the helper + reflection field added in the previous commit, the WeakReference + Cleaner dance in `create-execution-context` / `deserialize-context`, the `.offer drain-signal` preamble in `trigger-drain!`, and the `LinkedBlockingQueue` / `TimeUnit` / `Cleaner` / `WeakReference` imports. Keeps the `:running` guard and `:drain-active` counter for the `stop-context!` quiescence contract.

3. **`89a676d` — clear prior body conts on body re-run (resolves 2 suite flakes).**
   Root cause: when a spin body re-runs from scratch (Case 2 cache miss / dirty re-execution, Case 1a cache hit + rebuild mode), the prior body's continuations linger in `:await-conts` / `:track-subscriptions`. Those conts close over the prior body's CPS chain — which captures the prior body's child Spin instances and lexical locals. The next `:spin-completion` re-enters the prior CPS chain, which in rebuild mode invokes `(prior-spin-ref noop noop)` for side effects — re-running the prior child against the prior body's atoms.

   `clear-all-await-continuations!` ran only at signal-change generation boundaries and intentionally preserved `:await-reactive` so parallel/race continuations survive batches. Correct for signal-change resume but wrong for body re-run: at body re-run the body has been abandoned and every cont it registered is stale, reactive or not. Fix: `clear-prior-body-conts!` drops the spin's `:await-conts` + `:track-subscriptions` + back-refs in `:subscriptions [event-key]`. Called from `Spin.invoke` Case 1a and Case 2. Symmetric to `clear-created-spins!`.

   Resolves both prior known flakes:
   - `engine.rebuild-mode-test/test-rebuild-preserves-chain-head-consistency` — was deterministic on this branch's HEAD before the fix (5/5 fails), now passes in isolation AND in the full suite.
   - `pubsub.pub-test` — same root cause, intermittent flake; now stable.

   New regression test: `test-rebuild-does-not-re-invoke-prior-body-via-stale-cont` in `rebuild_mode_test.clj`.

## Test plan

- [x] Full spindel suite passes: 792 tests / 2711 assertions / 0 failures across 8 consecutive runs (`clojure -M:test`).
- [x] dvergr suite passes against this branch (its remaining intermittent failures in `dvergr.discourse.llm-test` / `dvergr.personas-test` reproduce against spindel without these commits too — pre-existing, unrelated).
- [x] No `:spin-execution` event path bypasses `trigger-drain!`.

## Notes for reviewer

- The first two commits change the `ExecutionContext` record arity (10 fields → 8). All five `->ExecutionContext` construction sites in `engine/context.cljc` are updated. No external consumer of the record fields exists in spindel src or test, and a downstream check against dvergr passes.
- Commit 3 (`clear-prior-body-conts!`) is the most behavioral change — it clears `:await-reactive` continuations on body re-run, which the prior code preserved across signal-change boundaries. The reasoning is in the commit message + a long docstring on the helper: at signal-change resume the body slice continues, so reactive conts must persist; at full body re-run the body has been abandoned, so they cannot. If you want this narrower (e.g., gated on a `:rebuild-mode?` check), happy to refactor.