### PR TITLE
feat(yggdrasil): composite workspace — collapse the spindel↔yggdrasil bridge

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
         riddley/riddley {:mvn/version "0.2.0"}
         org.replikativ/logging {:mvn/version "0.1.3"}
         is.simm/partial-cps {:mvn/version "0.1.55"}
-        org.replikativ/yggdrasil {:mvn/version "0.1.6"}
+        org.replikativ/yggdrasil {:mvn/version "0.2.27"}
         org.replikativ/hasch {:mvn/version "0.3.97"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         anglican/anglican {:mvn/version "1.1.0"}

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -1,58 +1,72 @@
 (ns org.replikativ.spindel.yggdrasil
   "Yggdrasil integration for spindel execution contexts.
 
-   Provides fork-safe references to yggdrasil systems (git, datahike, btrfs, etc.)
-   that automatically resolve from the current execution context.
+   A context holds ONE pforkable external-ref: a yggdrasil `CompositeSystem`
+   *workspace* of all registered systems (git + chat-db + KB + code-index + …).
+   `register!` composes each system into that one workspace; forking forks the
+   workspace as a unit (shared branch namespace across all sub-systems); diff /
+   merge / discard are single workspace operations.
 
    Key concepts:
-   - YggRef: Reference type wrapping system ID, resolves via *execution-context*
-   - register!: Register a yggdrasil system as external-ref, returns YggRef
-   - fork-context automatically forks all external-refs via PForkable protocol
-   - merge-fork!/discard-fork!: Parent-controlled merge/discard of forked branches
+   - register!: compose a yggdrasil system into the context's workspace
+     (stored once at [:external-refs ::workspace]); returns a YggRef keyed by
+     the system's id.
+   - YggRef / system / get-system: resolve a sub-system id THROUGH the
+     workspace composite — transparently branch-correct in forked contexts.
+   - fork-context forks the single workspace via the PForkable protocol
+     (CompositeSystem is Branchable → its branch! fans out to every sub-system
+     with the SAME fork branch name).
+   - workspace-diff / workspace-conflicts: per-sub-system delta vs parent, using
+     the per-system MERGE-BASE (mixed native bases — datahike :db, git main).
+   - merge-to-parent! / discard-from-parent!: parent-controlled, transactional
+     merge / discard of the fork's branches.
 
-   Naming convention: Prefix YggRef vars with 'y' (e.g., ygit, ydb) to signal deref needed.
+   Naming convention: Prefix YggRef vars with 'y' (e.g., ygit, ydb) to signal
+   deref needed.
 
    Example:
-     (def ygit (ygg/register! (git/create \".\")))
-     (def ydb (ygg/register! (dh/connect cfg)))
+     (def ygit (ygg/register! (git/create \".\")))   ; workspace = {git}
+     (def ydb  (ygg/register! (dh/connect cfg)))      ; workspace = {git, db}
 
-     @ygit  ; => GitSystem in current context
+     @ygit                      ; => the git sub-system in the current context
+     (ygg/system \"dvergr-db\")   ; => the db sub-system (canonical accessor)
 
-     ;; Fork automatically branches all registered yggdrasil systems
+     ;; Fork branches the whole workspace atomically (shared branch name)
      (let [child-ctx (ctx/fork-context parent-ctx)]
        (ec/with-context child-ctx
-         @ygit  ; => GitSystem on forked branch (automatic!)
-         (d/transact! @ydb [{:foo/bar 1}]))
-       (ygg/merge-to-parent! child-ctx))
-
-   For explicit fork handle pattern (backwards compatible):
-     (let [fork (ygg/fork!)]
-       (ygg/with-fork fork
-         @ygit)  ; => forked
-       (ygg/merge-fork! fork))"
+         @ygit  ; => git sub-system on the forked branch (automatic!)
+         (d/transact! @@ydb [{:foo/bar 1}]))
+       (ygg/merge-to-parent! child-ctx))            ; transactional"
   (:require [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.protocols :as rtp]
             [org.replikativ.spindel.engine.context :as ctx]
-            #?(:clj [yggdrasil.protocols :as ygg])))
+            #?@(:clj [[yggdrasil.protocols :as ygg]
+                      [yggdrasil.types :as ygt]
+                      [yggdrasil.composite :as ygc]])))
+
+;; =============================================================================
+;; The workspace external-ref key
+;; =============================================================================
+
+;; The single pforkable external-ref: a CompositeSystem of all registered
+;; yggdrasil systems. Keeping it under one key means fork-context forks the
+;; workspace as a unit (no per-system fan-out at the spindel layer — the
+;; composite's own branch! fans out one level down).
+(def workspace-key ::workspace)
 
 ;; =============================================================================
 ;; PForkable Extension for Yggdrasil Systems
 ;; =============================================================================
 
-;; Extend yggdrasil system types to implement PForkable.
-;; This allows fork-context to automatically fork them.
+;; Extend yggdrasil system types to implement PForkable so fork-context can
+;; fork them. The catch-all matches any Branchable yggdrasil system — including
+;; the CompositeSystem workspace, whose branch! fans out to every sub-system.
 
 #?(:clj
    (defn- fork-ygg-system
-     "Fork a yggdrasil system to a new branch.
-
-      Uses yggdrasil's Branchable protocol - works for any system type.
-
-      Args:
-        sys - Yggdrasil system (must implement Branchable)
-        fork-id - Keyword ID for the fork
-
-      Returns: New system instance on the new branch"
+     "Fork a yggdrasil system to a new branch via the Branchable protocol.
+      Works for any system type, including a CompositeSystem (whose branch!
+      fans the new branch name out to every sub-system)."
      [sys fork-id]
      (let [current-branch (ygg/current-branch sys)
            new-branch (keyword (str (name current-branch) "-" (name fork-id)))]
@@ -60,14 +74,8 @@
            (ygg/branch! new-branch)
            (ygg/checkout new-branch)))))
 
-;; Extend PForkable to all yggdrasil system types
-;; We use extend-protocol with Object as a catch-all for any yggdrasil system
-;; that implements the Branchable protocol
-
 #?(:clj
    (extend-protocol rtp/PForkable
-     ;; Default implementation for any object that implements yggdrasil Branchable
-     ;; This works because yggdrasil systems are records that satisfy the protocol
      Object
      (pfork [this fork-id]
        (if (satisfies? ygg/Branchable this)
@@ -77,17 +85,41 @@
                           :hint "Only yggdrasil systems can be registered as external-refs"}))))))
 
 ;; =============================================================================
