### PR TITLE
deps: bump yggdrasil 0.2.27 -> 0.2.28 (datahike 3-way merge fix)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
         riddley/riddley {:mvn/version "0.2.0"}
         org.replikativ/logging {:mvn/version "0.1.3"}
         is.simm/partial-cps {:mvn/version "0.1.55"}
-        org.replikativ/yggdrasil {:mvn/version "0.2.27"}
+        org.replikativ/yggdrasil {:mvn/version "0.2.28"}
         org.replikativ/hasch {:mvn/version "0.3.97"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         anglican/anglican {:mvn/version "1.1.0"}


### PR DESCRIPTION
One-line dep bump to consume yggdrasil 0.2.28 (replikativ/yggdrasil#4): the datahike `common-ancestor`/3-way-conflict fix. The bridge's `workspace-diff`/merge-base now detects sequential multi-fork conflicts correctly. Verified locally: resolves from Clojars, spindel loads, cljfmt clean, and dvergr's full 363-test suite is green against this spindel + yggdrasil 0.2.28.