### PR TITLE
feat(yggdrasil-bridge): fork-merge child-only carry + storage GC + merge-gate fail-safe

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
         riddley/riddley {:mvn/version "0.2.0"}
         org.replikativ/logging {:mvn/version "0.1.3"}
         is.simm/partial-cps {:mvn/version "0.1.55"}
-        org.replikativ/yggdrasil {:mvn/version "0.2.28"}
+        org.replikativ/yggdrasil {:mvn/version "0.2.29"}
         org.replikativ/hasch {:mvn/version "0.3.97"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         anglican/anglican {:mvn/version "1.1.0"}

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -42,6 +42,7 @@
             [org.replikativ.spindel.engine.context :as ctx]
             #?@(:clj [[yggdrasil.protocols :as ygg]
                       [yggdrasil.types :as ygt]
+                      [yggdrasil.gc :as ygg-gc]
                       [yggdrasil.composite :as ygc]])))
 
 ;; =============================================================================
@@ -572,3 +573,26 @@
       Example: (q ydb '[:find ?n :where [?e :user/name ?n]])"
      [ydb-ref query & args]
      (apply (requiring-resolve 'datahike.api/q) query @@ydb-ref args)))
+
+#?(:clj
+   (defn gc-system!
+     "Reclaim unreachable storage for a single yggdrasil system (e.g. a datahike
+      system's orphaned index blobs left by every transaction). Thin re-export of
+      `yggdrasil.gc/gc-system!` so callers needn't import yggdrasil internals.
+      `opts` are adapter-specific — datahike honours `:remove-before <Date>`
+      (default epoch = keep ALL history, drop only orphan garbage), git honours
+      `:grace-period-ms`; `:dry-run?` reports without deleting. Returns the
+      adapter's reclamation report."
+     ([sys] (ygg-gc/gc-system! sys {}))
+     ([sys opts] (ygg-gc/gc-system! sys opts))))
+
+#?(:clj
+   (defn gc!
+     "Reclaim unreachable storage across the CURRENT context's whole workspace —
+      every registered system (datahike kbs/msgs + git repos) GC'd as one
+      coordinated pass. The natural entry for a forked room/agent context: call it
+      on that ctx and all its stores are swept. `opts` flow to each adapter
+      (`:remove-before`, `:grace-period-ms`, `:dry-run?`). Returns {system-id →
+      report}, or nil if nothing is registered yet."
+     ([] (gc! {}))
+     ([opts] (when-let [ws (workspace)] (ygg-gc/gc-system! ws opts)))))

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -428,28 +428,49 @@
                            (catch Throwable e
                              (throw (ex-info "workspace merge failed mid-way; parent workspace left unchanged"
                                              {:rollback rollback} e))))]