-;; YggRef - Fork-safe reference to yggdrasil system
+;; Workspace + resolution
 ;; =============================================================================
 
-;; Following RuntimeAtom pattern: stores only ID, uses dynamic *execution-context*
+#?(:clj
+   (defn workspace
+     "The context's CompositeSystem workspace (all registered systems as one),
+      or nil if nothing registered yet. Reads the current execution context, or
+      an explicit `ctx`."
+     ([] (ec/get-state [:external-refs workspace-key]))
+     ([ctx] (rtp/get-state ctx [:external-refs workspace-key]))))
+
+#?(:clj
+   (defn- resolve-system
+     "Resolve a sub-system by id THROUGH the workspace composite in the current
+      context. Falls back to a direct [:external-refs id] read for contexts that
+      predate the workspace (or where nothing is registered) so resolution stays
+      robust. Returns the system or nil."
+     [id]
+     (if-let [ws (ec/get-state [:external-refs workspace-key])]
+       (or (get (:systems ws) id)
+           (when (= id (ygg/system-id ws)) ws))
+       (ec/get-state [:external-refs id]))))
+
+;; =============================================================================
+;; YggRef - Fork-safe reference to a yggdrasil sub-system
+;; =============================================================================
+
+;; Stores only the sub-system id; resolves via the workspace in the dynamic
+;; *execution-context*. The same YggRef works in parent and forked contexts.
 
 #?(:clj
    (deftype YggRef [id]
      clojure.lang.IDeref
      (deref [_this]
-       ;; Look up from [:external-refs id] in current context
-       (if-let [sys (ec/get-state [:external-refs id])]
+       (if-let [sys (resolve-system id)]
          sys
          (throw (ex-info "Yggdrasil system not found in current context"
                          {:id id
@@ -95,7 +127,7 @@
 
      clojure.lang.IMeta
      (meta [_this]
-       (when-let [sys (ec/get-state [:external-refs id])]
+       (when-let [sys (resolve-system id)]
          {:system-id id
           :system-type (ygg/system-type sys)
           :current-branch (ygg/current-branch sys)})))
@@ -124,17 +156,19 @@
   (.-id yref))
 
 ;; =============================================================================
-;; Registration
+;; Registration — compose into the workspace
 ;; =============================================================================
 
 (defn register!
-  "Register a yggdrasil system with current execution context.
+  "Compose a yggdrasil system into the current context's workspace.
 
-   The system is stored in [:external-refs] and will be automatically
-   forked when fork-context is called (via PForkable protocol).
+   The first call creates the workspace CompositeSystem; subsequent calls
+   rebuild it with the new system added. The workspace is stored ONCE at
+   [:external-refs ::workspace] and is automatically forked as a unit when
+   fork-context is called (via the PForkable protocol).
 
-   Returns a YggRef that resolves to the current system from context.
-   The same YggRef works in parent and forked contexts.
+   Returns a YggRef that resolves the system from context (through the
+   workspace). The same YggRef works in parent and forked contexts.
 
    Args:
      sys - Yggdrasil system (must implement SystemIdentity and Branchable)
@@ -146,33 +180,67 @@
      @ygit  ; => the git system"
   [sys]
   #?(:clj
-     (let [sys-id (ygg/system-id sys)]
-       (ec/swap-state! [:external-refs sys-id] (constantly sys))
+     (let [sys-id  (ygg/system-id sys)
+           ws      (ec/get-state [:external-refs workspace-key])
+           sys-map (assoc (if ws (:systems ws) {}) sys-id sys)
+           new-ws  (ygc/composite (vals sys-map)
+                                  :branch :main
+                                  :name "spindel-workspace")]
+       (ec/swap-state! [:external-refs workspace-key] (constantly new-ws))
        (->YggRef sys-id))
      :cljs
      (throw (ex-info "Yggdrasil not yet supported in ClojureScript" {}))))
 
-(defn get-system
-  "Get registered system by ID from current context.
+(defn system
+  "Get a registered sub-system by id from the current context, resolved through
+   the workspace. Branch-correct inside a forked context. Returns nil if absent.
 
-   Prefer using @ygg-ref instead.
-
-   Args:
-     sys-id - System ID (string)
-
-   Returns: Yggdrasil system or nil"
+   The canonical accessor — prefer this (or @ygg-ref) over reaching into
+   [:external-refs …] by hand."
   [sys-id]
-  (ec/get-state [:external-refs sys-id]))
+  #?(:clj (resolve-system sys-id)
+     :cljs (ec/get-state [:external-refs sys-id])))
+
+(defn get-system
+  "Alias for `system` (backwards-compatible name)."
+  [sys-id]
+  (system sys-id))
 
 (defn registered-systems
-  "Get all registered yggdrasil systems from current context.
-
-   Returns: Map of {sys-id -> system}"
+  "All registered sub-systems in the current context as {sys-id → system}
+   (the workspace's :systems map). Empty map when nothing is registered."
   []
-  (ec/get-state [:external-refs]))
+  #?(:clj (if-let [ws (ec/get-state [:external-refs workspace-key])]
+            (:systems ws)
+            {})
+     :cljs {}))
 
 ;; =============================================================================
-;; Fork Handle (for backwards compatibility and explicit control)
+;; Per-system pair helpers (child fork vs parent)
+;; =============================================================================
+
+#?(:clj
+   (defn- sub-systems
+     "The {sys-id → system} map of a context's workspace, or nil."
+     [c]
+     (when-let [ws (rtp/get-state c [:external-refs workspace-key])]
+       (:systems ws))))
+
+#?(:clj
+   (defn- mergeable-pairs
+     "Seq of [sys-id child-sys parent-sys] for sub-systems present in BOTH the
+      child and parent workspaces and Branchable in the child."
+     [child-ctx parent-ctx]
+     (let [child-sys  (sub-systems child-ctx)
+           parent-sys (sub-systems parent-ctx)]
+       (for [[sid csys] child-sys
+             :when (satisfies? ygg/Branchable csys)
+             :let  [psys (get parent-sys sid)]
+             :when psys]
+         [sid csys psys]))))
+
+;; =============================================================================
+;; Fork Handle (explicit control / backwards compatibility)
 ;; =============================================================================
 
 (defrecord ForkHandle [child-ctx parent-ctx fork-id])
@@ -182,167 +250,176 @@
   [x]
   (instance? ForkHandle x))
 
