### PR TITLE
fix: retention/leak audit — async-seq, sync, pubsub, parallel, dom, inference, distributed

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
         org.clojure/tools.analyzer.jvm {:mvn/version "1.3.2"}
         riddley/riddley {:mvn/version "0.2.0"}
         org.replikativ/logging {:mvn/version "0.1.3"}
-        is.simm/partial-cps {:mvn/version "0.1.54"}
+        is.simm/partial-cps {:mvn/version "0.1.55"}
         org.replikativ/yggdrasil {:mvn/version "0.1.6"}
         org.replikativ/hasch {:mvn/version "0.3.97"}
         org.clojure/core.async {:mvn/version "1.6.681"}

--- a/src/org/replikativ/spindel/distributed/core.cljc
+++ b/src/org/replikativ/spindel/distributed/core.cljc
@@ -257,6 +257,25 @@
     (unregister-response-handler! request-id)
     (handler response)))
 
+(defn fail-all-response-handlers!
+  "Fail and remove every pending response handler.
+
+  A handler is registered per in-flight remote invocation and is otherwise
+  removed only when its `::invoke-result` arrives (`handle-response!`). If a
+  response never comes — peer disconnect, dropped message, shutdown — the
+  handler would strand forever. Call this from a disconnect/shutdown hook so
+  pending callers are failed (and the registry cleared) rather than leaking.
+
+  `error` is an error value (e.g. an ex-info) delivered to each handler as
+  `{:request-id <id> :error error}`."
+  [error]
+  (let [pending @response-handlers]
+    (reset! response-handlers {})
+    (doseq [[request-id handler] pending]
+      (try
+        (handler {:request-id request-id :error error})
+        (catch #?(:clj Throwable :cljs :default) _ nil)))))
+
 ;; =============================================================================
 ;; Utility: Throwable detection
 ;; =============================================================================

--- a/src/org/replikativ/spindel/distributed/inspector.clj
+++ b/src/org/replikativ/spindel/distributed/inspector.clj
@@ -29,27 +29,34 @@
 ;; Object Cache
 ;; =============================================================================
 
-(def ^:private object-cache
-  "UUID → JVM object. Holds non-serializable values server-side.
-  Clients reference them by UUID; navigation resolves via cache."
+(def ^:dynamic *object-cache*
+  "UUID → JVM object. Holds non-serializable values server-side; clients
+  reference them by UUID and navigation resolves via this cache.
+
+  Dynamic and per-session: `make-inspector` binds it to a fresh atom that
+  lives on the inspector instance (see `with-session-cache`), so the cache —
+  which pins arbitrary JVM objects / Datahike entities — is reclaimed when
+  the inspector is dropped, rather than accumulating in a process-global atom
+  for the JVM's lifetime. The top-level default below is a fallback for any
+  direct `summarize`/`reflect` call made outside a `make-inspector` session."
   (atom {}))
 
 (defn- cache!
   "Store object in cache, return UUID reference."
   [obj]
   (let [id (java.util.UUID/randomUUID)]
-    (swap! object-cache assoc id obj)
+    (swap! *object-cache* assoc id obj)
     id))
 
 (defn- cached
   "Retrieve object from cache by UUID."
   [id]
-  (get @object-cache id))
+  (get @*object-cache* id))
 
 (defn clear-cache!
-  "Clear the object cache. Call when inspector sessions are disposed."
+  "Clear the currently-bound object cache."
   []
-  (reset! object-cache {}))
+  (reset! *object-cache* {}))
 
 ;; =============================================================================
 ;; Protocols
@@ -246,142 +253,157 @@
         signal (atom nil)
         ;; Map path → source object for edit-back
         path-objects (atom {})
-        root-node (reflect-value root-obj :entity-id entity-id)]
+        ;; Per-session object cache. Bound around this session's closures so
+        ;; the cached refs (arbitrary JVM objects / Datahike entities) are
+        ;; reclaimed when the inspector is dropped, instead of living in a
+        ;; process-global atom for the JVM's lifetime.
+        obj-cache (atom {})
+        with-session-cache (fn [f]
+                             (fn [& args]
+                               (binding [*object-cache* obj-cache]
+                                 (apply f args))))
+        root-node (binding [*object-cache* obj-cache]
+                    (reflect-value root-obj :entity-id entity-id))]
 
     ;; Initialize root
     (swap! tree assoc [] root-node)
     (swap! path-objects assoc [] root-obj)
     (reset! signal {:op :set-root :path [] :node root-node})
 
-    {:signal signal
-     :tree tree
+    (-> {:signal signal
+         :tree tree
 
-     :navigate!
-     (fn navigate! [path]
-       (let [parent-path (vec (butlast path))
-             field-key (last path)
-             parent-node (get @tree parent-path)]
-         (when parent-node
-           (let [field (first (filter #(= field-key (:key %)) (:fields parent-node)))
-                 summary (:summary field)]
-             (when (and summary (:nav? summary))
-               (let [ref-id (:ref summary)
-                     obj (when ref-id
-                           (let [c (cached ref-id)]
-                             (if (fn? c) (c) c)))]
-                 (when obj
-                   (let [;; If parent was a Datahike entity and this is a ref,
+         :navigate!
+         (fn navigate! [path]
+           (let [parent-path (vec (butlast path))
+                 field-key (last path)
+                 parent-node (get @tree parent-path)]
+             (when parent-node
+               (let [field (first (filter #(= field-key (:key %)) (:fields parent-node)))
+                     summary (:summary field)]
+                 (when (and summary (:nav? summary))
+                   (let [ref-id (:ref summary)
+                         obj (when ref-id
+                               (let [c (cached ref-id)]
+                                 (if (fn? c) (c) c)))]
+                     (when obj
+                       (let [;; If parent was a Datahike entity and this is a ref,
                          ;; the child might also be an entity
-                         child-eid (when (and conn (map? obj) (:db/id obj))
-                                     (:db/id obj))
-                         node (reflect-value obj :entity-id child-eid)
+                             child-eid (when (and conn (map? obj) (:db/id obj))
+                                         (:db/id obj))
+                             node (reflect-value obj :entity-id child-eid)
                          ;; If parent is atom-backed, propagate editability
-                         parent-atom? (or (:atom-backed? field)
-                                          (instance? clojure.lang.Atom
-                                                     (get @path-objects parent-path)))
-                         node (if (and parent-atom? (map? obj))
-                                (update node :fields
-                                        (fn [fs] (mapv #(assoc % :editable? true
-                                                               :atom-backed? true) fs)))
-                                node)]
-                     (swap! tree assoc path node)
-                     (swap! path-objects assoc path obj)
-                     (reset! signal {:op :expand :path path :node node})
-                     node))))))))
+                             parent-atom? (or (:atom-backed? field)
+                                              (instance? clojure.lang.Atom
+                                                         (get @path-objects parent-path)))
+                             node (if (and parent-atom? (map? obj))
+                                    (update node :fields
+                                            (fn [fs] (mapv #(assoc % :editable? true
+                                                                   :atom-backed? true) fs)))
+                                    node)]
+                         (swap! tree assoc path node)
+                         (swap! path-objects assoc path obj)
+                         (reset! signal {:op :expand :path path :node node})
+                         node))))))))
 
-     :collapse!
-     (fn collapse! [path]
-       (let [remove-prefix (fn [m prefix]
-                             (into {} (remove (fn [[k _]]
-                                                (and (>= (count k) (count prefix))
-                                                     (= prefix (vec (take (count prefix) k))))))
-                                   m))]
-         (swap! tree remove-prefix path)
-         (swap! path-objects remove-prefix path)
-         (reset! signal {:op :collapse :path path})))
+         :collapse!
+         (fn collapse! [path]
+           (let [remove-prefix (fn [m prefix]
+                                 (into {} (remove (fn [[k _]]
+                                                    (and (>= (count k) (count prefix))
+                                                         (= prefix (vec (take (count prefix) k))))))
+                                       m))]
+             (swap! tree remove-prefix path)
+             (swap! path-objects remove-prefix path)
+             (reset! signal {:op :collapse :path path})))
 
-     :edit!
-     (fn edit! [path field-key new-value]
-       (let [node (get @tree path)
-             obj (get @path-objects path)
-             field (when node
-                     (first (filter #(= field-key (:key %)) (:fields node))))]
-         (when (and field (:editable? field))
-           (cond
+         :edit!
+         (fn edit! [path field-key new-value]
+           (let [node (get @tree path)
+                 obj (get @path-objects path)
+                 field (when node
+                         (first (filter #(= field-key (:key %)) (:fields node))))]
+             (when (and field (:editable? field))
+               (cond
              ;; Datahike entity: transact via conn
-             (and conn (:entity-id field))
-             (let [eid (:entity-id field)
-                   attr (:attribute field)
-                   tx-data [[:db/add eid attr new-value]]]
-               @(conn tx-data)  ;; d/transact returns future-like
+                 (and conn (:entity-id field))
+                 (let [eid (:entity-id field)
+                       attr (:attribute field)
+                       tx-data [[:db/add eid attr new-value]]]
+                   @(conn tx-data)  ;; d/transact returns future-like
                ;; Re-reflect the entity
-               (let [updated (into {} (d/datafy (d/nav obj attr new-value)))
+                   (let [updated (into {} (d/datafy (d/nav obj attr new-value)))
                      ;; For entity, re-fetch from conn
-                     fresh-obj (if entity-id obj updated)
-                     fresh-node (reflect-value fresh-obj :entity-id (:entity-id field))]
-                 (swap! tree assoc path fresh-node)
-                 (swap! path-objects assoc path fresh-obj)
-                 (reset! signal {:op :update :path path :node fresh-node})
-                 tx-data))
+                         fresh-obj (if entity-id obj updated)
+                         fresh-node (reflect-value fresh-obj :entity-id (:entity-id field))]
+                     (swap! tree assoc path fresh-node)
+                     (swap! path-objects assoc path fresh-obj)
+                     (reset! signal {:op :update :path path :node fresh-node})
+                     tx-data))
 
              ;; Atom-backed field: swap the atom
-             (or (instance? clojure.lang.Atom obj)
-                 (:atom-backed? field))
-             (let [;; Walk up to find the atom source
-                   [the-atom atom-path]
-                   (loop [p path]
-                     (let [o (get @path-objects p)]
-                       (cond
-                         (instance? clojure.lang.Atom o) [o p]
-                         (empty? p) [nil nil]
-                         :else (recur (vec (butlast p))))))
+                 (or (instance? clojure.lang.Atom obj)
+                     (:atom-backed? field))
+                 (let [;; Walk up to find the atom source
+                       [the-atom atom-path]
+                       (loop [p path]
+                         (let [o (get @path-objects p)]
+                           (cond
+                             (instance? clojure.lang.Atom o) [o p]
+                             (empty? p) [nil nil]
+                             :else (recur (vec (butlast p))))))
                    ;; Build the nested path from atom root to this field
                    ;; path=[:config] atom-path=[] → nested-keys=[:config field-key]
                    ;; path=[:team 0] atom-path=[] → nested-keys=[:team 0 field-key]
-                   nested-keys (vec (concat (drop (count atom-path) path)
-                                            [field-key]))]
-               (when the-atom
-                 (swap! the-atom assoc-in nested-keys new-value)
+                       nested-keys (vec (concat (drop (count atom-path) path)
+                                                [field-key]))]
+                   (when the-atom
+                     (swap! the-atom assoc-in nested-keys new-value)
                  ;; Re-reflect the current node from the updated atom value
-                 (let [updated-val (get-in @the-atom (drop (count atom-path) path))
-                       fresh-node (if (= path atom-path)
-                                    (reflect-value the-atom)
-                                    (reflect-value updated-val))
+                     (let [updated-val (get-in @the-atom (drop (count atom-path) path))
+                           fresh-node (if (= path atom-path)
+                                        (reflect-value the-atom)
+                                        (reflect-value updated-val))
                        ;; Mark fields editable for atom-backed nodes
-                       fresh-node (update fresh-node :fields
-                                          (fn [fields]
-                                            (mapv #(assoc % :editable? true
-                                                          :atom-backed? true) fields)))]
-                   (swap! tree assoc path fresh-node)
-                   (reset! signal {:op :update :path path :node fresh-node})
-                   nil)))
+                           fresh-node (update fresh-node :fields
+                                              (fn [fields]
+                                                (mapv #(assoc % :editable? true
+                                                              :atom-backed? true) fields)))]
+                       (swap! tree assoc path fresh-node)
+                       (reset! signal {:op :update :path path :node fresh-node})
+                       nil)))
 
              ;; Mutable Java field
-             (and (:java-field field) (not (nil? obj)))
-             (try
-               (let [f (.getDeclaredField (class obj) (:java-field field))]
-                 (.setAccessible f true)
-                 (.set f obj new-value)
-                 (let [fresh-node (reflect-value obj)]
-                   (swap! tree assoc path fresh-node)
-                   (reset! signal {:op :update :path path :node fresh-node})
-                   nil))
-               (catch Exception e
-                 (reset! signal {:op :error :path path
-                                 :error (str "Edit failed: " (.getMessage e))})
-                 nil))
+                 (and (:java-field field) (not (nil? obj)))
+                 (try
+                   (let [f (.getDeclaredField (class obj) (:java-field field))]
+                     (.setAccessible f true)
+                     (.set f obj new-value)
+                     (let [fresh-node (reflect-value obj)]
+                       (swap! tree assoc path fresh-node)
+                       (reset! signal {:op :update :path path :node fresh-node})
+                       nil))
+                   (catch Exception e
+                     (reset! signal {:op :error :path path
+                                     :error (str "Edit failed: " (.getMessage e))})
+                     nil))
 
-             :else nil))))
+                 :else nil))))
 
-     :refresh!
-     (fn refresh! [path]
-       (let [obj (get @path-objects path)]
-         (when obj
-           (let [eid (when (and conn (map? obj) (:db/id obj)) (:db/id obj))
-                 node (reflect-value obj :entity-id eid)]
-             (swap! tree assoc path node)
-             (reset! signal {:op :update :path path :node node})
-             node))))}))
+         :refresh!
+         (fn refresh! [path]
+           (let [obj (get @path-objects path)]
+             (when obj
+               (let [eid (when (and conn (map? obj) (:db/id obj)) (:db/id obj))
+                     node (reflect-value obj :entity-id eid)]
+                 (swap! tree assoc path node)
+                 (reset! signal {:op :update :path path :node node})
+                 node))))}
+        ;; Bind the per-session cache around each cache-using closure so
+        ;; navigate!/edit!/refresh! resolve refs against THIS session's cache.
+        (update :navigate! with-session-cache)
+        (update :edit! with-session-cache)
+        (update :refresh! with-session-cache))))
 
 ;; =============================================================================
 ;; Batch edit support

--- a/src/org/replikativ/spindel/dom/browser.cljs
+++ b/src/org/replikativ/spindel/dom/browser.cljs
@@ -158,7 +158,10 @@
     (get @elements addr))
 
   (set-element! [_ addr el]
-    (swap! elements assoc addr el)))
+    (swap! elements assoc addr el))
+
+  (remove-element! [_ addr]
+    (swap! elements dissoc addr)))
 
 ;; =============================================================================
 ;; Constructor

--- a/src/org/replikativ/spindel/dom/cache.cljc
+++ b/src/org/replikativ/spindel/dom/cache.cljc
@@ -85,14 +85,21 @@
   (ec/swap-state! [:dom/attr-cache addr] (constantly attrs)))
 
 (defn evict-cache!
-  "Drop both the slot cache and attribute cache for an element address.
+  "Drop all per-address engine state for an element address.
 
-  Called when an element is unmounted so the per-address cache entries
-  do not accumulate for the lifetime of the context."
+  Called when an element is unmounted so the per-address entries do not
+  accumulate for the lifetime of the context. Covers every `[:dom/* <addr>]`
+  map the render path writes:
+  - `:dom/cache`       — slot cache
+  - `:dom/attr-cache`  — attribute cache
+  - `:dom/keyed-cache` — `ifor-each` per-call-site keyed cache
+  - `:dom/foreign`     — foreign-node marker"
   [addr]
   (when addr
     (ec/swap-state! [:dom/cache] (fn [m] (dissoc m addr)))
-    (ec/swap-state! [:dom/attr-cache] (fn [m] (dissoc m addr)))))
+    (ec/swap-state! [:dom/attr-cache] (fn [m] (dissoc m addr)))
+    (ec/swap-state! [:dom/keyed-cache] (fn [m] (dissoc m addr)))
+    (ec/swap-state! [:dom/foreign] (fn [m] (dissoc m addr)))))
 
 ;; =============================================================================
 ;; Attribute Reconciliation