-            ;; 3. commit atomically, then delete child branches
-            (rtp/swap-state! parent-ctx [:external-refs workspace-key]
-                             (constantly (assoc parent-ws
-                                                :systems (merge (sub-systems parent-ctx) merged))))
-            (doseq [[_ csys psys] pairs]
-              (ygg/delete-branch! psys (ygg/current-branch csys)))
-            {:merged (vec (keys merged))}))))))
+            ;; 3. commit atomically. CARRY child-only systems too — a system
+            ;; registered in the fork has no parent counterpart in `pairs`, so
+            ;; without this merge would silently DROP it (it's on its own default
+            ;; branch, not a to-be-deleted fork branch). Then delete child branches,
+            ;; then fire :on-merge so an external registry can reconcile in-band.
+            (let [child-only (apply dissoc (sub-systems child-ctx)
+                                    (keys (sub-systems parent-ctx)))]
+              (rtp/swap-state! parent-ctx [:external-refs workspace-key]
+                               (constantly (assoc parent-ws
+                                                  :systems (merge (sub-systems parent-ctx)
+                                                                  merged child-only))))
+              (doseq [[_ csys psys] pairs]
+                (ygg/delete-branch! psys (ygg/current-branch csys)))
+              (when-let [cb (:on-merge opts)]
+                (cb {:merged (vec (keys merged)) :child-only (vec (keys child-only))
+                     :parent-ctx parent-ctx :child-ctx child-ctx}))
+              {:merged (vec (keys merged)) :child-only (vec (keys child-only))})))))))
 
 #?(:clj
    (defn discard-from-parent!
      "Discard a forked context's workspace branches without merging. Deletes each
-      sub-system's fork branch (removing git worktrees etc.). Called from parent.
+      shared sub-system's fork branch (removing git worktrees etc.). Called from
+      parent. Fork-ONLY systems (registered in the fork, e.g. an agent-created DB)
+      have no shared branch to delete and their stores are NOT removed here — the
+      `:on-discard` callback receives them so an external owner can clean up (delete
+      the store, drop a deferred registry grant) and avoid an orphaned/resurrected DB.
 
       Args:
         child-ctx - Child ExecutionContext to discard
+        opts      - {:on-discard (fn [{:keys [child-only child-ctx]}])}
 
       Returns: nil"
-     [child-ctx]
-     (when-let [parent-ctx (:parent-ctx child-ctx)]
-       (doseq [[_ csys psys] (mergeable-pairs child-ctx parent-ctx)]
-         (ygg/delete-branch! psys (ygg/current-branch csys))))
-     nil))
+     ([child-ctx] (discard-from-parent! child-ctx {}))
+     ([child-ctx opts]
+      (when-let [parent-ctx (:parent-ctx child-ctx)]
+        (doseq [[_ csys psys] (mergeable-pairs child-ctx parent-ctx)]
+          (ygg/delete-branch! psys (ygg/current-branch csys)))
+        (when-let [cb (:on-discard opts)]
+          (let [child-only (apply dissoc (sub-systems child-ctx)
+                                  (keys (sub-systems parent-ctx)))]
+            (cb {:child-only (vec (keys child-only)) :child-only-systems child-only
+                 :child-ctx child-ctx}))))
+      nil)))
 
 ;; ForkHandle variants (delegate to the ctx-based ops)
 
@@ -463,8 +484,8 @@
    (defn discard-fork!
      "Discard fork's workspace branches (ForkHandle variant of
       discard-from-parent!)."
-     [fork-handle]
-     (discard-from-parent! (:child-ctx fork-handle))))
+     ([fork-handle] (discard-fork! fork-handle {}))
+     ([fork-handle opts] (discard-from-parent! (:child-ctx fork-handle) opts))))
 
 ;; =============================================================================
 ;; Merge From Parent (Parent → Child sync)

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -401,7 +401,9 @@
       (when-let [parent-ctx (:parent-ctx child-ctx)]
         (let [pairs     (mergeable-pairs child-ctx parent-ctx)
               parent-ws (rtp/get-state parent-ctx [:external-refs workspace-key])]
-          ;; 1. conflict pre-check
+          ;; 1. conflict pre-check. FAIL-SAFE: if conflict detection THROWS we must
+          ;; NOT swallow it as "no conflicts" (that would blind-merge); treat the
+          ;; error itself as an indeterminate conflict so the gate aborts.
           (when-not (or (:strategy opts) (:force opts))
             (let [confs (mapcat (fn [[sid csys psys]]
                                   (when (satisfies? ygg/Mergeable csys)
@@ -409,7 +411,9 @@
                                               (ygg/conflicts csys
                                                              (ygg/snapshot-id psys)
                                                              (ygg/snapshot-id csys)))
-                                         (catch Throwable _ nil))))
+                                         (catch Throwable e
+                                           [{:system sid :indeterminate? true
+                                             :error (.getMessage e)}]))))
                                 pairs)]
               (when (seq confs)
                 (throw (ex-info "workspace merge has conflicts; aborting (pass :strategy or :force)"

--- a/test/org/replikativ/spindel/yggdrasil_test.clj
+++ b/test/org/replikativ/spindel/yggdrasil_test.clj
@@ -213,6 +213,40 @@
               "Branch removed after discard"))))))
 
 ;; =============================================================================