-;; =============================================================================
-;; Fork Creation
-;; =============================================================================
-
 (defn fork!
-  "Create a forked execution context with branched yggdrasil systems.
+  "Create a forked execution context with the workspace branched.
 
-   This is a convenience wrapper around ctx/fork-context that returns
-   a ForkHandle for explicit merge/discard control.
-
-   The actual forking of yggdrasil systems happens automatically in
-   fork-context via the PForkable protocol.
-
-   Returns ForkHandle for later merge/discard. Must be called from parent context.
+   Convenience wrapper around ctx/fork-context that returns a ForkHandle for
+   explicit merge/discard control. The actual forking of the workspace happens
+   in fork-context via the PForkable protocol.
 
    Permission model:
-   - An agent CAN fork from its current context (creating children)
-   - An agent CAN merge its own children back into its branch
-   - An agent CANNOT merge its own context into its parent
+   - An agent CAN fork from its current context (creating children).
+   - An agent CAN merge its own children back into its branch.
+   - An agent CANNOT merge its own context into its parent.
 
    Example:
      (let [fork (fork!)]
        (with-fork fork
-         ;; Work in forked context - @ygit is on forked branch
          (spit (str (git/worktree-path @ygit) \"/new.clj\") \"...\"))
        (merge-fork! fork))"
   []
   #?(:clj
      (let [parent-ctx (ec/current-execution-context)
-           ;; fork-context automatically forks all [:external-refs] via PForkable
-           child-ctx (ctx/fork-context parent-ctx)
-           fork-id (:fork-id child-ctx)]
+           child-ctx  (ctx/fork-context parent-ctx)
+           fork-id    (:fork-id child-ctx)]
        (->ForkHandle child-ctx parent-ctx fork-id))
-
      :cljs
      (throw (ex-info "Yggdrasil fork not yet supported in ClojureScript" {}))))
 
 #?(:clj
    (defmacro with-fork
-     "Execute body in fork's context.
-
-      YggRef derefs (@ygit, @ydb) resolve to forked instances within body.
-
-      Args:
-        fork-handle - ForkHandle from fork!
-        body - Forms to execute in forked context
-
-      Example:
-        (let [fork (fork!)]
-          (with-fork fork
-            (spit (str (git/worktree-path @ygit) \"/new.clj\") \"...\"))
-          (merge-fork! fork))"
+     "Execute body in fork's context. YggRef derefs (@ygit, @ydb) resolve to
+      forked instances within body."
      [fork-handle & body]
      `(ec/with-context (:child-ctx ~fork-handle)
         ~@body)))
 
 ;; =============================================================================
-;; Merge/Discard (Parent-Controlled)
+;; Diff / Conflicts (per-system merge-base)
 ;; =============================================================================
 
 #?(:clj
-   (defn merge-fork!
-     "Merge fork's yggdrasil changes to parent. Called from parent context.
+   (defn- system-merge-base-diff
+     "The fork's OWN changes in one sub-system. Preferred: diff the MERGE-BASE
+      (common ancestor of parent + fork) → fork, so a live parent's concurrent
+      advance is excluded (git merge-base is exact). Falls back to parent→fork
+      when the merge-base can't be resolved.
 
-      Permission model: You can only merge forks that YOU created.
-      The child context has no privileges to merge into its parent.
-
-      Args:
-        fork-handle - ForkHandle from fork!
-
-      Returns: nil
-
-      Example:
-        (let [fork (fork!)]
-          (with-fork fork
-            ;; Make changes...
-            )
-          (merge-fork! fork))"
-     [fork-handle]
-     (let [{:keys [child-ctx parent-ctx]} fork-handle
-           child-systems (rtp/get-state child-ctx [:external-refs])
-           parent-systems (rtp/get-state parent-ctx [:external-refs])]
-
-       (doseq [[sys-id child-sys] child-systems
-               :when (satisfies? ygg/Branchable child-sys)
-               :let [parent-sys (get parent-systems sys-id)
-                     child-branch (ygg/current-branch child-sys)
-                     parent-branch (ygg/current-branch parent-sys)]]
-         ;; Merge child branch into parent branch
-         (let [merged-sys (-> parent-sys
-                              (ygg/checkout parent-branch)
-                              (ygg/merge! child-branch))]
-           ;; Update parent context with merged system
-           (rtp/swap-state! parent-ctx [:external-refs sys-id] (constantly merged-sys)))
-
-         ;; Cleanup: delete child branch
-         (ygg/delete-branch! parent-sys child-branch))
-
-       nil)))
+      Resolves everything to SNAPSHOT-IDS (git sha / datahike db hash) rather than
+      branch keywords — the sub-systems have mixed native branch names, so a
+      branch keyword (`:main` / `:main-fork-x`) is not a valid ref to pass
+      uniformly, whereas each system's own snapshot-id always is."
+     [csys psys]
+     (let [psnap (ygg/snapshot-id psys)
+           fsnap (ygg/snapshot-id csys)]
+       (or (try
+             (let [base (ygg/common-ancestor csys psnap fsnap)]
+               (when base (ygg/diff csys base fsnap)))
+             (catch Throwable _ nil))
+           (try (ygg/diff csys psnap fsnap)
+                (catch Throwable t (ygt/->DiffError psnap fsnap (.getMessage t))))))))
 
 #?(:clj
-   (defn discard-fork!
-     "Discard fork's yggdrasil branches without merging. Called from parent context.
+   (defn workspace-diff
+     "Per-sub-system delta of a forked context vs its parent — the unified diff a
+      reviewer reads: {sys-id → typed yggdrasil delta (GitDiff / DatahikeDiff /
+      DiffError)}. nil when the context has no parent.
 
-      Cleans up the forked branches. The fork handle should not be used after this.
+      Each sub-system is diffed on its OWN branch pair using the merge-base
+      (mixed native bases — datahike :db, git main — so a shared base branch name
+      would be wrong). Non-Mergeable sub-systems are omitted."
+     [child-ctx]
+     (when-let [parent-ctx (:parent-ctx child-ctx)]
+       (into {}
+             (keep (fn [[sid csys psys]]
+                     (when (and (satisfies? ygg/Mergeable csys)
+                                (satisfies? ygg/Graphable csys))
+                       [sid (system-merge-base-diff csys psys)])))
+             (mergeable-pairs child-ctx parent-ctx)))))
 
-      Args:
-        fork-handle - ForkHandle from fork!
+#?(:clj
+   (defn workspace-conflicts
+     "Per-sub-system conflicts of a forked context vs its parent, each tagged
+      `:system`. nil when the context has no parent. Often empty (datahike
+      conflict detection is conservative today)."
+     [child-ctx]
+     (when-let [parent-ctx (:parent-ctx child-ctx)]
+       (into []
+             (mapcat (fn [[sid csys psys]]
+                       (when (satisfies? ygg/Mergeable csys)
+                         (try (map #(assoc % :system sid)
+                                   (ygg/conflicts csys
+                                                  (ygg/snapshot-id psys)
+                                                  (ygg/snapshot-id csys)))
+                              (catch Throwable _ nil)))))
+             (mergeable-pairs child-ctx parent-ctx)))))
 
-      Returns: nil"
-     [fork-handle]
-     (let [{:keys [child-ctx parent-ctx]} fork-handle
-           child-systems (rtp/get-state child-ctx [:external-refs])
-           parent-systems (rtp/get-state parent-ctx [:external-refs])]
-
-       (doseq [[sys-id child-sys] child-systems
-               :when (satisfies? ygg/Branchable child-sys)
-               :let [parent-sys (get parent-systems sys-id)
-                     child-branch (ygg/current-branch child-sys)]]
-         ;; Delete child branch (also removes worktree for git)
-         (ygg/delete-branch! parent-sys child-branch))
-
-       nil)))
+;; context-diff: backwards-compatible alias (richer per-system map dropped in
+;; favour of the typed deltas from workspace-diff).
+#?(:clj (def context-diff workspace-diff))
 
 ;; =============================================================================
-;; Direct Context Merge/Discard (without ForkHandle)
+;; Merge / Discard (Parent-Controlled, transactional)
 ;; =============================================================================
 
 #?(:clj
    (defn merge-to-parent!
-     "Merge child context's yggdrasil changes to its parent.
+     "Merge a forked context's workspace into its parent — TRANSACTIONAL across
+      sub-systems.
 
-      Alternative to merge-fork! when working directly with contexts
-      instead of ForkHandle.
+      Algorithm:
+        1. Pre-check conflicts (unless :strategy or :force given); abort
+           untouched if any sub-system conflicts.
+        2. Stage every sub-system merge as a value.
+        3. Only when ALL succeed, atomically swap the parent's workspace and
+           delete the fork's branches.
+      If any sub-system merge throws, the parent workspace pointer is left
+      unchanged (no half-merge of the logical state) and the error is re-thrown
+      with diagnostics. (Underlying store writes for already-merged sub-systems
+      may have landed — git/datahike have no cross-store 2PC; the conflict
+      pre-check makes mid-merge failure unlikely.)
 
       Args:
         child-ctx - Child ExecutionContext to merge from
+        opts      - Optional {:strategy … :force true :message …} passed to
+                    yggdrasil merge!
 
-      Returns: nil"
-     [child-ctx]
-     (when-let [parent-ctx (:parent-ctx child-ctx)]
-       (let [child-systems (rtp/get-state child-ctx [:external-refs])
-             parent-systems (rtp/get-state parent-ctx [:external-refs])]
-
-         (doseq [[sys-id child-sys] child-systems
-                 :when (satisfies? ygg/Branchable child-sys)
-                 :let [parent-sys (get parent-systems sys-id)
-                       child-branch (ygg/current-branch child-sys)
-                       parent-branch (ygg/current-branch parent-sys)]]
-           (let [merged-sys (-> parent-sys
-                                (ygg/checkout parent-branch)
-                                (ygg/merge! child-branch))]
-             (rtp/swap-state! parent-ctx [:external-refs sys-id] (constantly merged-sys)))
-           (ygg/delete-branch! parent-sys child-branch))))
-     nil))
+      Returns: {:merged [sys-id …]} or nil if child has no parent."
+     ([child-ctx] (merge-to-parent! child-ctx {}))
+     ([child-ctx opts]
+      (when-let [parent-ctx (:parent-ctx child-ctx)]
+        (let [pairs     (mergeable-pairs child-ctx parent-ctx)
+              parent-ws (rtp/get-state parent-ctx [:external-refs workspace-key])]
+          ;; 1. conflict pre-check
+          (when-not (or (:strategy opts) (:force opts))
+            (let [confs (mapcat (fn [[sid csys psys]]
+                                  (when (satisfies? ygg/Mergeable csys)
+                                    (try (map #(assoc % :system sid)
+                                              (ygg/conflicts csys
+                                                             (ygg/snapshot-id psys)
+                                                             (ygg/snapshot-id csys)))
+                                         (catch Throwable _ nil))))
+                                pairs)]
+              (when (seq confs)
+                (throw (ex-info "workspace merge has conflicts; aborting (pass :strategy or :force)"
+                                {:conflicts (vec confs)})))))
+          ;; 2. stage all merges (capture rollback snapshots for diagnostics)
+          (let [rollback (into {} (map (fn [[sid _ psys]] [sid (ygg/snapshot-id psys)])) pairs)
+                merged   (try
+                           (reduce (fn [acc [sid _csys psys :as pair]]
+                                     (let [csys    (nth pair 1)
+                                           pbranch (ygg/current-branch psys)
+                                           cbranch (ygg/current-branch csys)
+                                           m (-> psys
+                                                 (ygg/checkout pbranch)
+                                                 (ygg/merge! cbranch opts))]
+                                       (assoc acc sid m)))
+                                   {} pairs)
+                           (catch Throwable e
+                             (throw (ex-info "workspace merge failed mid-way; parent workspace left unchanged"
+                                             {:rollback rollback} e))))]
+            ;; 3. commit atomically, then delete child branches
+            (rtp/swap-state! parent-ctx [:external-refs workspace-key]
+                             (constantly (assoc parent-ws
+                                                :systems (merge (sub-systems parent-ctx) merged))))
+            (doseq [[_ csys psys] pairs]
+              (ygg/delete-branch! psys (ygg/current-branch csys)))
+            {:merged (vec (keys merged))}))))))
 
 #?(:clj
    (defn discard-from-parent!
-     "Discard child context's yggdrasil branches without merging.
-
-      Alternative to discard-fork! when working directly with contexts.
+     "Discard a forked context's workspace branches without merging. Deletes each
+      sub-system's fork branch (removing git worktrees etc.). Called from parent.
 
       Args:
         child-ctx - Child ExecutionContext to discard
@@ -350,15 +427,24 @@
       Returns: nil"
      [child-ctx]
      (when-let [parent-ctx (:parent-ctx child-ctx)]
-       (let [child-systems (rtp/get-state child-ctx [:external-refs])
-             parent-systems (rtp/get-state parent-ctx [:external-refs])]
-
-         (doseq [[sys-id child-sys] child-systems
-                 :when (satisfies? ygg/Branchable child-sys)
-                 :let [parent-sys (get parent-systems sys-id)
-                       child-branch (ygg/current-branch child-sys)]]
-           (ygg/delete-branch! parent-sys child-branch))))
+       (doseq [[_ csys psys] (mergeable-pairs child-ctx parent-ctx)]
+         (ygg/delete-branch! psys (ygg/current-branch csys))))
      nil))
+
+;; ForkHandle variants (delegate to the ctx-based ops)
+
+#?(:clj
+   (defn merge-fork!
+     "Merge fork's workspace to parent (ForkHandle variant of merge-to-parent!)."
+     ([fork-handle] (merge-fork! fork-handle {}))
+     ([fork-handle opts] (merge-to-parent! (:child-ctx fork-handle) opts))))
+
+#?(:clj
+   (defn discard-fork!
+     "Discard fork's workspace branches (ForkHandle variant of
+      discard-from-parent!)."
+     [fork-handle]
+     (discard-from-parent! (:child-ctx fork-handle))))
 
 ;; =============================================================================
 ;; Merge From Parent (Parent → Child sync)
@@ -366,64 +452,46 @@
 
 #?(:clj
    (defn merge-from-parent!
-     "Merge parent's current state into child context.
-
-      This is the inverse of merge-to-parent! — it pulls parent changes
-      INTO the child. Useful for long-lived agent branches that need to
-      stay in sync with the parent (e.g., when the parent has merged
-      other children's work).
-
-      After merge, the child has all parent's latest changes plus its
-      own work. Conflicts are resolved per system's merge strategy.
-
-      Permission model: Called from within the child context.
+     "Merge parent's current state INTO a child context (inverse of
+      merge-to-parent!). Useful for long-lived agent branches that need to stay
+      in sync with the parent. Operates per sub-system, then swaps the child's
+      workspace. Called from within the child context.
 
       Args:
         child-ctx - The child ExecutionContext to update
-        opts      - Optional merge opts (passed to yggdrasil merge!)
-                    {:strategy :ours|:theirs|:union|fn
-                     :message \"merge message\"}
+        opts      - Optional merge opts {:strategy … :message …}
 
-      Returns: nil
-
-      Example:
-        (binding [rtc/*execution-context* child-ctx]
-          (merge-from-parent! child-ctx)
-          ;; child now has parent's latest changes
-          )"
+      Returns: nil"
      ([child-ctx] (merge-from-parent! child-ctx {}))
      ([child-ctx opts]
       (when-let [parent-ctx (:parent-ctx child-ctx)]
-        (let [child-systems (rtp/get-state child-ctx [:external-refs])
-              parent-systems (rtp/get-state parent-ctx [:external-refs])]
-
-          (doseq [[sys-id child-sys] child-systems
-                  :when (and (satisfies? ygg/Branchable child-sys)
-                             (satisfies? ygg/Mergeable child-sys))
-                  :let [parent-sys (get parent-systems sys-id)
-                        child-branch (ygg/current-branch child-sys)
-                        parent-branch (ygg/current-branch parent-sys)]]
-            ;; Merge parent branch into child branch (opposite of merge-to-parent!)
-            (let [merged-sys (-> child-sys
-                                 (ygg/checkout child-branch)
-                                 (ygg/merge! parent-branch
-                                             (merge {:message (str "Merge from " (name parent-branch))}
-                                                    opts)))]
-              ;; Update child context with merged system
-              (rtp/swap-state! child-ctx [:external-refs sys-id] (constantly merged-sys))))))
+        (let [parent-sys (sub-systems parent-ctx)
+              child-ws   (rtp/get-state child-ctx [:external-refs workspace-key])
+              child-sys  (sub-systems child-ctx)
+              merged     (reduce
+                          (fn [acc [sid csys]]
+                            (let [psys (get parent-sys sid)]
+                              (if (and psys
+                                       (satisfies? ygg/Branchable csys)
+                                       (satisfies? ygg/Mergeable csys))
+                                (let [cbranch (ygg/current-branch csys)
+                                      pbranch (ygg/current-branch psys)
+                                      m (-> csys
+                                            (ygg/checkout cbranch)
+                                            (ygg/merge! pbranch
+                                                        (merge {:message (str "Merge from " (name pbranch))}
+                                                               opts)))]
+                                  (assoc acc sid m))
+                                acc)))
+                          {} child-sys)]
+          (rtp/swap-state! child-ctx [:external-refs workspace-key]
+                           (constantly (assoc child-ws
+                                              :systems (merge child-sys merged))))))
       nil)))
 
 #?(:clj
    (defn merge-fork-from-parent!
-     "Merge parent's current state into a fork.
-
-      ForkHandle variant of merge-from-parent! for explicit control.
-
-      Args:
-        fork-handle - ForkHandle from fork!
-        opts        - Optional merge opts
-
-      Returns: nil"
+     "Merge parent's current state into a fork (ForkHandle variant)."
      ([fork-handle] (merge-fork-from-parent! fork-handle {}))
      ([fork-handle opts]
       (merge-from-parent! (:child-ctx fork-handle) opts))))
@@ -434,52 +502,17 @@
 
 #?(:clj
    (defn parent-system
-     "Get parent context's version of this system (read-only access).
-
-      Works with YggRef or raw system. Must be called from child context.
-
-      Args:
-        sys-or-ref - YggRef or raw yggdrasil system
-
-      Returns: Parent's system instance, or nil if at root"
+     "Get parent context's version of this sub-system (read-only). Works with a
+      YggRef or a raw system. Must be called from a child context. Returns nil
+      at root."
      [sys-or-ref]
      (let [sys-id (if (ygg-ref? sys-or-ref)
                     (ygg-ref-id sys-or-ref)
                     (ygg/system-id sys-or-ref))
-           ctx (ec/current-execution-context)
+           ctx        (ec/current-execution-context)
            parent-ctx (:parent-ctx ctx)]
        (when parent-ctx
-         (rtp/get-state parent-ctx [:external-refs sys-id])))))
-
-;; =============================================================================
-;; Context Diff (diff all systems between child and parent)
-;; =============================================================================
-
-#?(:clj
-   (defn context-diff
-     "Diff all yggdrasil systems between a child context and its parent.
-
-      Iterates over all external-refs in the child context that implement
-      Mergeable, and computes a diff between the parent's branch and the
-      child's branch for each system.
-
-      Returns map of {system-id -> {:type :git/:datahike, :diff ...}}
-      Returns nil if child has no parent."
-     [child-ctx]
-     (when-let [parent-ctx (:parent-ctx child-ctx)]
-       (let [child-systems (rtp/get-state child-ctx [:external-refs])
-             parent-systems (rtp/get-state parent-ctx [:external-refs])]
-         (into {}
-               (for [[sys-id child-sys] child-systems
-                     :when (satisfies? ygg/Mergeable child-sys)
-                     :let [parent-sys (get parent-systems sys-id)
-                           child-branch (ygg/current-branch child-sys)
-                           parent-branch (when parent-sys (ygg/current-branch parent-sys))]
-                     :when parent-sys]
-                 [sys-id {:type (ygg/system-type child-sys)
-                          :child-branch child-branch
-                          :parent-branch parent-branch
-                          :diff (ygg/diff parent-sys parent-branch child-branch)}]))))))
+         (get (sub-systems parent-ctx) sys-id)))))
 
 ;; =============================================================================
 ;; Optional Helpers (for datahike double-deref ergonomics)
@@ -487,14 +520,7 @@
 
 #?(:clj
    (defn db
-     "Get current db value from a datahike YggRef.
-
-      Equivalent to @@ydb - handles the double-deref.
-
-      Args:
-        ydb-ref - YggRef wrapping a datahike connection
-
-      Returns: Current datahike db value"
+     "Get current db value from a datahike YggRef. Equivalent to @@ydb."
      [ydb-ref]
      @@ydb-ref))
 
@@ -502,14 +528,6 @@
    (defn q
      "Query helper that handles datahike double-deref automatically.
 
-      Args:
-        ydb-ref - YggRef wrapping a datahike connection
-        query - Datalog query
-        args - Additional query arguments
-
-      Returns: Query result
-
-      Example:
-        (q ydb '[:find ?n :where [?e :user/name ?n]])"
+      Example: (q ydb '[:find ?n :where [?e :user/name ?n]])"
      [ydb-ref query & args]
      (apply (requiring-resolve 'datahike.api/q) query @@ydb-ref args)))

--- a/test/org/replikativ/spindel/yggdrasil_test.clj
+++ b/test/org/replikativ/spindel/yggdrasil_test.clj
@@ -387,3 +387,73 @@
         (finally
           (ctx/stop-context! ctx)
           (cleanup-temp-repo second-repo-path))))))
+
+;; =============================================================================
+;; Workspace API (collapsed composite) Tests
+;; =============================================================================
+
+(deftest test-workspace-composes
+  (testing "register! composes systems into ONE workspace composite"
+    (th/with-ctx [ctx]
+      (is (nil? (ygg/workspace)) "No workspace before any register!")
+      (ygg/register! *test-git-system*)
+      (let [ws (ygg/workspace)]
+        (is (some? ws) "Workspace exists after register!")
+        (is (= :composite (ygg-proto/system-type ws)) "Workspace is a CompositeSystem")
+        (is (= 1 (count (:systems ws))) "One sub-system in the workspace")))))
+
+(deftest test-workspace-resolution
+  (testing "system / get-system resolve a sub-system THROUGH the workspace"
+    (th/with-ctx [ctx]
+      (let [yref (ygg/register! *test-git-system*)
+            sid  (ygg-proto/system-id *test-git-system*)]
+        (is (identical? @yref (ygg/system sid))
+            "ygg/system returns the same instance as @yref")
+        (is (= :git (ygg-proto/system-type (ygg/system sid))))))))
+
+(deftest test-workspace-diff-merge-base
+  (testing "workspace-diff reports the fork's OWN change via per-system merge-base"
+    (th/with-ctx [ctx]
+      (let [yref (ygg/register! *test-git-system*)
+            sid  (ygg-proto/system-id *test-git-system*)
+            fork-handle (ygg/fork!)
+            child-ctx (:child-ctx fork-handle)]
+        ;; Commit a file inside the fork
+        (ygg/with-fork fork-handle
+          (let [branch-name (name (ygg-proto/current-branch @yref))
+                wt-path (str (:worktrees-dir @yref) "/" branch-name)]
+            (spit (str wt-path "/ws-diff.txt") "fork change")
+            (sh "git" "add" "ws-diff.txt" :dir wt-path)
+            (sh "git" "commit" "-m" "ws diff commit" :dir wt-path)))
+        ;; Advance the PARENT independently — merge-base must exclude this
+        (let [repo-path (:repo-path @yref)]
+          (spit (str repo-path "/parent-only.txt") "parent advance")
+          (sh "git" "add" "parent-only.txt" :dir repo-path)
+          (sh "git" "commit" "-m" "parent advance" :dir repo-path))
+        (let [diff (ygg/workspace-diff child-ctx)
+              gdiff (get diff sid)
+              files (set (map :path (:files gdiff)))]
+          (is (some? gdiff) "workspace-diff has the git sub-system")
+          (is (contains? files "ws-diff.txt") "fork's own file is in the diff")
+          (is (not (contains? files "parent-only.txt"))
+              "parent's concurrent advance is excluded (merge-base)"))
+        (ygg/discard-fork! fork-handle)))))
+
+(deftest test-workspace-merge-transactional
+  (testing "merge-to-parent! returns :merged and lands the fork's change"
+    (th/with-ctx [ctx]
+      (let [yref (ygg/register! *test-git-system*)
+            sid  (ygg-proto/system-id *test-git-system*)
+            fork-handle (ygg/fork!)
+            child-ctx (:child-ctx fork-handle)]
+        (ygg/with-fork fork-handle
+          (let [branch-name (name (ygg-proto/current-branch @yref))
+                wt-path (str (:worktrees-dir @yref) "/" branch-name)]
+            (spit (str wt-path "/ws-merge.txt") "merge me")
+            (sh "git" "add" "ws-merge.txt" :dir wt-path)
+            (sh "git" "commit" "-m" "ws merge commit" :dir wt-path)))
+        (let [result (ygg/merge-to-parent! child-ctx)]
+          (is (contains? (set (:merged result)) sid)
+              "merge-to-parent! reports the merged sub-system")
+          (is (.exists (io/file (str (:repo-path @yref) "/ws-merge.txt")))
+              "fork's file landed in the parent"))))))


### PR DESCRIPTION
Cherry-picks the two composite-workspace commits onto current `main` (which already has the leak/retention audit #12 + await-exclusion #13 squashed in):

- `deps: bump yggdrasil 0.1.6 -> 0.2.27` (prerequisite)
- `feat(yggdrasil): collapse bridge to one composite workspace` — adds `org.replikativ.spindel.yggdrasil/system` + `workspace-diff` + transactional `merge-to-parent!`, the single composite `[:external-refs ::workspace]`.

The other ~11 commits on `feat/context-workspace` were the granular form of the leak audit that already landed on main as `f9eb9ba` (#12) / `e588382` (#13), so they're intentionally dropped.

dvergr / simmis depend on `ygg/system` and currently require a `:local` spindel checkout; this unblocks consuming a published release. Full suite green: 814 tests / 2754 assertions, 0 failures.