--- a/src/org/replikativ/spindel/dom/discharge.cljc
+++ b/src/org/replikativ/spindel/dom/discharge.cljc
@@ -95,6 +95,11 @@
   (set-element! [this addr el]
     "Store element reference by address keyword.")
 
+  (remove-element! [this addr]
+    "Drop the element reference for an address keyword. Called when an
+     address is unmounted, so the discharge's addr→element registry does
+     not retain detached DOM nodes for the lifetime of the tree.")
+
   (remove-children-range! [this parent start-idx count]
     "Remove multiple children starting at index. Default: call remove-child! in loop.")
 
@@ -292,13 +297,21 @@
   subtree is render-initial!'d, so it would wipe the cache of an address
   that a still-live element (a surviving keyed descendant of a churned
   parent) re-claims later in the same pass. By end-of-pass `*rendered-addrs*`
-  holds every live address, so (pending - live) is exactly the dead set."
-  []
-  (when (and *pending-evictions* *rendered-addrs*)
-    (let [live (set (keys @*rendered-addrs*))]
-      (doseq [addr @*pending-evictions*]
-        (when-not (contains? live addr)
-          (cache/evict-cache! addr))))))
+  holds every live address, so (pending - live) is exactly the dead set.
+
+  When a `discharge` is supplied we also drop its addr→element registry entry
+  for each dead address (`remove-element!`) — otherwise the registry retains
+  the detached DOM node for the lifetime of the tree (it is only ever fully
+  cleared by `unmount!`). The 0-arity form keeps the cache-only behavior for
+  callers (e.g. focused unit tests) that have no discharge in hand."
+  ([] (flush-pending-evictions! nil))
+  ([discharge]
+   (when (and *pending-evictions* *rendered-addrs*)
+     (let [live (set (keys @*rendered-addrs*))]
+       (doseq [addr @*pending-evictions*]
+         (when-not (contains? live addr)
+           (cache/evict-cache! addr)
+           (when discharge (remove-element! discharge addr))))))))
 
 ;; =============================================================================
 ;; Attribute Delta Application
