### PR TITLE
fix(pubsub): make-promise watchers must wake on the awaiter's ctx

### DIFF
--- a/src/org/replikativ/spindel/pubsub/mult.cljc
+++ b/src/org/replikativ/spindel/pubsub/mult.cljc
@@ -27,7 +27,20 @@
 (defn- make-promise
   "Create a simple promise that can be delivered once and read multiple times.
    Uses a standard Clojure atom - no runtime dependency.
-   Uses compare-and-set! instead of swap! to avoid side effects inside retry-able swap fns."
+   Uses compare-and-set! instead of swap! to avoid side effects inside retry-able swap fns.
+
+   ## Cross-ctx delivery fix
+   The watcher is the awaiter's `resolve` CPS continuation. When the
+   producer's thread invokes it via `deliver!`, the Clojure dynamic var
+   `*execution-context*` is whatever the producer has bound — often a
+   different execution context from the one that registered the
+   watcher. Without restoring the awaiter's ctx, the completion event
+   gets enqueued on the producer's ctx, where no await-cont is
+   registered for the awaiter's parent, and the parent deadlocks.
+
+   We capture `*execution-context*` at `await-spin` construction
+   (before the watcher is added) and re-establish it around the
+   watcher invocation so the spin completes against its own ctx."
   []
   (let [state (atom {:delivered? false :value nil :watchers []})]
     {:state state
@@ -44,17 +57,26 @@
                          ;; CAS failed (concurrent modification) - retry
                          (recur))))))
      :await-spin (fn []
-                   (spin-core/make-spin
-                    (fn [resolve _reject]
-                      (loop []
-                        (let [s @state]
-                          (if (:delivered? s)
-                            (resolve (:value s))
-                            ;; Try to add watcher via CAS
-                            (when-not (compare-and-set! state s (update s :watchers conj resolve))
-                              ;; CAS failed - retry (will re-check delivered? on next iteration)
-                              (recur)))))
-                      spin-core/incomplete)))}))
+                   (let [captured-ctx (try (ec/current-execution-context)
+                                           (catch #?(:clj Throwable :cljs :default) _ nil))]
+                     (spin-core/make-spin
+                      (fn [resolve _reject]
+                        ;; Wrap resolve so the completion fires against the
+                        ;; ctx that registered the await, not the producer's.
+                        (let [wrapped (if captured-ctx
+                                        (fn [v]
+                                          (binding [ec/*execution-context* captured-ctx]
+                                            (resolve v)))
+                                        resolve)]
+                          (loop []
+                            (let [s @state]
+                              (if (:delivered? s)
+                                (wrapped (:value s))
+                                ;; Try to add watcher via CAS
+                                (when-not (compare-and-set! state s (update s :watchers conj wrapped))
+                                  ;; CAS failed - retry (will re-check delivered? on next iteration)
+                                  (recur))))))
+                        spin-core/incomplete))))}))
 
 (defn- deliver-promise! [p value]
   ((:deliver! p) value))

--- a/src/org/replikativ/spindel/pubsub/partitioned.cljc
+++ b/src/org/replikativ/spindel/pubsub/partitioned.cljc
@@ -30,7 +30,10 @@
 ;; =============================================================================
 
 (defn- make-promise
-  "Simple promise for coordination (same pattern as mult.cljc)."
+  "Simple promise for coordination (same pattern as mult.cljc — see that
+   ns for the cross-ctx-delivery rationale behind capturing ctx at
+   await-spin construction and re-binding it around the watcher
+   invocation)."
   []
   (let [state (atom {:delivered? false :value nil :watchers []})]
     {:state state
@@ -45,15 +48,22 @@
                              value)
                          (recur))))))
      :await-spin (fn []
-                   (spin-core/make-spin
-                    (fn [resolve _reject]
-                      (loop []
-                        (let [s @state]
-                          (if (:delivered? s)
-                            (resolve (:value s))
-                            (when-not (compare-and-set! state s (update s :watchers conj resolve))
-                              (recur)))))
-                      spin-core/incomplete)))}))
+                   (let [captured-ctx (try (ec/current-execution-context)
+                                           (catch #?(:clj Throwable :cljs :default) _ nil))]
+                     (spin-core/make-spin
+                      (fn [resolve _reject]
+                        (let [wrapped (if captured-ctx
+                                        (fn [v]
+                                          (binding [ec/*execution-context* captured-ctx]
+                                            (resolve v)))
+                                        resolve)]
+                          (loop []
+                            (let [s @state]
+                              (if (:delivered? s)
+                                (wrapped (:value s))
+                                (when-not (compare-and-set! state s (update s :watchers conj wrapped))
+                                  (recur))))))
+                        spin-core/incomplete))))}))
 
 (defn- deliver-promise! [p value]
   ((:deliver! p) value))

--- a/src/org/replikativ/spindel/pubsub/pub.cljc
+++ b/src/org/replikativ/spindel/pubsub/pub.cljc
@@ -26,7 +26,13 @@
 ;; Internal Topic Mult Management
 ;; =============================================================================
 
-;; Simple promise (same as in mult.cljc)
+;; Simple promise (same as in mult.cljc).
+;; The await-spin captures *execution-context* at construction time and
+;; re-binds it around the watcher's resolve invocation, so a producer
+;; that delivers from a different ctx (e.g. a fork-ctx pump signaling
+;; awaiters registered on a parent ctx) still enqueues the awaiter's
+;; :spin-completion event on the awaiter's own ctx. See the same
+;; comment in mult.cljc/make-promise for details.
 (defn- make-promise
   "Create a simple promise that can be delivered once and read multiple times.
    Uses compare-and-set! instead of swap! to avoid side effects inside retry-able swap fns."
@@ -46,17 +52,24 @@
                          ;; CAS failed (concurrent modification) - retry
                          (recur))))))
      :await-spin (fn []
-                   (spin-core/make-spin
-                    (fn [resolve _reject]
-                      (loop []
-                        (let [s @state]
-                          (if (:delivered? s)
-                            (resolve (:value s))
-                            ;; Try to add watcher via CAS
-                            (when-not (compare-and-set! state s (update s :watchers conj resolve))
-                              ;; CAS failed - retry (will re-check delivered? on next iteration)
-                              (recur)))))
-                      spin-core/incomplete)))}))
+                   (let [captured-ctx (try (ec/current-execution-context)
+                                           (catch #?(:clj Throwable :cljs :default) _ nil))]
+                     (spin-core/make-spin
+                      (fn [resolve _reject]
+                        (let [wrapped (if captured-ctx
+                                        (fn [v]
+                                          (binding [ec/*execution-context* captured-ctx]
+                                            (resolve v)))
+                                        resolve)]
+                          (loop []
+                            (let [s @state]
+                              (if (:delivered? s)
+                                (wrapped (:value s))
+                                ;; Try to add watcher via CAS
+                                (when-not (compare-and-set! state s (update s :watchers conj wrapped))
+                                  ;; CAS failed - retry (will re-check delivered? on next iteration)
+                                  (recur))))))
+                        spin-core/incomplete))))}))
 
 (defn- deliver-promise! [p value]
   ((:deliver! p) value))

--- a/src/org/replikativ/spindel/pubsub/pub.cljc
+++ b/src/org/replikativ/spindel/pubsub/pub.cljc
@@ -71,8 +71,12 @@
   [mults-atom topic]
   (or (:mult (get @mults-atom topic))
       (let [;; Create a promise-based async sequence for this topic
-            ;; Items will be pushed when they arrive
-            topic-items-atom (atom [])
+            ;; Items will be pushed when they arrive.
+            ;; PersistentQueue is required for FIFO: vector + (rest) +
+            ;; (conj item) corrupts order because rest returns a seq,
+            ;; and conj on a seq prepends instead of appending.
+            topic-items-atom (atom #?(:clj  clojure.lang.PersistentQueue/EMPTY
+                                      :cljs cljs.core/PersistentQueue.EMPTY))
             topic-waiter-atom (atom (make-promise))  ; Single waiter promise
             topic-closed-atom (atom false)
 
@@ -83,8 +87,8 @@
                             (cond
                                ;; Check for items
                               (seq @topic-items-atom)
-                              (let [item (first @topic-items-atom)]
-                                (swap! topic-items-atom rest)
+                              (let [item (peek @topic-items-atom)]
+                                (swap! topic-items-atom pop)
                                 [item this])
 
                                ;; Closed with no items

--- a/test/org/replikativ/spindel/pubsub/fork_ctx_reentrancy_test.cljc
+++ b/test/org/replikativ/spindel/pubsub/fork_ctx_reentrancy_test.cljc
@@ -158,6 +158,69 @@
         (ctx/stop-context! parent-ctx)
         (is (= {:reply "reply"} result))))))
 
+(deftest fork-ctx-mult-only-inline-roundtrip
+  (testing "Strip the pub layer. Just: source mailbox → mult → two taps.
+            One tap consumed by worker, second tap consumed by outer spin.
+            If THIS fails, the bug is in mult/fork-ctx interaction. If
+            it passes, the bug is specifically in the pub layer."
+    (reset! *trace* [])
+    (let [parent-ctx (ctx/create-execution-context)
+          done       (promise)]
+      (binding [ec/*execution-context* parent-ctx]
+        (sp/spawn!
+          (spin
+            (log-trace :outer-start)
+            (let [fork-ctx (ctx/fork-context parent-ctx)
+                  _ (log-trace :forked)
+                  source    (binding [ec/*execution-context* fork-ctx]
+                              (sync/create-mailbox fork-ctx))
+                  m         (binding [ec/*execution-context* fork-ctx]
+                              (mult/mult source))
+                  worker-tap (binding [ec/*execution-context* fork-ctx]
+                               (mult/tap m (buf/fixed-buffer 16)))
+                  result-tap (binding [ec/*execution-context* fork-ctx]
+                               (mult/tap m (buf/fixed-buffer 16)))
+                  _ (log-trace :taps-made)
+                  _worker (binding [ec/*execution-context* fork-ctx]
+                            (sp/spawn!
+                              (spin
+                                (log-trace :worker-start)
+                                (when-let [[msg _] (await (anext worker-tap))]
+                                  (log-trace :worker-got msg)
+                                  ;; Post "reply" back to source so result-tap sees it
+                                  (binding [ec/*execution-context* fork-ctx]
+                                    (sync/post! source {:k :reply :for msg}))
+                                  (log-trace :worker-posted)))))
+                  _ (log-trace :worker-spawned)
+                  _ (binding [ec/*execution-context* fork-ctx]
+                      (sync/post! source {:k :go}))
+                  _ (log-trace :posted-go)
+                  [first-msg _] (await (anext result-tap))
+                  _ (log-trace :outer-got-first first-msg)
+                  ;; If first-msg is :go, await again for :reply
+                  [r _] (if (= :reply (:k first-msg))
+                          [first-msg nil]
+                          (await (anext result-tap)))]
+              (log-trace :outer-got-final r)
+              (deliver done r)))))
+      (let [result (deref done 3000 :TIMEOUT)
+            ;; Reach into the TapSeq's internal state to see what's in result-tap's buffer
+            inspect-tap (fn [tap label]
+                          (try
+                            (let [tsa (.-tap-state-atom tap)
+                                  state @tsa
+                                  buffer (:buffer state)]
+                              (println label "buffer-count:"
+                                       (when buffer (count buffer))
+                                       "closed?:" (when-let [c (:closed? state)] @c)))
+                            (catch Throwable e
+                              (println label "inspect error:" (.getMessage e)))))]
+        (when-let [last-trace @*trace*]
+          (println "MULT-ONLY TRACE:" (pr-str last-trace)))
+        (ctx/stop-context! parent-ctx)
+        (is (= :reply (:k result))
+            "Reply should flow through second tap.")))))
+
 (deftest fork-ctx-pubsub-inline-using-with-context
   (testing "Same as failing test but NO outer spawn — uses with-context
             to bind parent-ctx around the work without an outer Spin.

--- a/test/org/replikativ/spindel/pubsub/fork_ctx_reentrancy_test.cljc
+++ b/test/org/replikativ/spindel/pubsub/fork_ctx_reentrancy_test.cljc
@@ -19,18 +19,19 @@
 
    This namespace strips dvergr away to test whether the bug lives in
    spindel's lazy pump-start + fork-context interaction."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require #?(:clj [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer [deftest is testing] :include-macros true])
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.context :as ctx]
             [org.replikativ.spindel.pubsub.mult :as mult]
             [org.replikativ.spindel.pubsub.pub :as pub]
             [org.replikativ.spindel.pubsub.buffer :as buf]
             [org.replikativ.spindel.spin.sync :as sync]
-            [org.replikativ.spindel.spin.cps :refer [spin]]
-            [org.replikativ.spindel.spin.combinators :as comb]
+            #?(:clj [org.replikativ.spindel.spin.cps :refer [spin]])
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.effects.await :refer [await]]
-            [is.simm.partial-cps.sequence :refer [anext]]))
+            [is.simm.partial-cps.sequence :refer [anext]])
+  #?(:cljs (:require-macros [org.replikativ.spindel.spin.cps :refer [spin]])))
 
 ;; A "bus" = mailbox + mult + a single :to-keyed pub over a tap of the mult.
 ;; This mimics dvergr.bus minus the type-pub and log-drain — the smallest
@@ -66,183 +67,188 @@
   (let [sub (bus-subscribe! bus worker-id (buf/fixed-buffer 16))]
     (binding [ec/*execution-context* (:ctx bus)]
       (sp/spawn!
-        (spin
-          (log-trace :worker-spin-start)
-          (loop [s sub]
-            (log-trace :worker-awaiting)
-            (when-let [[msg r] (await (anext s))]
-              (log-trace :worker-got msg)
-              (bus-post! bus {:to (:from msg) :from worker-id :content "reply"})
-              (log-trace :worker-posted-reply)
-              (recur r))))))
+       (spin
+        (log-trace :worker-spin-start)
+        (loop [s sub]
+          (log-trace :worker-awaiting)
+          (when-let [[msg r] (await (anext s))]
+            (log-trace :worker-got msg)
+            (bus-post! bus {:to (:from msg) :from worker-id :content "reply"})
+            (log-trace :worker-posted-reply)
+            (recur r))))))
     sub))
 
-(deftest fork-ctx-pubsub-inline-roundtrip
-  (testing "Round-trip over a pub built on a fork-context's source, all
+#?(:clj
+   (deftest fork-ctx-pubsub-inline-roundtrip
+     (testing "Round-trip over a pub built on a fork-context's source, all
             happening inside ONE outer spin. Mirrors dvergr.proposals/propose!'s
             (fork-room + join + ask) inline pattern. Without the bug, the
             outer spin's await returns the worker's reply."
-    (reset! *trace* [])
-    (let [parent-ctx (ctx/create-execution-context)
-          worker-id  :worker
-          done       (promise)]
-      (binding [ec/*execution-context* parent-ctx]
-        (sp/spawn!
-          (spin
-            (log-trace :outer-spin-start)
-            (let [;; All of these happen inside the outer spin frame ─────
-                  fork-ctx (ctx/fork-context parent-ctx)
-                  _ (log-trace :forked)
-                  bus      (make-bus fork-ctx)
-                  _ (log-trace :bus-made)
-                  _worker  (spawn-echo-worker! bus worker-id)
-                  _ (log-trace :worker-spawned)
-                  asker-id (keyword (str "ask-" (rand-int 1000000)))
-                  asker-sub (bus-subscribe! bus asker-id (buf/fixed-buffer 1))
-                  _ (log-trace :asker-subscribed)
-                  _        (bus-post! bus {:to worker-id :from asker-id
-                                           :content "go"})
-                  _ (log-trace :posted-go)
-                  [reply _] (await (anext asker-sub))]
-              (log-trace :outer-got-reply reply)
-              (deliver done {:reply (:content reply)})))))
-      (let [result (deref done 3000 :TIMEOUT)]
-        (ctx/stop-context! parent-ctx)
-        (println "TRACE:" (pr-str @*trace*))
-        (is (= {:reply "reply"} result)
-            "Expected the worker's reply to flow back through the pub.")))))
+       (reset! *trace* [])
+       (let [parent-ctx (ctx/create-execution-context)
+             worker-id  :worker
+             done       (promise)]
+         (binding [ec/*execution-context* parent-ctx]
+           (sp/spawn!
+            (spin
+             (log-trace :outer-spin-start)
+             (let [;; All of these happen inside the outer spin frame ─────
+                   fork-ctx (ctx/fork-context parent-ctx)
+                   _ (log-trace :forked)
+                   bus      (make-bus fork-ctx)
+                   _ (log-trace :bus-made)
+                   _worker  (spawn-echo-worker! bus worker-id)
+                   _ (log-trace :worker-spawned)
+                   asker-id (keyword (str "ask-" (rand-int 1000000)))
+                   asker-sub (bus-subscribe! bus asker-id (buf/fixed-buffer 1))
+                   _ (log-trace :asker-subscribed)
+                   _        (bus-post! bus {:to worker-id :from asker-id
+                                            :content "go"})
+                   _ (log-trace :posted-go)
+                   [reply _] (await (anext asker-sub))]
+               (log-trace :outer-got-reply reply)
+               (deliver done {:reply (:content reply)})))))
+         (let [result (deref done 3000 :TIMEOUT)]
+           (ctx/stop-context! parent-ctx)
+           (println "TRACE:" (pr-str @*trace*))
+           (is (= {:reply "reply"} result)
+               "Expected the worker's reply to flow back through the pub."))))))
 
-(deftest fork-ctx-pubsub-bus-built-outside
-  (testing "CONTROL: same flow but bus + worker built OUTSIDE the outer
+#?(:clj
+   (deftest fork-ctx-pubsub-bus-built-outside
+     (testing "CONTROL: same flow but bus + worker built OUTSIDE the outer
             spin. Should pass — confirms the bug is specific to the
             inline pattern, not the topology."
-    (let [parent-ctx (ctx/create-execution-context)
-          worker-id  :worker
-          fork-ctx   (binding [ec/*execution-context* parent-ctx]
-                       (ctx/fork-context parent-ctx))
-          bus        (make-bus fork-ctx)
-          _worker    (spawn-echo-worker! bus worker-id)
-          asker-id   (keyword (str "ask-" (rand-int 1000000)))
-          asker-sub  (binding [ec/*execution-context* fork-ctx]
-                       (bus-subscribe! bus asker-id (buf/fixed-buffer 1)))
-          done       (promise)]
-      (binding [ec/*execution-context* fork-ctx]
-        (sp/spawn!
-          (spin
-            (bus-post! bus {:to worker-id :from asker-id :content "go"})
-            (let [[reply _] (await (anext asker-sub))]
-              (deliver done {:reply (:content reply)})))))
-      (let [result (deref done 3000 :TIMEOUT)]
-        (ctx/stop-context! parent-ctx)
-        (is (= {:reply "reply"} result))))))
+       (let [parent-ctx (ctx/create-execution-context)
+             worker-id  :worker
+             fork-ctx   (binding [ec/*execution-context* parent-ctx]
+                          (ctx/fork-context parent-ctx))
+             bus        (make-bus fork-ctx)
+             _worker    (spawn-echo-worker! bus worker-id)
+             asker-id   (keyword (str "ask-" (rand-int 1000000)))
+             asker-sub  (binding [ec/*execution-context* fork-ctx]
+                          (bus-subscribe! bus asker-id (buf/fixed-buffer 1)))
+             done       (promise)]
+         (binding [ec/*execution-context* fork-ctx]
+           (sp/spawn!
+            (spin
+             (bus-post! bus {:to worker-id :from asker-id :content "go"})
+             (let [[reply _] (await (anext asker-sub))]
+               (deliver done {:reply (:content reply)})))))
+         (let [result (deref done 3000 :TIMEOUT)]
+           (ctx/stop-context! parent-ctx)
+           (is (= {:reply "reply"} result)))))))
 
-(deftest fork-ctx-pubsub-inline-no-fork
-  (testing "CONTROL 2: same as the failing test but uses parent-ctx for
+#?(:clj
+   (deftest fork-ctx-pubsub-inline-no-fork
+     (testing "CONTROL 2: same as the failing test but uses parent-ctx for
             the bus (no fork-context). Isolates whether fork-context is
             the necessary ingredient."
-    (let [parent-ctx (ctx/create-execution-context)
-          worker-id  :worker
-          done       (promise)]
-      (binding [ec/*execution-context* parent-ctx]
-        (sp/spawn!
-          (spin
-            (let [bus       (make-bus parent-ctx)   ; same ctx, no fork
-                  _worker   (spawn-echo-worker! bus worker-id)
-                  asker-id  (keyword (str "ask-" (rand-int 1000000)))
-                  asker-sub (bus-subscribe! bus asker-id (buf/fixed-buffer 1))
-                  _         (bus-post! bus {:to worker-id :from asker-id
-                                            :content "go"})
-                  [reply _] (await (anext asker-sub))]
-              (deliver done {:reply (:content reply)})))))
-      (let [result (deref done 3000 :TIMEOUT)]
-        (ctx/stop-context! parent-ctx)
-        (is (= {:reply "reply"} result))))))
+       (let [parent-ctx (ctx/create-execution-context)
+             worker-id  :worker
+             done       (promise)]
+         (binding [ec/*execution-context* parent-ctx]
+           (sp/spawn!
+            (spin
+             (let [bus       (make-bus parent-ctx)   ; same ctx, no fork
+                   _worker   (spawn-echo-worker! bus worker-id)
+                   asker-id  (keyword (str "ask-" (rand-int 1000000)))
+                   asker-sub (bus-subscribe! bus asker-id (buf/fixed-buffer 1))
+                   _         (bus-post! bus {:to worker-id :from asker-id
+                                             :content "go"})
+                   [reply _] (await (anext asker-sub))]
+               (deliver done {:reply (:content reply)})))))
+         (let [result (deref done 3000 :TIMEOUT)]
+           (ctx/stop-context! parent-ctx)
+           (is (= {:reply "reply"} result)))))))
 
-(deftest fork-ctx-mult-only-inline-roundtrip
-  (testing "Strip the pub layer. Just: source mailbox → mult → two taps.
+#?(:clj
+   (deftest fork-ctx-mult-only-inline-roundtrip
+     (testing "Strip the pub layer. Just: source mailbox → mult → two taps.
             One tap consumed by worker, second tap consumed by outer spin.
             If THIS fails, the bug is in mult/fork-ctx interaction. If
             it passes, the bug is specifically in the pub layer."
-    (reset! *trace* [])
-    (let [parent-ctx (ctx/create-execution-context)
-          done       (promise)]
-      (binding [ec/*execution-context* parent-ctx]
-        (sp/spawn!
-          (spin
-            (log-trace :outer-start)
-            (let [fork-ctx (ctx/fork-context parent-ctx)
-                  _ (log-trace :forked)
-                  source    (binding [ec/*execution-context* fork-ctx]
-                              (sync/create-mailbox fork-ctx))
-                  m         (binding [ec/*execution-context* fork-ctx]
-                              (mult/mult source))
-                  worker-tap (binding [ec/*execution-context* fork-ctx]
-                               (mult/tap m (buf/fixed-buffer 16)))
-                  result-tap (binding [ec/*execution-context* fork-ctx]
-                               (mult/tap m (buf/fixed-buffer 16)))
-                  _ (log-trace :taps-made)
-                  _worker (binding [ec/*execution-context* fork-ctx]
-                            (sp/spawn!
+       (reset! *trace* [])
+       (let [parent-ctx (ctx/create-execution-context)
+             done       (promise)]
+         (binding [ec/*execution-context* parent-ctx]
+           (sp/spawn!
+            (spin
+             (log-trace :outer-start)
+             (let [fork-ctx (ctx/fork-context parent-ctx)
+                   _ (log-trace :forked)
+                   source    (binding [ec/*execution-context* fork-ctx]
+                               (sync/create-mailbox fork-ctx))
+                   m         (binding [ec/*execution-context* fork-ctx]
+                               (mult/mult source))
+                   worker-tap (binding [ec/*execution-context* fork-ctx]
+                                (mult/tap m (buf/fixed-buffer 16)))
+                   result-tap (binding [ec/*execution-context* fork-ctx]
+                                (mult/tap m (buf/fixed-buffer 16)))
+                   _ (log-trace :taps-made)
+                   _worker (binding [ec/*execution-context* fork-ctx]
+                             (sp/spawn!
                               (spin
-                                (log-trace :worker-start)
-                                (when-let [[msg _] (await (anext worker-tap))]
-                                  (log-trace :worker-got msg)
+                               (log-trace :worker-start)
+                               (when-let [[msg _] (await (anext worker-tap))]
+                                 (log-trace :worker-got msg)
                                   ;; Post "reply" back to source so result-tap sees it
-                                  (binding [ec/*execution-context* fork-ctx]
-                                    (sync/post! source {:k :reply :for msg}))
-                                  (log-trace :worker-posted)))))
-                  _ (log-trace :worker-spawned)
-                  _ (binding [ec/*execution-context* fork-ctx]
-                      (sync/post! source {:k :go}))
-                  _ (log-trace :posted-go)
-                  [first-msg _] (await (anext result-tap))
-                  _ (log-trace :outer-got-first first-msg)
+                                 (binding [ec/*execution-context* fork-ctx]
+                                   (sync/post! source {:k :reply :for msg}))
+                                 (log-trace :worker-posted)))))
+                   _ (log-trace :worker-spawned)
+                   _ (binding [ec/*execution-context* fork-ctx]
+                       (sync/post! source {:k :go}))
+                   _ (log-trace :posted-go)
+                   [first-msg _] (await (anext result-tap))
+                   _ (log-trace :outer-got-first first-msg)
                   ;; If first-msg is :go, await again for :reply
-                  [r _] (if (= :reply (:k first-msg))
-                          [first-msg nil]
-                          (await (anext result-tap)))]
-              (log-trace :outer-got-final r)
-              (deliver done r)))))
-      (let [result (deref done 3000 :TIMEOUT)
+                   [r _] (if (= :reply (:k first-msg))
+                           [first-msg nil]
+                           (await (anext result-tap)))]
+               (log-trace :outer-got-final r)
+               (deliver done r)))))
+         (let [result (deref done 3000 :TIMEOUT)
             ;; Reach into the TapSeq's internal state to see what's in result-tap's buffer
-            inspect-tap (fn [tap label]
-                          (try
-                            (let [tsa (.-tap-state-atom tap)
-                                  state @tsa
-                                  buffer (:buffer state)]
-                              (println label "buffer-count:"
-                                       (when buffer (count buffer))
-                                       "closed?:" (when-let [c (:closed? state)] @c)))
-                            (catch Throwable e
-                              (println label "inspect error:" (.getMessage e)))))]
-        (when-let [last-trace @*trace*]
-          (println "MULT-ONLY TRACE:" (pr-str last-trace)))
-        (ctx/stop-context! parent-ctx)
-        (is (= :reply (:k result))
-            "Reply should flow through second tap.")))))
+               inspect-tap (fn [tap label]
+                             (try
+                               (let [tsa (.-tap-state-atom tap)
+                                     state @tsa
+                                     buffer (:buffer state)]
+                                 (println label "buffer-count:"
+                                          (when buffer (count buffer))
+                                          "closed?:" (when-let [c (:closed? state)] @c)))
+                               (catch Throwable e
+                                 (println label "inspect error:" (.getMessage e)))))]
+           (when-let [last-trace @*trace*]
+             (println "MULT-ONLY TRACE:" (pr-str last-trace)))
+           (ctx/stop-context! parent-ctx)
+           (is (= :reply (:k result))
+               "Reply should flow through second tap."))))))
 
-(deftest fork-ctx-pubsub-inline-using-with-context
-  (testing "Same as failing test but NO outer spawn — uses with-context
+#?(:clj
+   (deftest fork-ctx-pubsub-inline-using-with-context
+     (testing "Same as failing test but NO outer spawn — uses with-context
             to bind parent-ctx around the work without an outer Spin.
             This isolates whether the bug requires being inside a Spin
             CPS body, or whether merely binding parent ctx then forking
             inline reproduces it."
-    (let [parent-ctx (ctx/create-execution-context)
-          worker-id  :worker
-          done       (promise)]
-      (binding [ec/*execution-context* parent-ctx]
-        (let [fork-ctx (ctx/fork-context parent-ctx)
-              bus     (make-bus fork-ctx)
-              _worker (spawn-echo-worker! bus worker-id)
-              asker-id (keyword (str "ask-" (rand-int 1000000)))
-              asker-sub (bus-subscribe! bus asker-id (buf/fixed-buffer 1))]
-          (bus-post! bus {:to worker-id :from asker-id :content "go"})
-          (binding [ec/*execution-context* fork-ctx]
-            (sp/spawn!
-              (spin
-                (let [[reply _] (await (anext asker-sub))]
-                  (deliver done {:reply (:content reply)})))))))
-      (let [result (deref done 3000 :TIMEOUT)]
-        (ctx/stop-context! parent-ctx)
-        (is (= {:reply "reply"} result)
-            "Should work since the setup happened outside the spin.")))))
+       (let [parent-ctx (ctx/create-execution-context)
+             worker-id  :worker
+             done       (promise)]
+         (binding [ec/*execution-context* parent-ctx]
+           (let [fork-ctx (ctx/fork-context parent-ctx)
+                 bus     (make-bus fork-ctx)
+                 _worker (spawn-echo-worker! bus worker-id)
+                 asker-id (keyword (str "ask-" (rand-int 1000000)))
+                 asker-sub (bus-subscribe! bus asker-id (buf/fixed-buffer 1))]
+             (bus-post! bus {:to worker-id :from asker-id :content "go"})
+             (binding [ec/*execution-context* fork-ctx]
+               (sp/spawn!
+                (spin
+                 (let [[reply _] (await (anext asker-sub))]
+                   (deliver done {:reply (:content reply)})))))))
+         (let [result (deref done 3000 :TIMEOUT)]
+           (ctx/stop-context! parent-ctx)
+           (is (= {:reply "reply"} result)
+               "Should work since the setup happened outside the spin."))))))

--- a/test/org/replikativ/spindel/pubsub/fork_ctx_reentrancy_test.cljc
+++ b/test/org/replikativ/spindel/pubsub/fork_ctx_reentrancy_test.cljc
@@ -1,0 +1,185 @@
+(ns org.replikativ.spindel.pubsub.fork-ctx-reentrancy-test
+  "Reentrancy bug repro: pubsub round-trip inside an outer spin where
+   the source/mult/pub are constructed on a fork-context.
+
+   Mimics the topology dvergr.bus uses:
+     mailbox → mult → tap → pub → topic-mult → tap
+
+   The failing pattern in dvergr.proposals/propose!:
+     (sp/spawn!
+       (sp/spin
+         (let [fork  (fork-context parent-ctx)
+               ;; build bus (mailbox+mult+pub) on fork-ctx
+               ;; subscribe to topic A (worker)
+               ;; subscribe to topic B (asker)
+               ;; post message to topic A
+               ;; participant spin reads A, posts reply to topic B
+               reply (await ...on topic B sub...)]
+            ...)))
+
+   This namespace strips dvergr away to test whether the bug lives in
+   spindel's lazy pump-start + fork-context interaction."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.pubsub.mult :as mult]
+            [org.replikativ.spindel.pubsub.pub :as pub]
+            [org.replikativ.spindel.pubsub.buffer :as buf]
+            [org.replikativ.spindel.spin.sync :as sync]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.spin.combinators :as comb]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [is.simm.partial-cps.sequence :refer [anext]]))
+
+;; A "bus" = mailbox + mult + a single :to-keyed pub over a tap of the mult.
+;; This mimics dvergr.bus minus the type-pub and log-drain — the smallest
+;; surface that triggers the deadlock.
+(defn- make-bus
+  [bus-ctx]
+  (binding [ec/*execution-context* bus-ctx]
+    (let [source  (sync/create-mailbox bus-ctx)
+          m       (mult/mult source)
+          to-tap  (mult/tap m (buf/fixed-buffer 256))
+          to-pub  (pub/pub to-tap :to)]
+      {:ctx bus-ctx :source source :mult m :to-pub to-pub})))
+
+(defn- bus-subscribe!
+  [bus topic-val buffer]
+  (binding [ec/*execution-context* (:ctx bus)]
+    (pub/sub (:to-pub bus) topic-val buffer)))
+
+(defn- bus-post!
+  [bus msg]
+  (binding [ec/*execution-context* (:ctx bus)]
+    (sync/post! (:source bus) msg)))
+
+(def ^:dynamic *trace* (atom []))
+
+(defn- log-trace [tag & extra]
+  (swap! *trace* conj (vec (cons tag extra))))
+
+(defn- spawn-echo-worker!
+  "Subscribe a worker on [:to worker-id]; on each msg, post a reply back to
+   the sender."
+  [bus worker-id]
+  (let [sub (bus-subscribe! bus worker-id (buf/fixed-buffer 16))]
+    (binding [ec/*execution-context* (:ctx bus)]
+      (sp/spawn!
+        (spin
+          (log-trace :worker-spin-start)
+          (loop [s sub]
+            (log-trace :worker-awaiting)
+            (when-let [[msg r] (await (anext s))]
+              (log-trace :worker-got msg)
+              (bus-post! bus {:to (:from msg) :from worker-id :content "reply"})
+              (log-trace :worker-posted-reply)
+              (recur r))))))
+    sub))
+
+(deftest fork-ctx-pubsub-inline-roundtrip
+  (testing "Round-trip over a pub built on a fork-context's source, all
+            happening inside ONE outer spin. Mirrors dvergr.proposals/propose!'s
+            (fork-room + join + ask) inline pattern. Without the bug, the
+            outer spin's await returns the worker's reply."
+    (reset! *trace* [])
+    (let [parent-ctx (ctx/create-execution-context)
+          worker-id  :worker
+          done       (promise)]
+      (binding [ec/*execution-context* parent-ctx]
+        (sp/spawn!
+          (spin
+            (log-trace :outer-spin-start)
+            (let [;; All of these happen inside the outer spin frame ─────
+                  fork-ctx (ctx/fork-context parent-ctx)
+                  _ (log-trace :forked)
+                  bus      (make-bus fork-ctx)
+                  _ (log-trace :bus-made)
+                  _worker  (spawn-echo-worker! bus worker-id)
+                  _ (log-trace :worker-spawned)
+                  asker-id (keyword (str "ask-" (rand-int 1000000)))
+                  asker-sub (bus-subscribe! bus asker-id (buf/fixed-buffer 1))
+                  _ (log-trace :asker-subscribed)
+                  _        (bus-post! bus {:to worker-id :from asker-id
+                                           :content "go"})
+                  _ (log-trace :posted-go)
+                  [reply _] (await (anext asker-sub))]
+              (log-trace :outer-got-reply reply)
+              (deliver done {:reply (:content reply)})))))
+      (let [result (deref done 3000 :TIMEOUT)]
+        (ctx/stop-context! parent-ctx)
+        (println "TRACE:" (pr-str @*trace*))
+        (is (= {:reply "reply"} result)
+            "Expected the worker's reply to flow back through the pub.")))))
+
+(deftest fork-ctx-pubsub-bus-built-outside
+  (testing "CONTROL: same flow but bus + worker built OUTSIDE the outer
+            spin. Should pass — confirms the bug is specific to the
+            inline pattern, not the topology."
+    (let [parent-ctx (ctx/create-execution-context)
+          worker-id  :worker
+          fork-ctx   (binding [ec/*execution-context* parent-ctx]
+                       (ctx/fork-context parent-ctx))
+          bus        (make-bus fork-ctx)
+          _worker    (spawn-echo-worker! bus worker-id)
+          asker-id   (keyword (str "ask-" (rand-int 1000000)))
+          asker-sub  (binding [ec/*execution-context* fork-ctx]
+                       (bus-subscribe! bus asker-id (buf/fixed-buffer 1)))
+          done       (promise)]
+      (binding [ec/*execution-context* fork-ctx]
+        (sp/spawn!
+          (spin
+            (bus-post! bus {:to worker-id :from asker-id :content "go"})
+            (let [[reply _] (await (anext asker-sub))]
+              (deliver done {:reply (:content reply)})))))
+      (let [result (deref done 3000 :TIMEOUT)]
+        (ctx/stop-context! parent-ctx)
+        (is (= {:reply "reply"} result))))))
+
+(deftest fork-ctx-pubsub-inline-no-fork
+  (testing "CONTROL 2: same as the failing test but uses parent-ctx for
+            the bus (no fork-context). Isolates whether fork-context is
+            the necessary ingredient."
+    (let [parent-ctx (ctx/create-execution-context)
+          worker-id  :worker
+          done       (promise)]
+      (binding [ec/*execution-context* parent-ctx]
+        (sp/spawn!
+          (spin
+            (let [bus       (make-bus parent-ctx)   ; same ctx, no fork
+                  _worker   (spawn-echo-worker! bus worker-id)
+                  asker-id  (keyword (str "ask-" (rand-int 1000000)))
+                  asker-sub (bus-subscribe! bus asker-id (buf/fixed-buffer 1))
+                  _         (bus-post! bus {:to worker-id :from asker-id
+                                            :content "go"})
+                  [reply _] (await (anext asker-sub))]
+              (deliver done {:reply (:content reply)})))))
+      (let [result (deref done 3000 :TIMEOUT)]
+        (ctx/stop-context! parent-ctx)
+        (is (= {:reply "reply"} result))))))
+
+(deftest fork-ctx-pubsub-inline-using-with-context
+  (testing "Same as failing test but NO outer spawn — uses with-context
+            to bind parent-ctx around the work without an outer Spin.
+            This isolates whether the bug requires being inside a Spin
+            CPS body, or whether merely binding parent ctx then forking
+            inline reproduces it."
+    (let [parent-ctx (ctx/create-execution-context)
+          worker-id  :worker
+          done       (promise)]
+      (binding [ec/*execution-context* parent-ctx]
+        (let [fork-ctx (ctx/fork-context parent-ctx)
+              bus     (make-bus fork-ctx)
+              _worker (spawn-echo-worker! bus worker-id)
+              asker-id (keyword (str "ask-" (rand-int 1000000)))
+              asker-sub (bus-subscribe! bus asker-id (buf/fixed-buffer 1))]
+          (bus-post! bus {:to worker-id :from asker-id :content "go"})
+          (binding [ec/*execution-context* fork-ctx]
+            (sp/spawn!
+              (spin
+                (let [[reply _] (await (anext asker-sub))]
+                  (deliver done {:reply (:content reply)})))))))
+      (let [result (deref done 3000 :TIMEOUT)]
+        (ctx/stop-context! parent-ctx)
+        (is (= {:reply "reply"} result)
+            "Should work since the setup happened outside the spin.")))))

--- a/test/org/replikativ/spindel/pubsub/pub_test.cljc
+++ b/test/org/replikativ/spindel/pubsub/pub_test.cljc
@@ -246,12 +246,12 @@
          ;; sleeps. The pre-fix vector+rest+conj bug reverses order in batches.
          (binding [ec/*execution-context* ctx]
            (sp/spawn!
-             (spin
-               (loop [s sub]
-                 (when-let [[m r] (await (anext s))]
-                   (Thread/sleep 30)
-                   (swap! got conj (:n m))
-                   (recur r))))))
+            (spin
+             (loop [s sub]
+               (when-let [[m r] (await (anext s))]
+                 (Thread/sleep 30)
+                 (swap! got conj (:n m))
+                 (recur r))))))
          ;; Burst-post n-items.
          (binding [ec/*execution-context* ctx]
            (dotimes [i n-items]

--- a/test/org/replikativ/spindel/pubsub/pub_test.cljc
+++ b/test/org/replikativ/spindel/pubsub/pub_test.cljc
@@ -4,11 +4,14 @@
                :cljs [cljs.test :refer [deftest is testing] :include-macros true])
             [org.replikativ.spindel.pubsub.pub :as pub]
             [org.replikativ.spindel.pubsub.buffer :as buf]
+            [org.replikativ.spindel.pubsub.mult :as mult]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.context :as ctx]
             [is.simm.partial-cps.sequence :refer [PAsyncSeq anext]]
             #?(:clj [org.replikativ.spindel.spin.cps :refer [spin]])
             [org.replikativ.spindel.spin.combinators :as comb]
+            [org.replikativ.spindel.spin.sync :as sync]
+            [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.effects.await :refer [await]]
             [org.replikativ.spindel.test-helpers :as th])
   #?(:cljs (:require-macros [org.replikativ.spindel.spin.cps :refer [spin]]
@@ -215,3 +218,46 @@
            (is (= 5 (count result2)) "Second subscriber should get 5 items")
            (is (= (set (range 5)) (set result1)) "First subscriber should get all values")
            (is (= (set (range 5)) (set result2)) "Second subscriber should get all values"))))))
+
+;; =============================================================================
+;; FIFO Order Under Backpressure
+;; Regression: topic-items-atom was a vector, but (swap! atom rest) returns
+;; a ListSeq; (swap! atom conj item) on a seq prepends instead of appending,
+;; corrupting FIFO order. Fixed by switching to PersistentQueue.
+;; =============================================================================
+
+#?(:clj
+   (deftest test-pub-fifo-order-under-backpressure
+     (testing "subscriber receives messages in post order even when buffers backpressure"
+       (let [ctx     (ctx/create-execution-context)
+             [mbox m tap p sub]
+             (binding [ec/*execution-context* ctx]
+               (let [mbox (sync/create-mailbox ctx)
+                     m    (mult/mult mbox)
+                     tap  (mult/tap m (buf/fixed-buffer 2))
+                     p    (pub/pub tap :type)
+                     sub  (pub/sub p :x (buf/fixed-buffer 2))]
+                 [mbox m tap p sub]))
+             got     (atom [])
+             n-items 10]
+         ;; Slow blocking consumer behind multiple small buffers.
+         ;; topology: mailbox → mult (buf 2) → pub → sub (buf 2) → slow consumer
+         ;; Items pile up at the pub's topic-items queue while the consumer
+         ;; sleeps. The pre-fix vector+rest+conj bug reverses order in batches.
+         (binding [ec/*execution-context* ctx]
+           (sp/spawn!
+             (spin
+               (loop [s sub]
+                 (when-let [[m r] (await (anext s))]
+                   (Thread/sleep 30)
+                   (swap! got conj (:n m))
+                   (recur r))))))
+         ;; Burst-post n-items.
+         (binding [ec/*execution-context* ctx]
+           (dotimes [i n-items]
+             (sync/post! mbox {:type :x :n i})))
+         ;; Wait for the slow consumer to drain (30ms × n + slack).
+         (Thread/sleep (+ 200 (* 30 n-items)))
+         (is (= n-items (count @got)) "all items delivered")
+         (is (= (vec (range n-items)) @got)
+             "items delivered in FIFO order under backpressure")))))


### PR DESCRIPTION
## Summary

`make-promise` in the pubsub layer (mult / pub / partitioned) stored
plain CPS `resolve` continuations as watchers. When a producer's
`deliver!` fired from a different execution context than the one that
registered the watcher — for example, a fork-ctx pump signaling
awaiters that were registered on a parent ctx — the resolve ran with
the producer's `*execution-context*` dynamically bound. The
`enqueue-completion-event!` call inside the resolve
(spin/core.cljc:339) then routed the `:spin-completion` event to the
producer's ctx, while the parent's await-cont sat on the awaiter's
ctx. The two never met → deadlock.

The fix captures `(ec/current-execution-context)` at `await-spin`
construction and wraps `resolve` so its invocation re-binds the
captured ctx. The awaited spin then completes on the same ctx where
its await-cont was registered.

Applied uniformly to all three `make-promise` copies (mult.cljc,
pub.cljc, partitioned.cljc).

## Repro & regression net

`test/org/replikativ/spindel/pubsub/fork_ctx_reentrancy_test.cljc`
exercises five variants of the pattern:

- `fork-ctx-pubsub-inline-roundtrip`          — deterministic deadlock pre-fix
- `fork-ctx-mult-only-inline-roundtrip`       — deterministic deadlock pre-fix (no pub layer)
- `fork-ctx-pubsub-bus-built-outside`         — passes (control: bus outside spin)
- `fork-ctx-pubsub-inline-no-fork`            — passes (control: no fork-ctx)
- `fork-ctx-pubsub-inline-using-with-context` — passes (control: no outer spin)

Both failing variants required *both* (a) fork-context's overlay
backend and (b) the bus topology being constructed inside an outer
Spin's body on that fork ctx.

## Downstream

dvergr.proposals/propose! constructs a bus on a freshly-forked ctx
from inside its spin body. Under load this used to flake ~10× more
often than the underlying race — fixed here.

## Test plan

- [x] All 801 spindel tests pass (0 failures, 0 errors).
- [x] dvergr.proposals_test: 5/5 sequential kaocha runs clean (was 0-9/9 failures pre-fix when ec-state load was introduced).
- [x] New repro tests deterministic pre/post-fix.