### PR TITLE
Preserve fire-and-forget spawn'd spins from premature GC cleanup

### DIFF
--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -1414,6 +1414,37 @@
   [context spin-id]
   (boolean (seq (rtp/get-state context [:track-subscriptions spin-id]))))
 
+(defn- has-live-external-await?
+  "True if `spin-id` has any `:external-await` continuation pending —
+  the body is suspended on a Deferred, Mailbox, or plain-fn external
+  resource that has not yet fired. Such a cont holds the only path
+  back to the body's continuation; reaping it silently drops the
+  eventual delivery.
+
+  Necessary because the `Spin` Java object holds no strong reference
+  on its own continuations once the body suspends — only the user's
+  local binding does. A fire-and-forget `(spawn! (spin … (await ext)
+  …))` keeps the Spin reachable only in the caller's lexical scope;
+  once the caller stops referencing it, the Cleaner fires
+  `try-gc-cleanup-spin!`. Without this guard the cont is reaped and
+  the eventual `ext` delivery has nowhere to resume — the body's
+  continuation (which might `deliver` to an external promise) never
+  fires. The dvergr `discourse.llm-test` flake (~20 % when many
+  spawn-and-await pairs run in one JVM) reproduces this exactly.
+
+  Spin-await conts (`[:spin/complete _]`) are NOT counted here:
+  those go through the `:spin-completion` dispatch, and the awaitee
+  Spin is held alive by the cont's `:awaited-spin` field — so the
+  awaiter/awaitee pair is reachable together, and cascade cleanup
+  reaps both safely once the user drops both. External resources
+  (Deferred / Mailbox / plain-fn) are NOT held by the cont (it only
+  holds `wrapped-resolve`), so reaping the cont severs the last path
+  back to the awaiter's body."
+  [context spin-id]
+  (boolean
+   (some (fn [[_k v]] (= :external-await (:kind v)))
+         (rtp/get-state context [:await-conts spin-id]))))
+
 (defn try-gc-cleanup-spin!
   "Called from GC callback. Attempts full cleanup if safe, otherwise marks
   the spin as orphaned for deferred cleanup.
@@ -1423,22 +1454,24 @@
   2. It has no observers (no other spins depend on it)
   3. It has no live signal continuations (no `(track sig)` waiters
      bound to a still-live signal)
+  4. It has no live `:external-await` continuations (no body slice
+     suspended on a Deferred / Mailbox / plain-fn external resource
+     that has not yet fired)
 
   If any condition fails, it's marked `:orphaned? true` and a later
   cleanup pass — triggered when the last observer or signal-cont is
   torn down — will full-clean it.
 
-  Why (3) is essential: a spin with `(track sig)` in its body keeps
-  a track continuation registered in `:track-subscriptions spin-id`
-  that the engine resumes on every signal change. The cont's `:resolve-fn`
-  closes over the CPS body slice (which references `spin-id`,
-  atoms, etc.) but NOT over the `Spin` Java object itself. So the
-  Spin object can become GC-eligible (e.g. the user's `let` binding
-  goes out of scope after last use) while the reactive machinery is
-  still very much alive. Without this check, the Cleaner thread
-  would fire, `full-cleanup-spin!` would clear the cont and the
-  signal's observer registration, and subsequent signal changes
-  would silently no-op — a deeply confusing reactive drop.
+  Why (3) and (4) are essential: in both cases the cont's
+  `:resolve-fn` closes over the CPS body slice (which references
+  `spin-id`, atoms, etc.) but NOT over the `Spin` Java object
+  itself. So the Spin can become GC-eligible (the user's `let`
+  binding goes out of scope after last use) while the reactive or
+  suspended machinery is still very much alive. Without these
+  checks, the Cleaner thread fires, `full-cleanup-spin!` clears the
+  cont, and subsequent firings — signal change in (3)'s case, or
+  external-resource delivery in (4)'s case — silently no-op. Both
+  modes manifest as the awaiter never running again, with no error.
 
   Args:
     context - context record (implements PState protocol)
@@ -1449,21 +1482,24 @@
   (let [node (rtp/get-state context [:nodes spin-id])]
     (when node ;; may already be cleaned
       (let [has-observers? (seq (nodes/get-observers node))
-            live-signal-cont? (has-live-signal-cont? context spin-id)]
+            live-signal-cont? (has-live-signal-cont? context spin-id)
+            live-external-await? (has-live-external-await? context spin-id)]
         (cond
-          (or has-observers? live-signal-cont?)
-          ;; Has observers and/or live signal continuations → mark
-          ;; orphaned and defer cleanup. The Cleaner has run, so the
-          ;; Spin object itself is unreachable, but the runtime still
-          ;; needs this spin's state to fire reactive updates.
+          (or has-observers? live-signal-cont? live-external-await?)
+          ;; Has observers, live signal continuations, or live external
+          ;; awaits → mark orphaned and defer cleanup. The Cleaner has
+          ;; run, so the Spin object itself is unreachable, but the
+          ;; runtime still needs this spin's state to fire reactive
+          ;; updates or resume from a pending external delivery.
           (rtp/swap-state! context [:nodes spin-id]
                            #(when % (assoc % :orphaned? true)))
 
           :else
-          ;; No observers, no live signal continuations → safe to
-          ;; fully clean up + cascade to dependencies. Stale spin-
-          ;; completion conts (awaits of since-cleaned parents) are
-          ;; cleaned away by full-cleanup-spin!.
+          ;; No observers, no live signal continuations, no pending
+          ;; external awaits → safe to fully clean up + cascade to
+          ;; dependencies. Stale spin-completion conts (awaits of
+          ;; since-cleaned parents) are cleaned away by
+          ;; `full-cleanup-spin!`.
           (let [deps (nodes/get-deps node)
                 dep-spin-ids (:spins deps #{})]
             (full-cleanup-spin! context spin-id)
@@ -1473,7 +1509,8 @@
                 (when (and dep-node
                            (:orphaned? dep-node)
                            (empty? (nodes/get-observers dep-node))
-                           (not (has-live-signal-cont? context dep-id)))
+                           (not (has-live-signal-cont? context dep-id))
+                           (not (has-live-external-await? context dep-id)))
                   (full-cleanup-spin! context dep-id))))))))))
 
 (defn track-signal-dep!

--- a/src/org/replikativ/spindel/spin/sync.cljc
+++ b/src/org/replikativ/spindel/spin/sync.cljc
@@ -378,11 +378,38 @@
      (spawn! (spin (do-work)))
      (spawn! (spin (do-work)) {:on-error my-handler})
 
+   GC contract: `spawn!` registers the Spin instance in the context's
+   `[:engine/spawned spin-id]` slot for the duration of its body. This
+   prevents the Spin's Cleaner from firing mid-body when the caller
+   has no further reference to it — exactly the
+   `(spawn! (spin … (deliver p (await x)) …))` pattern. Without this
+   the Spin instance becomes GC-eligible the moment `spawn!` returns
+   (no caller-held local), and a `try-gc-cleanup-spin!` between
+   suspend and resume reaps the body's await cont — the eventual
+   resumption then has no continuation to fire and the body's side
+   effects (e.g. delivering to `p`) silently never happen. The slot is
+   cleared from the resolve/reject callbacks, after which a later GC
+   of the Spin object can safely clean up the now-quiescent node.
+
    Returns nil."
   ([s] (spawn! s {}))
   ([s {:keys [on-error]
        :or {on-error (fn [e] (binding [#?(:clj *out* :cljs *print-fn*)
                                        #?(:clj *err* :cljs *print-err-fn*)]
                                (println "Error in spawned spin:" e)))}}]
-   (s (fn [_]) on-error)
+   (let [ctx #?(:clj (try (ec/current-execution-context)
+                          (catch Throwable _ nil))
+                :cljs (try (ec/current-execution-context)
+                           (catch :default _ nil)))
+         sid (when ctx (spin-core/spin-id s))
+         release! (fn []
+                    (when ctx
+                      (binding [ec/*execution-context* ctx]
+                        (ec/swap-state! [:engine/spawned]
+                                        (fn [m] (dissoc m sid))))))]
+     (when ctx
+       (binding [ec/*execution-context* ctx]
+         (ec/swap-state! [:engine/spawned] (fn [m] (assoc m sid s)))))
+     (s (fn [_] (release!))
+        (fn [e] (release!) (on-error e))))
    nil))

--- a/test/org/replikativ/spindel/spin/gc_test.cljc
+++ b/test/org/replikativ/spindel/spin/gc_test.cljc
@@ -18,6 +18,7 @@
             [org.replikativ.spindel.signal :as sig]
             [org.replikativ.spindel.effects.await :refer [await]]
             [org.replikativ.spindel.effects.track :refer [track]]
+            [org.replikativ.spindel.spin.sync :as sync]
             [org.replikativ.spindel.test-helpers :refer [async with-ctx run-spin!]])
   #?(:cljs (:require-macros [org.replikativ.spindel.spin.cps :refer [spin]]
                             [org.replikativ.spindel.signal :refer [signal]])))
@@ -175,6 +176,113 @@
                             (is (nil? (rtp/get-state ctx [:nodes sid])) "Still cleaned")
                             (done))
                           (fn [e] (is false (str "Spin failed: " e)) (done))))))))
+
+(deftest test-try-gc-cleanup-preserves-live-external-await
+  (testing "try-gc-cleanup-spin! defers cleanup for a spin suspended on a
+            Deferred/Mailbox external resource.
+
+            Regression: without this, a fire-and-forget spawn'd spin whose
+            body is mid-await on a Deferred can have its Spin Java object
+            GC'd while the deferred has not yet been delivered. The Cleaner
+            then fires try-gc-cleanup-spin!, which used to only check for
+            observers and signal track conts — both absent for such a spin
+            — and fully reaped the node + its :external-await cont. The
+            Deferred's eventual delivery had nowhere to resume; the body's
+            continuation (which might `deliver` to an external promise)
+            never fired. Symptom in dvergr: 20% flake rate on
+            discourse/personas tests where every operation completes
+            (probes confirm) but await-spin still returns ::timeout
+            because the outer promise was never delivered."
+    (async done
+           (with-ctx [ctx]
+             (let [d (sync/create-deferred ctx)
+                   s (spin (await d))
+                   sid (spin-core/spin-id s)]
+          ;; Start the body — it suspends on the deferred await, registering
+          ;; an :external-await cont on the spin.
+               (s (fn [_]) (fn [_]))
+               (let [conts (rtp/get-state ctx [:await-conts sid])]
+                 (is (some? conts) "Body must have registered an await cont before we test GC")
+                 (is (some (fn [[_ v]] (= :external-await (:kind v))) conts)
+                     "The cont must be :external-await (Deferred path)"))
+          ;; Simulate the Spin's Cleaner firing — the user has dropped their
+          ;; reference. The fix: try-gc-cleanup-spin! should see the live
+          ;; external-await cont and DEFER cleanup (mark orphaned), not fully
+          ;; reap the node + cont.
+               (simple/try-gc-cleanup-spin! ctx sid)
+               (let [node (rtp/get-state ctx [:nodes sid])]
+                 (is (some? node)
+                     "Node must survive try-gc-cleanup: it has a live external-await pending")
+                 (is (:orphaned? node)
+                     "Node must be marked :orphaned? — fully reachable for resume but reaped on next safe pass"))
+               (is (seq (rtp/get-state ctx [:await-conts sid]))
+                   "The :external-await cont must survive — otherwise the Deferred's eventual delivery would have nowhere to resume")
+               (done))))))
+
+#?(:clj
+   ;; JVM-only: relies on `await-drain-complete!` to deterministically
+   ;; wait for the spin's resolve callback (which fires `release!`) to
+   ;; run before asserting. CLJS has no equivalent blocking primitive
+   ;; — the drain runs on the event loop after `(d :delivered)` returns,
+   ;; so an inline assertion would race with the resolve. The contract
+   ;; itself (register on spawn, release on resolve) is the same on
+   ;; both platforms and is exercised end-to-end by the JVM-only
+   ;; `test-spawn-survives-gc-mid-await-jvm` below.
+   (deftest test-spawn-registers-and-releases-keep-alive
+     (testing "spawn! holds the Spin instance in [:engine/spawned] for the
+              lifetime of its body, then releases it on body resolution"
+       (let [ctx (ctx/create-execution-context)]
+         (try
+           (binding [ec/*execution-context* ctx]
+             (let [d (sync/create-deferred ctx)
+                   s (spin (await d))
+                   sid (spin-core/spin-id s)]
+               (sync/spawn! s)
+               ;; Body suspends on the deferred await. The spin's instance MUST
+               ;; be held in the engine's spawned-registry — otherwise GC could
+               ;; reap it mid-await.
+               (is (identical? s (get (rtp/get-state ctx [:engine/spawned]) sid))
+                   "spawn! must register the Spin in [:engine/spawned spin-id] while body is in flight")
+               ;; Deliver the deferred → body resumes → resolves → release should fire.
+               (d :delivered)
+               (simple/await-drain-complete! ctx)
+               (is (nil? (get (rtp/get-state ctx [:engine/spawned]) sid))
+                   "spawn! must release the Spin from [:engine/spawned spin-id] after body resolves")))
+           (finally
+             (ctx/stop-context! ctx)))))))
+
+#?(:clj
+   (deftest test-spawn-survives-gc-mid-await-jvm
+     (testing "A fire-and-forget (spawn! (spin … (await ext) (deliver p …))) spin
+              must survive GC while suspended on an external await. The Spin
+              instance has no caller-held reference after spawn!; without
+              spawn's keep-alive the Cleaner fires mid-body, reaps the await
+              cont, and the eventual external delivery silently never resumes
+              the body — the promise stays undelivered. This was the
+              root-cause of the dvergr discourse.llm-test flake."
+       (let [ctx (ctx/create-execution-context)]
+         (try
+           (binding [ec/*execution-context* ctx]
+             (let [d (sync/create-deferred ctx)
+                   p (promise)]
+               ;; Fire-and-forget: the Spin instance is created inline and
+               ;; passed straight to spawn!. No caller-held ref → after this
+               ;; call returns, GC can reach the Spin unless spawn! holds it.
+               (sync/spawn! (spin (deliver p (await d))))
+               ;; Aggressively GC. With the fix, the Spin is held by
+               ;; [:engine/spawned] until its body resolves, so GC can't
+               ;; reap it mid-await. Without the fix, the Cleaner would
+               ;; fire here, full-cleanup would clear the await cont, and
+               ;; the eventual `(d :delivered)` below would have nowhere
+               ;; to resume.
+               (dotimes [_ 3] (System/gc) (Thread/sleep 50))
+               ;; Now deliver the deferred — body should resume and put
+               ;; `:delivered` on p.
+               (d :delivered)
+               (is (= :delivered (deref p 2000 ::timeout))
+                   "Body must have resumed from the await and delivered to p")))
+           (finally
+             (ctx/stop-context! ctx)))))))
 
 (deftest test-no-residual-after-bulk-cleanup
   (testing "No residual spin state after creating many spins and cleaning them"


### PR DESCRIPTION
## Summary

A spawn'd spin whose body is mid-await on an external resource (Deferred / Mailbox / plain-fn) could have its `Spin` Java object GC'd before the resource fires. The Cleaner fires `try-gc-cleanup-spin!`, which previously only checked for observers and signal track conts — neither of which a fire-and-forget spin has. The await cont got reaped; the eventual external delivery had nowhere to resume; the body's continuation (e.g. `(deliver p …)`) silently never fired.

Reproduced in dvergr as a ~20 % flake rate on `discourse.llm-test` and related tests. Probes confirmed every operation completed (`BRIDGE → FUTURE → AWAIT → EMIT-REPLY → ASK :reply-received`), but the outer `await-spin` still returned `::timeout` because the spawn'd outer spin's await cont on the ask spin had been reaped between suspend and ask-completion.

## Two complementary fixes

### 1. `spawn!` holds the Spin alive in `[:engine/spawned spin-id]`

For the lifetime of its body. Released by the resolve/reject callbacks. This eliminates the GC race for the fire-and-forget pattern by ensuring the Spin's Cleaner doesn't fire mid-body. After resolve, `release!` drops the strong ref so a later GC + Cleaner can fully clean the now-quiescent node via the normal path.

### 2. `try-gc-cleanup-spin!` also checks live `:external-await` continuations

As defense in depth. A spin created/invoked outside `spawn!` (e.g. through a direct IFn call from an event handler) that gets dropped while mid-await on a Deferred/Mailbox is now preserved instead of fully reaped. Marked `:orphaned?`; cascade cleanup picks it up on a later pass once the await actually fires.

Spin-await conts (`[:spin/complete _]`) are NOT counted as live — the awaitee `Spin` is held alive by the cont's `:awaited-spin`, so the awaiter/awaitee pair is reachable together and cascade cleanup works correctly when the user drops both. External resources (Deferred etc.) are NOT held by the cont — it only holds `wrapped-resolve` — so reaping the cont severs the only path back to the awaiter's body. The asymmetry in the original `try-gc-cleanup-spin!` design assumed all await conts behave the same as `:spin/complete`; this commit recognizes the external case as a distinct invariant.

## Regression tests in `gc_test.cljc`

- `test-try-gc-cleanup-preserves-live-external-await` — engine-level check that `try-gc-cleanup-spin!` defers cleanup of a spin with an `:external-await` cont (marks `:orphaned?`; cont survives).
- `test-spawn-registers-and-releases-keep-alive` — deterministic contract on `spawn!`'s new `[:engine/spawned]` register-on-spawn / release-on-resolve protocol.
- `test-spawn-survives-gc-mid-await-jvm` — end-to-end JVM test: `(spawn! (spin (deliver p (await d))))` followed by aggressive `System/gc` + deliver. The body must resume from the await and deliver the value, even though the Spin instance has no caller-held reference between spawn! and the resume.

## Test plan

- [x] spindel: 795 tests / 2725 assertions / 0 failures (was 793 / 2716 — 2 new tests, +9 assertions).
- [x] dvergr `discourse.llm-test`: 10 / 10 passes (was ~20 % flake rate).
- [x] dvergr full suite: 5 / 5 passes across consecutive runs (every prior intermittent failure in discourse / personas tests was the same GC-mid-await pattern).