+;; Child-only systems on merge / discard + lifecycle callbacks
+;; =============================================================================
+
+(deftest test-merge-carries-child-only-system
+  (testing "a system registered ONLY in the fork is carried to the parent on merge, and :on-merge fires"
+    (th/with-ctx [ctx]
+      (ygg/register! *test-git-system*)                 ; base system, in the parent
+      (let [fork-handle (ygg/fork!)
+            child-repo  (create-temp-repo)
+            cb          (atom nil)]
+        ;; register a NEW system that exists ONLY in the fork
+        (ygg/with-fork fork-handle
+          (ygg/register! (git-adapter/create child-repo {:system-name "child-only"})))
+        (is (nil? (ygg/system "child-only")) "fork-only system is invisible in the parent before merge")
+        (ygg/merge-fork! fork-handle {:on-merge (fn [m] (reset! cb m))})
+        (is (some? (ygg/system "child-only")) "fork-only system is CARRIED into the parent on merge")
+        (is (= ["child-only"] (mapv str (:child-only @cb))) ":on-merge callback received the child-only set")
+        (cleanup-temp-repo child-repo)))))
+
+(deftest test-discard-fires-on-discard-with-child-only
+  (testing "discard fires :on-discard with the fork-only systems so an external owner can clean up"
+    (th/with-ctx [ctx]
+      (ygg/register! *test-git-system*)
+      (let [fork-handle (ygg/fork!)
+            child-repo  (create-temp-repo)
+            cb          (atom nil)]
+        (ygg/with-fork fork-handle
+          (ygg/register! (git-adapter/create child-repo {:system-name "scratch"})))
+        (ygg/discard-fork! fork-handle {:on-discard (fn [m] (reset! cb m))})
+        (is (= ["scratch"] (mapv str (:child-only @cb))) ":on-discard callback received the child-only set")
+        (is (nil? (ygg/system "scratch")) "fork-only system is not in the parent after discard")
+        (cleanup-temp-repo child-repo)))))
+
+;; =============================================================================
 ;; Nested Fork Tests
 ;; =============================================================================
 


### PR DESCRIPTION
Three commits on the spindel↔yggdrasil bridge, on top of the merged sci-opts passthrough. Pairs with yggdrasil PR replikativ/yggdrasil#5 (GC + conflict-safety).

### `feat(yggdrasil): carry child-only systems on merge + merge/discard lifecycle callbacks`
`merge-to-parent!` only merged sub-systems present in BOTH child and parent, so a system **registered only in the fork** (e.g. an agent-created DB) was silently dropped on merge and orphaned on discard. Now the merge carries child-only systems into the parent, and `merge-to-parent!`/`discard-from-parent!` accept `:on-merge`/`:on-discard` callbacks so the caller can reconcile external bookkeeping transactionally with the workspace swap.

### `feat(yggdrasil-bridge): public gc! / gc-system!`
Re-export yggdrasil's storage GC through the bridge so callers needn't import yggdrasil internals:
- `gc-system!` — GC one yggdrasil system (delegates to `yggdrasil.gc/gc-system!`).
- `gc!` — GC the **current context's whole composite workspace** (every registered system — datahike + git — in one coordinated pass); the natural entry for a forked room/agent ctx. opts flow to each adapter (`:remove-before`, `:grace-period-ms`, `:dry-run?`).

### `fix(merge-gate): fail-safe on conflict-detection errors`
`merge-to-parent!`'s conflict pre-check wrapped `conflicts` in `(catch Throwable _ nil)` — so an **error** in conflict detection was swallowed as "no conflicts" and green-lit a blind merge. Now an error becomes an `:indeterminate?` conflict entry so the gate aborts (caller can pass `:force`/`:strategy`). Fail-safe: if we cannot determine merge safety, do not auto-merge.

Requires yggdrasil#5 (the `gc!`/`gc-system!` it re-exports + the conflict fallback) once that lands + is released.