### PR TITLE
fix: exclude clojure.core/await in namespaces that refer spindel's await

### DIFF
--- a/src/org/replikativ/spindel/core.cljc
+++ b/src/org/replikativ/spindel/core.cljc
@@ -7,7 +7,7 @@
      (require '[org.replikativ.spindel.core :as s :refer [spin signal await track]])
 
    For advanced usage, require individual namespaces directly."
-  (:refer-clojure :exclude [for atom])
+  (:refer-clojure :exclude [for atom await])
   (:require
    [org.replikativ.spindel.engine.core :as ec]
    [org.replikativ.spindel.engine.context :as ctx]

--- a/src/org/replikativ/spindel/pubsub/mult.cljc
+++ b/src/org/replikativ/spindel/pubsub/mult.cljc
@@ -12,6 +12,7 @@
 
    Unlike core.async channels, PAsyncSeq is copy-on-read, so mult provides
    the coordination layer for synchronized fan-out."
+  (:refer-clojure :exclude [await])
   (:require [is.simm.partial-cps.sequence :refer [PAsyncSeq anext]]
             [org.replikativ.spindel.pubsub.buffer :as buf]
             [org.replikativ.spindel.spin.core :as spin-core]

--- a/src/org/replikativ/spindel/pubsub/partitioned.cljc
+++ b/src/org/replikativ/spindel/pubsub/partitioned.cljc
@@ -14,6 +14,7 @@
    fills up, the pump spin blocks. This backs up the entire source (same
    as Rama). Use dropping-buffer or sliding-buffer if independent partition
    throughput is needed."
+  (:refer-clojure :exclude [await])
   (:require [is.simm.partial-cps.sequence :refer [PAsyncSeq anext]]
             [org.replikativ.spindel.pubsub.mult :as mult]
             [org.replikativ.spindel.pubsub.buffer :as buf]

--- a/src/org/replikativ/spindel/pubsub/pub.cljc
+++ b/src/org/replikativ/spindel/pubsub/pub.cljc
@@ -14,6 +14,7 @@
      (def p (pub source-aseq :type))
      (def events-sub (sub p :user-event))
      (def logs-sub (sub p :log-entry))"
+  (:refer-clojure :exclude [await])
   (:require [is.simm.partial-cps.sequence :refer [PAsyncSeq anext]]
             [org.replikativ.spindel.pubsub.mult :as mult]
             [org.replikativ.spindel.spin.core :as spin-core]

--- a/src/org/replikativ/spindel/seq/core.cljc
+++ b/src/org/replikativ/spindel/seq/core.cljc
@@ -1,6 +1,6 @@
 (ns org.replikativ.spindel.seq.core
   "Core async sequence generation - gen-aseq macro and yield"
-  (:refer-clojure :exclude [for])
+  (:refer-clojure :exclude [for await])
   (:require [is.simm.partial-cps.sequence :as pcps-seq :refer [PAsyncSeq]]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.spin.core :as spin-core]


### PR DESCRIPTION
Namespaces that refer (or define) `await` print a load-time warning on every startup:

```
WARNING: await already refers to: #'clojure.core/await in namespace: org.replikativ.spindel.pubsub.mult, being replaced by: #'org.replikativ.spindel.effects.await/await
```

(also pubsub.pub, pubsub.partitioned, seq.core, and spindel.core).

Fix: add `(:refer-clojure :exclude [await])` to each affected ns (extending the existing exclude vectors in `core`/`seq.core`), making the shadow intentional and silent. No behavior change. Verified: the namespaces load with no `await already refers` warnings.