### PR TITLE
feat(yggdrasil): unregister! — remove a system from the ctx workspace composite

### DIFF
--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -191,6 +191,26 @@
      :cljs
      (throw (ex-info "Yggdrasil not yet supported in ClojureScript" {}))))
 
+(defn unregister!
+  "Remove the system identified by `sys-id` from the current context's workspace
+   composite — the mirror of `register!`. No-op if absent. When the last system
+   is removed the workspace is cleared (so `system` returns nil). Returns true if
+   a system was removed."
+  [sys-id]
+  #?(:clj
+     (when-let [ws (ec/get-state [:external-refs workspace-key])]
+       (let [systems (:systems ws)]
+         (when (contains? systems sys-id)
+           (let [sys-map (dissoc systems sys-id)]
+             (ec/swap-state! [:external-refs workspace-key]
+                             (constantly (when (seq sys-map)
+                                           (ygc/composite (vals sys-map)
+                                                          :branch :main
+                                                          :name "spindel-workspace"))))
+             true))))
+     :cljs
+     (throw (ex-info "Yggdrasil not yet supported in ClojureScript" {}))))
+
 (defn system
   "Get a registered sub-system by id from the current context, resolved through
    the workspace. Branch-correct inside a forked context. Returns nil if absent.


### PR DESCRIPTION
The mirror of `register!`: dissoc the system from the `[:external-refs ::workspace]` composite and `swap-state!` the workspace (cleared when the last system is removed).

Enables:
- **runtime detach** of an attached system from a context's workspace, and
- **teardown** of per-room systems (KB / repo / messages) when a room is deleted.

Downstream (dvergr) registers per-room datahike + git systems into the ctx composite and needs the inverse to tear them down on room delete; without it the consuming namespace fails to load (`No such var: ygg/unregister!`).

Additive (+20 lines in `yggdrasil.cljc`), no behavior change to `register!`. Cut clean off `main`.