@@ -898,7 +911,7 @@
       (let [result (clear-deltas-deep vdom)]
         ;; Evict caches of addresses unmounted this pass that no live
         ;; element re-claimed (deferred — see flush-pending-evictions!).
-        (flush-pending-evictions!)
+        (flush-pending-evictions! discharge)
         ;; Advance the applied-vnodes generations so memory stays
         ;; bounded while cross-cycle cached-result protection holds.
         (rotate-applied! *applied-vnodes*)
@@ -1132,6 +1145,9 @@
 
   (set-element! [_ addr el]
     (swap! elements assoc addr el))
+
+  (remove-element! [_ addr]
+    (swap! elements dissoc addr))
 
   (remove-children-range! [this parent start-idx n]
     (default-remove-children-range! this parent start-idx n))

--- a/src/org/replikativ/spindel/dom/render.cljc
+++ b/src/org/replikativ/spindel/dom/render.cljc
@@ -28,6 +28,7 @@
   produce vnodes with deltas attached that are discharged to the DOM."
   (:require [org.replikativ.spindel.dom.discharge :as disch]
             [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.engine.core :as ec]
             [replikativ.logging :as log]))
 
 ;; =============================================================================
@@ -96,7 +97,7 @@
               (log/trace :render/delta-update {:nodes-with-deltas (count nodes-with-deltas)})
               (doseq [node nodes-with-deltas]
                 (disch/discharge-vnode! discharge node))))
-          (disch/flush-pending-evictions!))
+          (disch/flush-pending-evictions! discharge))
 
         ;; Clear deltas for next render cycle
         ;; No ref transfer needed — cleared vnodes carry same :addr values
@@ -196,7 +197,11 @@
   "
   [container the-spin discharge]
   (let [render-effect (create-render-effect container discharge)
-        spin-id (spin-core/spin-id the-spin)]
+        spin-id (spin-core/spin-id the-spin)
+        ;; Capture the context so `:stop!` can cancel against it later, even
+        ;; if the caller invokes it with no *execution-context* bound.
+        ctx (try (ec/current-execution-context)
+                 (catch #?(:clj Throwable :cljs :default) _ nil))]
 
     (log/debug :render/start {:spin-id spin-id})
 
@@ -215,5 +220,13 @@
     {:spin-id spin-id
      :stop! (fn []
               (log/debug :render/stop {:spin-id spin-id})
-              ;; TODO: Implement cancellation
+              ;; Cancel the render spin: tears down its reactive continuations
+              ;; and signal/spin dependency subscriptions so it stops
+              ;; re-executing on signal changes, and lets the engine reclaim
+              ;; its node + conts. Without this, a stopped render keeps its
+              ;; reactive machinery (and the render-effect closure it resumes
+              ;; into) alive for the lifetime of the context.
+              (when ctx
+                (binding [ec/*execution-context* ctx]
+                  (spin-core/cancel-spin! the-spin)))
               nil)}))

--- a/src/org/replikativ/spindel/effects/await.cljc
+++ b/src/org/replikativ/spindel/effects/await.cljc
@@ -474,13 +474,18 @@
   and only the NEW body slice (registered by the parent's re-run)
   advances. See `cancellable-external-pair` for the design rationale."
   [deferred spin-id source-loc resolve reject]
-  (let [[wr wj _cancel-token]
+  (let [[wr wj cancel-token]
         (cancellable-external-pair
          spin-id resolve reject
          [::deferred #?(:clj (System/identityHashCode deferred)
                         :cljs (.-id deferred))]
          source-loc)]
-    (deferred wr wj))
+    ;; Thread the cancel-token into the Deferred's 2-arity (via the dynamic
+    ;; var, same as the Mailbox branch) so it can store it on the pending
+    ;; reader and prune cancelled readers — otherwise a cancelled await on a
+    ;; never-delivered deferred strands its `:pending` entry forever.
+    (binding [ec/*external-await-cancel-token* cancel-token]
+      (deferred wr wj)))
   spin-core/incomplete)
 
 (defn reactive-spin?

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -162,10 +162,15 @@
                                        :value value
                                        :pending [])))))]
 
-    ;; Notify all pending readers INLINE if this was the first assignment
+    ;; Notify all pending readers INLINE if this was the first assignment.
+    ;; Each pending entry is a `{:spin-id :cancel-token :resolve}` map (the
+    ;; Deferred 2-arity stores cancellation metadata so it can prune cancelled
+    ;; readers). The wrapped `:resolve` already no-ops if its await was
+    ;; cancelled, so we can invoke them all; the metadata is for the
+    ;; prune-on-read sweep, not needed here.
     ;; Event handler already bound *in-trampoline* false
     (when-let [pending @pending-callbacks]
-      (doseq [resolve pending]
+      (doseq [{:keys [resolve]} pending]
         (pcps-async/invoke-continuation resolve value)))
 
     ;; Return the assigned value

--- a/src/org/replikativ/spindel/inference/inference.cljc
+++ b/src/org/replikativ/spindel/inference/inference.cljc
@@ -1051,7 +1051,14 @@
                new-samples (mapv (fn [[ctx lw]] [ctx lw]) particles)]
 
            (recur (inc iteration)
-                  (into all-samples new-samples))))))))
+                  ;; Retain only the tail we will actually use (the final
+                  ;; result is `(take-last (* num-particles 3) …)`). Each
+                  ;; sample pins a forked ExecutionContext, so accumulating
+                  ;; every iteration's samples would hold `num-particles *
+                  ;; num-iterations` heavy contexts at once. Trimming here
+                  ;; lets older iterations' contexts become GC-eligible.
+                  (vec (take-last (* num-particles 3)
+                                  (into all-samples new-samples))))))))))
 
 (defn get-variational-dists
   "Extract learned variational distributions from BBVI measure.

--- a/src/org/replikativ/spindel/pubsub/pub.cljc
+++ b/src/org/replikativ/spindel/pubsub/pub.cljc
@@ -207,10 +207,14 @@
                 (if-let [result (await (anext source))]
                   (let [[item rest-seq] result
                         topic (topic-fn item)]
-                     ;; Ensure topic mult exists (auto-create if needed to prevent
-                     ;; race between pump and late subscribers)
-                    (ensure-topic-mult! mults-atom topic)
-                    ((:push-fn (get @mults-atom topic)) item)
+                     ;; Route only to a topic that currently has a mult (i.e.
+                     ;; ≥1 subscriber). Items for unsubscribed topics are
+                     ;; dropped — matching core.async pub and
+                     ;; `test-pub-unsubscribed-topics-dropped` — instead of
+                     ;; auto-creating a topic mult that would never be reclaimed
+                     ;; (the idle-topic leak). `sub*` is the sole mult creator.
+                    (when-let [entry (get @mults-atom topic)]
+                      ((:push-fn entry) item))
                     (recur rest-seq))
                    ;; Source exhausted
                   (do
@@ -242,8 +246,15 @@
 
   (unsub* [pub topic tap-seq]
     (let [{:keys [mults-atom]} pub]
-      (when-let [{:keys [mult]} (get @mults-atom topic)]
-        (mult/untap mult tap-seq))))
+      (when-let [{:keys [mult close-fn]} (get @mults-atom topic)]
+        (mult/untap mult tap-seq)
+        ;; Reclaim the topic once its last subscriber is gone, so a
+        ;; subscribed-then-fully-unsubscribed topic doesn't linger (and keep
+        ;; receiving/dropping pump items). A later re-subscribe re-creates it
+        ;; via `ensure-topic-mult!`.
+        (when (empty? @(:taps-atom mult))
+          (close-fn)
+          (swap! mults-atom dissoc topic)))))
 
   (unsub-all* [pub]
     (let [{:keys [mults-atom]} pub]

--- a/src/org/replikativ/spindel/semaphore.cljc
+++ b/src/org/replikativ/spindel/semaphore.cljc
@@ -107,33 +107,45 @@
       (do-work)
       (release sem))"
   [sem]
-  (spin/make-spin
-   (fn [resolve reject]
-     (let [sem-id (.-id sem)
-           got-permit? (atom false)]  ; Capture decision atomically
+  ;; Give the acquire spin a known id up-front so the enqueued waiter can carry
+  ;; it: if this acquire is cancelled (e.g. a race/timeout loser), the waiter
+  ;; is identifiable and gets pruned — both here (on enqueue) and in `release`
+  ;; (which must not hand a permit to a cancelled acquirer).
+  (let [acquire-spin-id (keyword (gensym "sem-acquire-"))]
+    (spin/make-spin
+     (fn [resolve reject]
+       (let [sem-id (.-id sem)
+             got-permit? (atom false)  ; Capture decision atomically
+             dead-waiter? (fn [{:keys [spin-id]}]
+                            (and spin-id (ec/spin-is-cancelled? spin-id)))]
 
-       ;; Atomically try to acquire or enqueue
-       ;; Uses *execution-context* from spin context - no captured runtime!
-       (ec/swap-state! [:semaphores sem-id]
-                       (fn [state]
-                         (let [permits (:permits state)]
-                           (if (pos? permits)
-               ;; Permit available - decrement and mark as acquired
-                             (do
-                               (reset! got-permit? true)
-                               (update state :permits dec))
-               ;; No permits - add to waiting queue
-                             (update state :waiting-queue
-                                     conj {:resolve resolve
-                                           :reject reject
-                                           :timestamp #?(:clj (System/currentTimeMillis)
-                                                         :cljs (.now js/Date))})))))
+         ;; Atomically try to acquire or enqueue
+         ;; Uses *execution-context* from spin context - no captured runtime!
+         (ec/swap-state! [:semaphores sem-id]
+                         (fn [state]
+                           (let [permits (:permits state)]
+                             (if (pos? permits)
+                 ;; Permit available - decrement and mark as acquired
+                               (do
+                                 (reset! got-permit? true)
+                                 (update state :permits dec))
+                 ;; No permits - prune cancelled waiters, then enqueue ours
+                 ;; (preserve the PersistentQueue type + FIFO order)
+                               (update state :waiting-queue
+                                       (fn [q]
+                                         (conj (into (empty q) (remove dead-waiter? q))
+                                               {:resolve resolve
+                                                :reject reject
+                                                :spin-id acquire-spin-id
+                                                :timestamp #?(:clj (System/currentTimeMillis)
+                                                              :cljs (.now js/Date))})))))))
 
-       ;; If we got the permit, resolve immediately
-       (when @got-permit?
-         (spin/resume resolve :acquired))
+         ;; If we got the permit, resolve immediately
+         (when @got-permit?
+           (spin/resume resolve :acquired))
 
-       spin/incomplete))))
+         spin/incomplete))
+     acquire-spin-id)))
 
 (defn release
   "Release a permit, waking up the next waiter if any.
@@ -158,21 +170,29 @@
             max-permits (:max-permits old-state)]
 
         (cond
-          ;; Queue not empty - wake up first waiter
+          ;; Queue not empty - wake up first LIVE waiter
           (seq queue)
           (let [waiter (peek queue)
                 new-state (update old-state :waiting-queue pop)]
             (if (ec/cas-state! path old-state new-state)
-              (do
-                ;; Successfully dequeued - schedule waiter to run on executor.
-                ;; alive-fn drops the callback if the context is stopped before
-                ;; setTimeout fires (CLJS) — prevents stale resumes from
-                ;; bleeding into a freshly-created context.
-                (let [ctx ec/*execution-context*]
-                  (executor/execute! (:executor ctx)
-                                     (executor/alive-fn ctx
-                                                        #(spin/resume (:resolve waiter) :acquired))))
-                :released)
+              (if (and (:spin-id waiter)
+                       (ec/spin-is-cancelled? (:spin-id waiter)))
+                ;; The front waiter's acquire was cancelled — drop it WITHOUT
+                ;; consuming this release's permit, and look for the next live
+                ;; waiter (or fall through to incrementing permits if the
+                ;; queue drains). Handing the permit to a cancelled acquirer
+                ;; would lose it.
+                (recur)
+                (do
+                  ;; Successfully dequeued a live waiter - schedule it on the
+                  ;; executor. alive-fn drops the callback if the context is
+                  ;; stopped before setTimeout fires (CLJS) — prevents stale
+                  ;; resumes from bleeding into a freshly-created context.
+                  (let [ctx ec/*execution-context*]
+                    (executor/execute! (:executor ctx)
+                                       (executor/alive-fn ctx
+                                                          #(spin/resume (:resolve waiter) :acquired))))
+                  :released))
               ;; CAS failed - retry
               (recur)))
 

--- a/src/org/replikativ/spindel/seq/combinators.cljc
+++ b/src/org/replikativ/spindel/seq/combinators.cljc
@@ -1,10 +1,12 @@
 (ns org.replikativ.spindel.seq.combinators
   "Async sequence combinators and utilities"
+  (:refer-clojure :exclude [first rest reduce into sequence eduction await])
   (:require [is.simm.partial-cps.sequence :refer [PAsyncSeq anext]]
-            [org.replikativ.spindel.spin :as spin]
             [org.replikativ.spindel.seq.core :as core]
-            [org.replikativ.spindel.effects.reactive :refer [await]]
-            [replikativ.logging :as log]))
+            [org.replikativ.spindel.effects.await :refer [await]]
+            #?(:clj [org.replikativ.spindel.spin.cps :refer [spin]])
+            [replikativ.logging :as log])
+  #?(:cljs (:require-macros [org.replikativ.spindel.spin.cps :refer [spin]])))
 
 ;; =============================================================================
 ;; Core Operations
@@ -16,7 +18,7 @@
   Example:
     (await (first pages))  ;=> first-page"
   [aseq]
-  (spin/spin
+  (spin
    (when-let [[v _] (await (anext aseq))]
      v)))
 
@@ -28,7 +30,7 @@
   Example:
     (await (rest pages))  ;=> rest-of-pages"
   [aseq]
-  (spin/spin
+  (spin
    (when-let [[_ rest-seq] (await (anext aseq))]
      rest-seq)))
 
@@ -46,7 +48,7 @@
     (await (reduce conj [] pages))
     (await (reduce + 0 page-counts))"
   ([rf init aseq]
-   (spin/spin
+   (spin
     (loop [acc init
            seq aseq]
       (if seq
@@ -79,7 +81,7 @@
   ([to aseq]
    (reduce conj to aseq))
   ([to xform aseq]
-   (spin/spin
+   (spin
     (let [rf (xform conj)]
       (await (reduce rf to aseq))))))
 
@@ -126,7 +128,7 @@
   (when (seq coll)
     (reify PAsyncSeq
       (anext [_]
-        (spin/spin
+        (spin
          (log/trace :seq/from-coll-emit {:value (clojure.core/first coll)})
          [(clojure.core/first coll)
           (from-coll (clojure.core/rest coll))])))))
@@ -145,7 +147,7 @@
     (defn fetch-pages [api-fn]
       (iterate-async
         (fn [cursor]
-          (spin/spin
+          (spin
             (let [{:keys [page next]} (await (api-fn cursor))]
               (if next
                 {:value page :next-state next :done? false}

--- a/src/org/replikativ/spindel/seq/core.cljc
+++ b/src/org/replikativ/spindel/seq/core.cljc
@@ -5,7 +5,6 @@
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.spin.sync :as sync]
-            [org.replikativ.spindel.spin.combinators :refer [race]]
             [org.replikativ.spindel.effects.await :refer [await]]
             [is.simm.partial-cps.async :as async]
             #?(:clj [is.simm.partial-cps.ioc :as ioc])
@@ -71,16 +70,32 @@
      (binding [ec/*yield-handler* yield-handler]
        (cps-fn resolve-fn reject-fn))))
 
-(deftype ASeqGenerator [gen-id cps-fn shared-term-deferred resolve-fn reject-fn]
+;; `sink-atom` holds the deferred for the *current* anext step. Each anext
+;; resets it to a fresh single-shot deferred that BOTH the yield handler and
+;; the terminal resolve/reject deliver to (tagged `[:yield …]` / `[:ok …]` /
+;; `[:error …]`). The body runs until exactly one of those fires, so the
+;; step-deferred is delivered exactly once, drains its `:pending`, and becomes
+;; GC-eligible. This replaces the previous design — a single long-lived
+;; `shared-term-deferred` raced against a fresh yield-deferred each step — which
+;; stranded one never-removed `resolve` continuation on the shared deferred's
+;; `:pending` per consumed element (the cancelled race loser), accumulating
+;; unboundedly inside engine state for long/infinite generators. anext calls on
+;; a generator are strictly sequential (each yields its continuation in
+;; `rest-gen`), so a single current-step sink is sufficient.
+(deftype ASeqGenerator [gen-id cps-fn sink-atom resolve-fn reject-fn]
   PAsyncSeq
   (anext [_]
     (spin
-     (let [;; Fresh yield deferred for THIS anext call
-           yield-deferred (sync/deferred)
+     (let [;; Fresh single-shot deferred for THIS anext call.
+           step-deferred (sync/deferred)
 
-            ;; Yield handler delivers [:yield marker]
+            ;; Point the terminal resolve/reject (shared closures) at this
+            ;; step's deferred before running the body.
+           _ (reset! sink-atom step-deferred)
+
+            ;; Yield handler delivers [:yield marker] to the same deferred.
            yield-handler (fn [marker _cont]
-                           (yield-deferred [:yield marker]))
+                           (step-deferred [:yield marker]))
 
             ;; Execute CPS with yield-handler bound
             ;; IMPORTANT: Use helper function to establish binding OUTSIDE CPS transformation
@@ -89,13 +104,12 @@
             ;; happens in regular (non-CPS) code.
            _ (execute-cps-with-yield-handler! cps-fn yield-handler resolve-fn reject-fn)
 
-            ;; Race: await whichever completes first
-           result (await (race (spin (await yield-deferred))
-                               (spin (await shared-term-deferred))))]
+            ;; Await the single per-step deferred (no race, nothing to leak).
+           result (await step-deferred)]
 
         ;; Pattern match on result
        (cond
-          ;; Yield won
+          ;; Yielded a value
          (and (vector? result) (= :yield (first result)))
          (let [[_ marker] result
                yield-value (:value marker)
@@ -114,22 +128,22 @@
                rest-gen (ASeqGenerator.
                          (keyword (str (name gen-id) "-cont"))
                          wrapped-cps-fn
-                         shared-term-deferred
+                         sink-atom
                          resolve-fn
                          reject-fn)]
            [yield-value rest-gen])
 
-          ;; Termination won
+          ;; Body completed (sequence terminated)
          (and (vector? result) (= :ok (first result)))
          nil
 
-          ;; Error won
+          ;; Body raised
          (and (vector? result) (= :error (first result)))
          (throw (second result))
 
           ;; Unexpected
          :else
-         (throw (ex-info "Unexpected race result" {:result result}))))))
+         (throw (ex-info "Unexpected gen-aseq step result" {:result result}))))))
 
   Object
   (toString [_this]
@@ -157,24 +171,32 @@
    - Call resolve-fn when complete
    - Call reject-fn on error
 
-   Creates shared termination deferred and resolve/reject functions
-   that are passed to all continuations."
+   The resolve/reject closures (shared across the whole generator chain, since
+   the body's continuation captures them) deliver to whatever per-anext
+   deferred is currently installed in `sink-atom`. anext resets `sink-atom`
+   before running the body, so each step terminates into its own short-lived
+   deferred — nothing accumulates across steps."
   [cps-fn gen-id]
-  ;; Shared termination deferred for entire sequence lifetime
-  (let [shared-term-deferred (sync/deferred)
+  ;; Holds the current anext step's deferred; reset by ASeqGenerator.anext.
+  ;; A plain atom (not a fork-safe runtime atom): it's transient per-step
+  ;; coordination, deliberately kept OUT of engine state so it neither
+  ;; accumulates nor gets copied on fork.
+  (let [sink-atom (atom nil)
 
-        ;; Shared resolve-fn delivers [:ok result] to termination deferred
+        ;; resolve-fn delivers [:ok result] to the current step's deferred.
         resolve-fn (fn [result]
-                     (shared-term-deferred [:ok result])
+                     (when-let [d @sink-atom]
+                       (d [:ok result]))
                      result)
 
-        ;; Shared reject-fn delivers [:error err] to termination deferred
-        ;; Don't throw here - let the race/anext handle the error
+        ;; reject-fn delivers [:error err] to the current step's deferred.
+        ;; Don't throw here - let anext re-throw after awaiting.
         reject-fn (fn [err]
-                    (shared-term-deferred [:error err])
+                    (when-let [d @sink-atom]
+                      (d [:error err]))
                     nil)]
 
-    (ASeqGenerator. gen-id cps-fn shared-term-deferred resolve-fn reject-fn)))
+    (ASeqGenerator. gen-id cps-fn sink-atom resolve-fn reject-fn)))
 
 ;; =============================================================================
 ;; gen-aseq Macro

--- a/src/org/replikativ/spindel/spin/combinators.cljc
+++ b/src/org/replikativ/spindel/spin/combinators.cljc
@@ -74,27 +74,34 @@
         completed (atom 0)
         done? (atom false)
         spin-vec (vec spins)
-        ;; Path in runtime state for this parallel's results
-        results-path [:parallel/results parallel-spin-id]]
+        ;; Initial accumulator for child results — a LOCAL atom, not engine
+        ;; state. Its lifetime is the initial child callbacks (held by the
+        ;; children/deferreds), so it is reclaimed exactly when the initial
+        ;; fan-out finishes — no leak, and no dependence on node-teardown
+        ;; timing (which would race a GC'd-but-still-in-flight parallel).
+        ;; The in-flight accumulation is inherently unforkable anyway (the
+        ;; executor-scheduled children aren't fork-copied), so a local atom
+        ;; loses no real fork-safety here. Once the parallel completes, the
+        ;; result vector is cached on the node, and the reactive phase below
+        ;; reads/updates THAT (per-context, overlay-copied → fork-isolated).
+        results-atom (atom (vec (repeat n nil)))]
     (binding [ec/*execution-context* execution-context]
-      ;; Initialize results vector in runtime state (fork-safe)
-      (ec/swap-state! results-path (constantly (vec (repeat n nil))))
-
       (spin-core/make-spin
        (fn [resolve reject]
          ;; Start each child using CPS (no deref). The child will invoke our callbacks
          ;; when it completes; we coordinate final resolution here.
          (doseq [[i child-spin] (map-indexed vector spin-vec)]
            (let [on-ok (fn [v]
-                         ;; Update result for this child in runtime state (fork-safe)
-                         (ec/swap-state! results-path #(assoc % i v))
+                         ;; Update this child's slot in the local accumulator
+                         ;; (atomic swap! — children complete concurrently).
+                         (swap! results-atom assoc i v)
                          (when (= n (swap! completed inc))
                            ;; All children completed initially
                            (when (compare-and-set! done? false true)
                              ;; Capture initial values BEFORE registering continuations
                              ;; Used to distinguish initial completion events (already in queue)
                              ;; from re-completions (should trigger notifications)
-                             (let [initial-results (vec (ec/get-state results-path))]
+                             (let [initial-results @results-atom]
                                ;; Register continuations for reactive child re-completions
                                ;; This makes parallel reactive: when children re-run due to
                                ;; tracked signal changes, parallel will update and notify awaiters
@@ -112,14 +119,24 @@
                                                       ;; re-completions due to signal changes carry a
                                                       ;; different value.
                                                       (when (not= new-val initial-val)
-                                                        ;; Update result in runtime state (fork-safe)
-                                                        (ec/swap-state! results-path #(assoc % j new-val))
-                                                        ;; Get current results and re-cache
-                                                        (let [current-results (ec/get-state results-path)]
+                                                        ;; Reactive phase: the parallel's result vector
+                                                        ;; now lives on the node's cached result (which is
+                                                        ;; per-context engine state, overlay-copied on fork
+                                                        ;; → fork-isolated). Read the current vector, update
+                                                        ;; slot j, and re-cache. Reactive re-completions are
+                                                        ;; processed serially in the drain loop, so this
+                                                        ;; read-modify-write needs no extra atomicity.
+                                                        ;; `initial-results` is the fallback if the node
+                                                        ;; result isn't a vector yet (shouldn't happen post
+                                                        ;; initial completion, but keeps us robust).
+                                                        (let [cached (ec/spin-current-result parallel-spin-id)
+                                                              base (let [p (when cached (:payload cached))]
+                                                                     (if (vector? p) p initial-results))
+                                                              updated (assoc base j new-val)]
                                                           ;; Re-cache parallel's result to notify our awaiters
                                                           (ec/spin-cache-result!
                                                            parallel-spin-id
-                                                           (spin-core/ok current-results))
+                                                           (spin-core/ok updated))
                                                           ;; Fire completion event to resume awaiting spins
                                                           (ec/enqueue-event!
                                                            {:type :spin-completion :id parallel-spin-id}))))
@@ -156,8 +173,10 @@
                                                    :on-resume (fn [_]
                                                                 (ec/spin-current-result t-id))}]
                                      (ec/continuation-add! parallel-spin-id cont-map))))
-                               ;; Initial resolve with current results from runtime state
-                               (spin-core/resume resolve (ec/get-state results-path))))))
+                               ;; Initial resolve with the accumulated results. The
+                               ;; engine caches this vector on the parallel's node;
+                               ;; the reactive conts above update that cached value.
+                               (spin-core/resume resolve @results-atom)))))
 
                  on-err (fn [e]
                           ;; First error wins; cancel siblings and reject

--- a/src/org/replikativ/spindel/spin/sync.cljc
+++ b/src/org/replikativ/spindel/spin/sync.cljc
@@ -41,7 +41,22 @@
   (#?(:clj invoke :cljs -invoke) [_this resolve _reject]
    ;; ATOMIC check-and-add: Use swap! to check assigned? and add to pending atomically
    ;; This prevents race where assignment happens between check and add-to-pending
-    (let [value-to-resolve (atom nil)
+    (let [current-spin-id ec/*spin-id*
+          current-cancel-token ec/*external-await-cancel-token*
+          ;; Prune already-cancelled readers whenever we add a new one — same
+          ;; cancellation-aware sweep as Mailbox's take. A cancelled await
+          ;; (race loser, cont truncation) leaves its reader in `:pending`,
+          ;; which is only flushed on delivery; a deferred that is awaited-
+          ;; then-cancelled but NEVER delivered would otherwise accumulate
+          ;; readers without bound.
+          ctx (try (ec/current-execution-context)
+                   (catch #?(:clj Throwable :cljs :default) _ nil))
+          cancelled-tokens (when ctx (ec/get-state [:engine/cancelled-tokens]))
+          dead-reader? (fn [{:keys [spin-id cancel-token]}]
+                         (or (and spin-id (ec/spin-is-cancelled? spin-id))
+                             (and cancel-token cancelled-tokens
+                                  (contains? cancelled-tokens cancel-token))))
+          value-to-resolve (atom nil)
           _result-state (swap! state-atom
                                (fn [state]
                                  (if (:assigned? state)
@@ -49,8 +64,15 @@
                                    (do
                                      (reset! value-to-resolve (:value state))
                                      state)
-                                 ;; Not assigned - add to pending
-                                   (update state :pending (fnil conj []) resolve))))]
+                                 ;; Not assigned - prune dead readers, then add ours
+                                   (update state :pending
+                                           (fn [ps]
+                                             (conj (if ctx
+                                                     (filterv (complement dead-reader?) (or ps []))
+                                                     (or ps []))
+                                                   {:spin-id current-spin-id
+                                                    :cancel-token current-cancel-token
+                                                    :resolve resolve}))))))]
       (if-let [value @value-to-resolve]
        ;; Was already assigned - resolve immediately
        ;; CRITICAL: Reset *in-trampoline* to ensure Thunks from recur are trampolined
@@ -212,6 +234,22 @@
    ;; ATOMIC check-and-take or add-to-waiters
     (let [current-spin-id ec/*spin-id*
           current-cancel-token ec/*external-await-cancel-token*
+          ;; Prune already-cancelled waiters whenever we add a new one. A
+          ;; cancelled await (race loser, signal-change cont truncation)
+          ;; leaves its waiter behind: `post-inline!` only skips/drops
+          ;; cancelled waiters when a message ARRIVES, so a mailbox that's
+          ;; taken-but-never-posted would accumulate them without bound. By
+          ;; sweeping here we bound `:waiters` to the live waiters between
+          ;; consecutive takes (the same cancelled-detection `post-inline!`
+          ;; uses: whole-spin cancellation OR a cancel-token in
+          ;; `:engine/cancelled-tokens`).
+          ctx (try (ec/current-execution-context)
+                   (catch #?(:clj Throwable :cljs :default) _ nil))
+          cancelled-tokens (when ctx (ec/get-state [:engine/cancelled-tokens]))
+          dead-waiter? (fn [{:keys [spin-id cancel-token]}]
+                         (or (and spin-id (ec/spin-is-cancelled? spin-id))
+                             (and cancel-token cancelled-tokens
+                                  (contains? cancelled-tokens cancel-token))))
           msg-to-resolve (atom ::not-found)
           _result (swap! state-atom
                          (fn [state]
@@ -221,10 +259,13 @@
                                (reset! msg-to-resolve (peek (:queue state)))
                              ;; Remove front element
                                (update state :queue pop))
-                           ;; Queue empty - add to waiters with spin-id + cancel-token
-                             (update state :waiters conj {:spin-id current-spin-id
-                                                          :cancel-token current-cancel-token
-                                                          :resolve resolve}))))]
+                           ;; Queue empty - prune dead waiters, then add ours
+                             (update state :waiters
+                                     (fn [ws]
+                                       (conj (if ctx (filterv (complement dead-waiter?) ws) ws)
+                                             {:spin-id current-spin-id
+                                              :cancel-token current-cancel-token
+                                              :resolve resolve}))))))]
 
       (if (not= ::not-found @msg-to-resolve)
        ;; Got message - resume continuation immediately

--- a/test/org/replikativ/spindel/dom/deferred_eviction_test.clj
+++ b/test/org/replikativ/spindel/dom/deferred_eviction_test.clj
@@ -40,6 +40,25 @@
         (is (some? (cache/get-slot-cache :el-live))
             "address still claimed in *rendered-addrs* is spared")))))
 
+(deftest flush-removes-element-registry-entry-on-unmount
+  (testing "flush-pending-evictions! drops the discharge's addr->element entry
+            for unmounted addresses, but spares addresses re-claimed live (#8)"
+    (with-ctx [_ctx]
+      (let [{:keys [discharge elements]} (disch/make-mock-discharge)]
+        ;; Register an element at each address (as render-initial! would).
+        (disch/set-element! discharge :el-dead :node-dead)
+        (disch/set-element! discharge :el-live :node-live)
+        (binding [disch/*pending-evictions* (atom #{})
+                  disch/*rendered-addrs*    (atom {:el-live {:tag :div :addr :el-live}})]
+          (#'disch/call-refs-on-unmount! {:tag :div :addr :el-dead})
+          (#'disch/call-refs-on-unmount! {:tag :div :addr :el-live})
+          ;; Pass the discharge so flush also prunes the element registry.
+          (disch/flush-pending-evictions! discharge)
+          (is (nil? (get @elements :el-dead))
+              "unmounted address must be removed from the element registry")
+          (is (= :node-live (get @elements :el-live))
+              "address still claimed by a live element must be retained"))))))
+
 (deftest eager-eviction-fallback-without-render-pass
   (testing "Outside a render pass (no *pending-evictions* binding) eviction is eager"
     (with-ctx [_ctx]

--- a/test/org/replikativ/spindel/dom/seq_diff_test.cljc
+++ b/test/org/replikativ/spindel/dom/seq_diff_test.cljc
@@ -472,6 +472,7 @@
   (set-text-content! [_ el t]   (disch/set-text-content! inner el t))
   (get-element     [_ addr]     (disch/get-element inner addr))
   (set-element!    [_ addr el]  (disch/set-element! inner addr el))
+  (remove-element! [_ addr]     (disch/remove-element! inner addr))
   (remove-children-range! [this p s n]
     (disch/default-remove-children-range! this p s n))
   (insert-children! [this p cs s]

--- a/test/org/replikativ/spindel/seq/leak_test.clj
+++ b/test/org/replikativ/spindel/seq/leak_test.clj
@@ -104,8 +104,31 @@
                0
                (:atoms state))))
 
+(defn- gc-until
+  "Force GC up to `tries` times (short pauses) until `(pred)` holds, returning
+  the final `(pred)`.
+
+  The two GC-dependent guards (#2 consumed-value release, #5 parallel
+  engine-state reclamation) rely on `System/gc`, which is advisory — a single
+  pass may not collect everything. Retrying until the expected condition holds
+  (or we give up) removes the only real flake surface; the assertion that
+  follows still fails loudly if the condition never becomes true. The
+  structural guards below take no GC and need none of this."
+  [pred tries]
+  (loop [i 0]
+    (let [ok (pred)]
+      (if (or ok (>= i tries))
+        ok
+        (do (System/gc) (Thread/sleep 80) (recur (inc i)))))))
+
 ;; =============================================================================
 ;; #1 — gen-aseq shared-term-deferred pending leak
+;;
+;; STRUCTURAL guard (deterministic, no GC/timing): `engine-undelivered-pending`
+;; reads exact engine state. Post-fix the measured value is 0 every run (the
+;; per-anext deferred is always delivered); pre-fix it was 97 after 100 items.
+;; The `<= 5` bound is an O(1)-vs-O(N) discriminator with headroom for benign
+;; transients — NOT a fuzzy threshold.
 ;; =============================================================================
 
 (deftest gen-aseq-no-shared-deferred-pending-leak
@@ -154,36 +177,36 @@
           ;; sequence head is passed straight into the driver, never bound).
           mid (drive-cps-aseq! (psq/sequence (map identity) src) k)]
       (is (some? mid) "precondition: mid-stream node exists")
-      (dotimes [_ 3] (System/gc) (Thread/sleep 50))
-      ;; Of the first k elements (all consumed before `mid`), most must be GC'd.
-      ;; NOTE: `mid` MUST stay strongly reachable across the System/gc above and
-      ;; into the assertion below — that is the whole point (a held mid-stream
-      ;; node must not pin earlier elements). It is referenced in the message
+      ;; GC-DEPENDENT guard. Of the first k elements (all consumed before the
+      ;; held `mid` node), most must be collectable — a held mid-stream node
+      ;; must not pin earlier elements. `System/gc` is advisory, so retry via
+      ;; `gc-until` rather than a fixed number of passes (removes the flake
+      ;; surface). In practice all 100 clear; `>= 0.8k` tolerates GC laziness
+      ;; while still cleanly separating fixed (0 cleared pre-fix) from released.
+      ;;
+      ;; NOTE: `mid` MUST stay strongly reachable across the GCs and into the
+      ;; assertion — that is the whole point. It is referenced in the message
       ;; expression so JVM locals-clearing keeps it live until the `is` runs;
       ;; without that reference it gets nulled early and the buffer is collected
       ;; regardless of any leak, masking the bug.
-      (let [first-k (take k refs)
-            cleared (count (filter #(nil? (.get ^WeakReference %)) first-k))]
-        (is (>= cleared (int (* 0.8 k)))
-            (str "sequence retains consumed values: only " cleared "/" k
+      (let [threshold (int (* 0.8 k))
+            cleared #(count (filter (fn [w] (nil? (.get ^WeakReference w)))
+                                    (take k refs)))]
+        (gc-until #(>= (cleared) threshold) 15)
+        (is (>= (cleared) threshold)
+            (str "sequence retains consumed values: only " (cleared) "/" k
                  " elements consumed before the held node were GC'd "
                  "(expected most — a held node must not pin earlier elements); "
                  "held node present=" (some? mid)))))))
 
 ;; =============================================================================
 ;; #5 — parallel must not accumulate per-call engine state
+;;
+;; GC-DEPENDENT guard: node/`:parallel-results` reclamation is triggered by the
+;; Spin Cleaner, so we converge via `gc-until`. Post-fix the engine-state size
+;; returns to baseline every run (measured 0 → 0); pre-fix it grew by one
+;; permanent entry per call. The `<= base + 8` bound is reclamation headroom.
 ;; =============================================================================
-
-(defn- gc-until
-  "Force GC up to `tries` times (short pauses) until `(pred)` holds. Node
-  reclamation is GC-triggered (Cleaner -> try-gc-cleanup-spin!), so we converge
-  via repeated System/gc rather than assert on a single pass."
-  [pred tries]
-  (loop [i 0]
-    (let [ok (pred)]
-      (if (or ok (>= i tries))
-        ok
-        (do (System/gc) (Thread/sleep 80) (recur (inc i)))))))
 
 (deftest parallel-does-not-accumulate-engine-state
   (testing "repeated parallel calls must not leave per-call entries in engine
@@ -211,6 +234,12 @@
 
 ;; =============================================================================
 ;; #3 — Mailbox prunes cancelled waiters
+;;
+;; STRUCTURAL guard (deterministic). Measured `:waiters` is exactly 1 every run
+;; (pre-fix ~29). The residual 1 is expected, not noise: pruning happens when
+;; the NEXT take arrives, so the final race's cancelled waiter has no successor
+;; to prune it. It stays at 1, never grows — the `<= 5` bound is O(1) headroom.
+;; (#3/#6/#7 are the same prune-on-read design and all sit at a stable 1.)
 ;; =============================================================================
 
 (deftest mailbox-prunes-cancelled-waiters
@@ -234,6 +263,10 @@
 
 ;; =============================================================================
 ;; #4 — pub does not accumulate idle (unsubscribed) topic mults
+;;
+;; STRUCTURAL guard (deterministic). Measured topic-mult count is exactly 1
+;; (the single subscribed topic) every run; pre-fix it was 40 (one per distinct
+;; topic seen). `<= 5` is O(subscribed-topics) headroom.
 ;; =============================================================================
 
 (deftest pub-does-not-accumulate-idle-topics
@@ -267,6 +300,9 @@
 
 ;; =============================================================================
 ;; #6 — Deferred prunes cancelled readers (same pattern as Mailbox #3)
+;;
+;; STRUCTURAL guard (deterministic): `:pending` is a stable 1 (the last
+;; cancelled reader, no successor to prune it); pre-fix ~10. See #3.
 ;; =============================================================================
 
 (deftest deferred-prunes-cancelled-readers
@@ -288,6 +324,9 @@
 
 ;; =============================================================================
 ;; #7 — Semaphore prunes cancelled acquirers (same pattern as Mailbox #3)
+;;
+;; STRUCTURAL guard (deterministic): `:waiting-queue` is a stable 1 (the last
+;; cancelled acquirer, no successor to prune it); pre-fix ~29. See #3.
 ;; =============================================================================
 
 (deftest semaphore-prunes-cancelled-acquirers

--- a/test/org/replikativ/spindel/seq/leak_test.clj
+++ b/test/org/replikativ/spindel/seq/leak_test.clj
@@ -1,0 +1,310 @@
+(ns org.replikativ.spindel.seq.leak-test
+  "Retention / memory-leak REGRESSION GUARDS for the async-sequence + sync +
+  pubsub stack. Each pins a leak found in the 2026-05 retention audit and
+  fixed in the same pass — they must stay green:
+
+  - #1 `gen-aseq` shared-term-deferred `:pending` accumulation (one dead await
+    continuation per consumed element, living in engine state). Fixed: a
+    single-shot per-`anext` deferred, no shared accumulator.
+  - #2 partial-cps `sequence` retaining already-consumed elements (a held
+    mid-stream node pinning the whole consumed prefix). Fixed: lazy-cell
+    rewrite that releases the consumed prefix.
+  - #3 `Mailbox` stranded waiters — a cancelled `await` left its waiter in
+    `:waiters` (pruned only on a later post). Fixed: prune cancelled waiters
+    on take too.
+  - #4 `pub` idle-topic mults — a high-cardinality topic-fn auto-created one
+    mult per distinct topic, never reclaimed. Fixed: the pump routes only to
+    subscribed topics (others dropped), and a topic is reclaimed on last untap.
+  - #5 `parallel` orphaning a permanent per-call `[:parallel/results <id>]`
+    entry in engine state. Fixed: initial accumulator in a LOCAL atom, reactive
+    result on the spin's node (reclaimed by normal teardown).
+  - #6 `Deferred` `:pending` — same pattern as #3 (cancelled awaits on a
+    never-delivered deferred stranded their reader). Fixed: thread the cancel
+    token, prune cancelled readers on await.
+  - #7 `Semaphore` `:waiting-queue` — same pattern (cancelled acquires
+    stranded their waiter, and `release` would hand the permit to a dead
+    acquirer). Fixed: prune cancelled acquirers on acquire, skip them on release.
+
+  (#3, #6, #7 are one consistency fix — cancellation-aware wait-list pruning —
+  applied uniformly across the three sync primitives.)
+
+  JVM-only (`.clj`): the structural probes read engine internals and the #2
+  retention probe uses java.lang.ref.WeakReference, neither of which has a
+  CLJS equivalent."
+  (:refer-clojure :exclude [await])
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.engine.state-backend :as backend]
+            [org.replikativ.spindel.seq.core :refer [gen-aseq yield]]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.spin.combinators :refer [parallel race]]
+            [org.replikativ.spindel.spin.sync :as sync]
+            [org.replikativ.spindel.semaphore :as sem]
+            [org.replikativ.spindel.pubsub.pub :as pub]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [is.simm.partial-cps.sequence :as psq :refer [anext]])
+  (:import [java.lang.ref WeakReference]))
+
+;; =============================================================================
+;; Drivers
+;; =============================================================================
+
+(defn drive-spin-aseq!
+  "Consume up to `n` steps of a spindel PAsyncSeq (whose `anext` returns a Spin)
+  by blocking deref. Returns the rest-seq after `n` steps, or nil if exhausted."
+  [aseq n]
+  (loop [s aseq i 0]
+    (if (and s (< i n))
+      (if-let [pair @(anext s)]
+        (recur (second pair) (inc i))
+        nil)
+      s)))
+
+(defn run-cps!
+  "Run a partial-cps CPS fn to completion synchronously (all resolves on this
+  test's sources fire inline)."
+  [cps]
+  (let [out (atom ::none)
+        err (atom ::none)]
+    (cps (fn [v] (reset! out v)) (fn [e] (reset! err e)))
+    (when (not= ::none @err) (throw @err))
+    @out))
+
+(defn drive-cps-aseq!
+  "Consume up to `n` steps of a partial-cps PAsyncSeq (whose `anext` returns a
+  raw CPS fn). Returns the rest-seq node after `n` steps, or nil if exhausted."
+  [aseq n]
+  (loop [s aseq i 0]
+    (if (and s (< i n))
+      (if-let [pair (run-cps! (anext s))]
+        (recur (second pair) (inc i))
+        nil)
+      s)))
+
+;; =============================================================================
+;; Engine-state probe
+;; =============================================================================
+
+(defn engine-undelivered-pending
+  "Total resolve-continuations sitting in *undelivered* Deferred `:pending`
+  vectors across the context's `:atoms` map.
+
+  This is the direct, fix-agnostic signal of the gen-aseq shared-deferred
+  leak: a never-delivered shared deferred accumulates one pending entry per
+  consumed element, so this scales with consumption pre-fix and stays O(1)
+  post-fix (each per-anext deferred is delivered, leaving `:pending` empty)."
+  [ctx]
+  (let [state (backend/backend-deref (:backend ctx))]
+    (reduce-kv (fn [acc _id entry]
+                 (let [v (:value entry)]
+                   (if (and (map? v) (contains? v :pending) (not (:assigned? v)))
+                     (+ acc (count (:pending v)))
+                     acc)))
+               0
+               (:atoms state))))
+
+;; =============================================================================
+;; #1 — gen-aseq shared-term-deferred pending leak
+;; =============================================================================
+
+(deftest gen-aseq-no-shared-deferred-pending-leak
+  (testing "consuming a long gen-aseq must not accumulate dead await
+            continuations in engine state (shared-term-deferred :pending)"
+    (let [ctx (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* ctx]
+          (let [g (gen-aseq
+                   (loop [k 0]
+                     (when (< k 100000)
+                       (yield k)
+                       (recur (inc k)))))]
+            (drive-spin-aseq! g 100)
+            (let [pending (engine-undelivered-pending ctx)]
+              (is (<= pending 5)
+                  (str "gen-aseq leak: " pending " undelivered await continuations "
+                       "accumulated in engine state after consuming 100 elements "
+                       "(expected O(1))")))))
+        (finally
+          (ctx/stop-context! ctx))))))
+
+;; =============================================================================
+;; #2 — partial-cps `sequence` consumed-value retention
+;; =============================================================================
+
+(deftest sequence-does-not-retain-consumed-values
+  (testing "partial-cps `sequence` must release elements once the consumer has
+            advanced past them; holding a mid-stream node must not pin earlier
+            elements"
+    (let [n 200
+          k 100
+          refs (java.util.ArrayList.)
+          ;; Source produces a fresh sentinel Object per element from an int
+          ;; counter, so the source chain itself retains only the int — the
+          ;; ONLY retention path for the objects is the transducer's buffer.
+          src (psq/make-generator-seq
+               (fn [idx]
+                 (fn [resolve _reject]
+                   (resolve (when (< idx n)
+                              (let [o (Object.)]
+                                (.add refs (WeakReference. o))
+                                [o (inc idx)])))))
+               0)
+          ;; Advance to the node at index k WITHOUT retaining the head (the
+          ;; sequence head is passed straight into the driver, never bound).
+          mid (drive-cps-aseq! (psq/sequence (map identity) src) k)]
+      (is (some? mid) "precondition: mid-stream node exists")
+      (dotimes [_ 3] (System/gc) (Thread/sleep 50))
+      ;; Of the first k elements (all consumed before `mid`), most must be GC'd.
+      ;; NOTE: `mid` MUST stay strongly reachable across the System/gc above and
+      ;; into the assertion below — that is the whole point (a held mid-stream
+      ;; node must not pin earlier elements). It is referenced in the message
+      ;; expression so JVM locals-clearing keeps it live until the `is` runs;
+      ;; without that reference it gets nulled early and the buffer is collected
+      ;; regardless of any leak, masking the bug.
+      (let [first-k (take k refs)
+            cleared (count (filter #(nil? (.get ^WeakReference %)) first-k))]
+        (is (>= cleared (int (* 0.8 k)))
+            (str "sequence retains consumed values: only " cleared "/" k
+                 " elements consumed before the held node were GC'd "
+                 "(expected most — a held node must not pin earlier elements); "
+                 "held node present=" (some? mid)))))))
+
+;; =============================================================================
+;; #5 — parallel must not accumulate per-call engine state
+;; =============================================================================
+
+(defn- gc-until
+  "Force GC up to `tries` times (short pauses) until `(pred)` holds. Node
+  reclamation is GC-triggered (Cleaner -> try-gc-cleanup-spin!), so we converge
+  via repeated System/gc rather than assert on a single pass."
+  [pred tries]
+  (loop [i 0]
+    (let [ok (pred)]
+      (if (or ok (>= i tries))
+        ok
+        (do (System/gc) (Thread/sleep 80) (recur (inc i)))))))
+
+(deftest parallel-does-not-accumulate-engine-state
+  (testing "repeated parallel calls must not leave per-call entries in engine
+            state: there must be NO :parallel/results side key, and overall
+            engine state must return to baseline once parallels are dropped"
+    (let [ctx (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* ctx]
+          (let [state-size (fn []
+                             (let [s (backend/backend-deref (:backend ctx))]
+                               (+ (count (:nodes s))
+                                  (count (:parallel/results s)) ; must remain 0 (key removed)
+                                  (count (:spin-aux s)))))
+                base (state-size)]
+            (dotimes [_ 80] @(parallel (spin 1) (spin 2) (spin 3)))
+            (gc-until #(<= (state-size) (+ base 8)) 15)
+            (let [s (backend/backend-deref (:backend ctx))]
+              (is (empty? (:parallel/results s))
+                  "parallel must not store a permanent per-call :parallel/results entry")
+              (is (<= (state-size) (+ base 8))
+                  (str "parallel engine-state leak: size " (state-size)
+                       " after 80 parallels dropped + GC (baseline " base ")")))))
+        (finally
+          (ctx/stop-context! ctx))))))
+
+;; =============================================================================
+;; #3 — Mailbox prunes cancelled waiters
+;; =============================================================================
+
+(deftest mailbox-prunes-cancelled-waiters
+  (testing "cancelled mailbox awaits must not accumulate in :waiters; taking
+            sweeps out waiters whose await was cancelled"
+    (let [ctx (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* ctx]
+          (let [mbx (sync/mailbox)]
+            ;; Each race cancels the losing (await mbx) branch. No message is
+            ;; ever posted, so without on-take pruning these waiters would
+            ;; accumulate one per iteration.
+            (dotimes [_ 30]
+              @(race (spin :winner) (spin (await mbx))))
+            (let [waiters (count (:waiters @(.-state-atom mbx)))]
+              (is (<= waiters 5)
+                  (str "mailbox waiter leak: " waiters " stranded waiters after "
+                       "30 cancelled awaits (expected O(1))")))))
+        (finally
+          (ctx/stop-context! ctx))))))
+
+;; =============================================================================
+;; #4 — pub does not accumulate idle (unsubscribed) topic mults
+;; =============================================================================
+
+(deftest pub-does-not-accumulate-idle-topics
+  (testing "a high-cardinality topic-fn must not create a mult per distinct
+            topic; only subscribed topics get a mult, others are dropped"
+    (let [ctx (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* ctx]
+          (let [n 40
+                items (vec (for [i (range n)] {:topic (keyword (str "t" i)) :v i}))
+                src (gen-aseq
+                     (loop [xs items]
+                       (when (seq xs)
+                         (yield (first xs))
+                         (recur (rest xs)))))
+                p (pub/pub src :topic)]
+            (pub/sub p :t0)             ; one subscriber; starts the pump
+            ;; Wait for the pump to drain the source.
+            (loop [tries 0]
+              (when (and (not (pub/pub-closed? p)) (< tries 300))
+                (Thread/sleep 10)
+                (recur (inc tries))))
+            (is (pub/pub-closed? p) "precondition: pump drained the source")
+            (let [topics (count @(:mults-atom p))]
+              (is (<= topics 5)
+                  (str "pub topic leak: " topics " topic mults retained for "
+                       n " distinct topics with a single subscriber "
+                       "(expected O(subscribed-topics))")))))
+        (finally
+          (ctx/stop-context! ctx))))))
+
+;; =============================================================================
+;; #6 — Deferred prunes cancelled readers (same pattern as Mailbox #3)
+;; =============================================================================
+
+(deftest deferred-prunes-cancelled-readers
+  (testing "cancelled awaits on a never-delivered deferred must not accumulate
+            in :pending; awaiting sweeps out cancelled readers"
+    (let [ctx (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* ctx]
+          (let [d (sync/deferred)]
+            ;; d is never delivered; each race cancels the losing (await d).
+            (dotimes [_ 30]
+              @(race (spin :winner) (spin (await d))))
+            (let [pending (count (:pending @(.-state-atom d)))]
+              (is (<= pending 5)
+                  (str "deferred :pending leak: " pending " stranded readers after "
+                       "30 cancelled awaits (expected O(1))")))))
+        (finally
+          (ctx/stop-context! ctx))))))
+
+;; =============================================================================
+;; #7 — Semaphore prunes cancelled acquirers (same pattern as Mailbox #3)
+;; =============================================================================
+
+(deftest semaphore-prunes-cancelled-acquirers
+  (testing "cancelled acquires on an exhausted semaphore must not accumulate
+            in :waiting-queue; acquiring sweeps out cancelled acquirers"
+    (let [ctx (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* ctx]
+          (let [s (sem/semaphore 1)]
+            ;; Take the only permit so every subsequent acquire must queue.
+            @(sem/acquire s)
+            ;; Each race cancels the losing acquire spin directly.
+            (dotimes [_ 30]
+              @(race (spin :winner) (sem/acquire s)))
+            (let [waiters (count (ec/get-state [:semaphores (.-id s) :waiting-queue]))]
+              (is (<= waiters 5)
+                  (str "semaphore :waiting-queue leak: " waiters " stranded "
+                       "acquirers after 30 cancelled acquires (expected O(1))")))))
+        (finally
+          (ctx/stop-context! ctx))))))

--- a/test/org/replikativ/spindel/spin/parallel_test.cljc
+++ b/test/org/replikativ/spindel/spin/parallel_test.cljc
@@ -472,3 +472,47 @@
                                    (second batch-spins)
                                    (nth batch-spins 2))]
              (is (= [25 25 25] result) "Should complete with externally created model")))))))
+
+;; =============================================================================
+;; CLJ-only: fork-isolation of a REACTIVE parallel
+;; =============================================================================
+;;
+;; Regression guard for the #5 fix (parallel results moved off a permanent
+;; engine side-key onto the spin's node). The reactive phase reads/updates the
+;; node's cached result, which is per-context (overlay-copied on fork) — so a
+;; signal change in a fork must update only the fork's parallel result and
+;; leave the parent's untouched.
+
+#?(:clj
+   (deftest test-parallel-reactive-fork-isolation
+     (testing "A reactive parallel's result updates per-context: changing a
+               tracked signal in a fork must not mutate the parent's result"
+       (let [parent (ctx/create-execution-context
+                     {:executor (sched/thread-pool-executor 4)})]
+         (try
+           (let [par (binding [ec/*execution-context* parent]
+                       (let [sig (signal 10)
+                             p   (parallel (spin (:new (track sig))) (spin :static))]
+                         @p
+                         (simple/await-drain-complete! parent)
+                         {:sig sig :p p}))
+                 {:keys [sig p]} par
+                 ;; The same `parallel` results never live in a side key.
+                 _ (is (not (contains? (rtp/get-state parent []) :parallel/results))
+                       "parallel must not create a :parallel/results engine key")
+                 fork (ctx/fork-context parent)]
+             ;; Mutate the tracked signal ONLY in the fork, then drain the fork.
+             (binding [ec/*execution-context* fork]
+               (reset! sig 99)
+               (simple/await-drain-complete! fork))
+             (let [pid          (spin-core/spin-id p)
+                   parent-result (:payload (binding [ec/*execution-context* parent]
+                                             (ec/spin-current-result pid)))
+                   fork-result   (:payload (binding [ec/*execution-context* fork]
+                                             (ec/spin-current-result pid)))]
+               (is (= [10 :static] parent-result)
+                   "parent's parallel result must be unchanged by the fork")
+               (is (= [99 :static] fork-result)
+                   "fork's parallel result must reflect the fork-local signal change")))
+           (finally
+             (ctx/close-context! parent)))))))


### PR DESCRIPTION
## What

A retention audit of the async-sequence + reactive stack found a recurring leak pattern — *a registration added on the happy path but never removed on cancellation/teardown* — plus several subsystem-specific cases. This PR fixes all of them, each with a regression guard where practically testable. (The `incremental`/delta subsystem audited clean.)

Depends on **partial-cps 0.1.55** (commit 1), which carries the matching `sequence` fix (#2 below, fixed in that repo).

## Findings & fixes

**Core async-seq / sync (the recurring pattern):**
- **#1 `gen-aseq`** raced a fresh yield-deferred against one long-lived shared-term-deferred; the cancelled losing branch stranded a `resolve` in `:pending` every step → unbounded growth in engine state. Now a single per-`anext` deferred, no shared accumulator.
- **#2 partial-cps `sequence`** retained every consumed element in a shared monotonic buffer → fixed in partial-cps 0.1.55 (lazy-cell rewrite); consumed here via the dep bump.
- **#3/#6/#7 Mailbox / Deferred / Semaphore** stranded cancelled waiters (pruned only on post/deliver/release). Now pruned on the read/acquire side too; `release` skips a cancelled acquirer so the permit isn't lost.

**Other subsystems:**
- **#4 pub** auto-created a topic mult per distinct topic and never reclaimed it. Now routes only to subscribed topics (others dropped, per `test-pub-unsubscribed-topics-dropped` / core.async), and reclaims a topic on last untap.
- **#5 `parallel`** orphaned a permanent `[:parallel/results <id>]` engine key. Now a local atom for initial fan-out + the spin's node for reactive results (fork-isolated, reclaimed on teardown).
- **#8–#11 DOM**: discharge's `addr→element` registry retained detached nodes on unmount → added `remove-element!` wired through `flush-pending-evictions!`; `evict-cache!` also reclaims `:dom/foreign` / `:dom/keyed-cache`; `render-spin!`'s `:stop!` now actually cancels the render spin.
- **#12 inference**: `bbvi-infer` accumulated every iteration's forked contexts; now bounded to the tail it uses.
- **#13/#14 distributed**: inspector `object-cache` is now per-session (was a process-global); added `fail-all-response-handlers!` as an abandonment primitive for pending remote invocations.

Also: repaired `seq.combinators`' broken requires (it referenced two non-existent namespaces and couldn't load).

## Tests

New `seq/leak_test.clj` pins #1–#8 (structural engine-state assertions + a `WeakReference` retention check for the sequence fix), plus a `parallel` reactive **fork-isolation** test and a discharge element-registry eviction assertion.

- `clojure -M:format` — clean
- `clojure -X:test` (JVM) — **810 tests / 2750 assertions, 0 failures**
- `npx shadow-cljs compile test` (CLJS) — **378 tests / 1414 assertions, 0 failures**

## Notes
- `inspector.clj`'s large diff is mostly cljfmt re-indentation from wrapping the closure map; the semantic change (global → per-session cache) is small.
- #14's registry currently has no production caller/disconnect hook; the fix adds the abandonment primitive for when one is wired.