### PR TITLE
fix(cancel): cancel-spin! unwinds a suspended spin so try/finally runs

### DIFF
--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -610,9 +610,42 @@
                      {:type spin-cancelled
                       :spin-id sid
                       :cancelled-at #?(:clj (java.util.Date.)
-                                       :cljs (js/Date.))})]
-    ;; Requires *execution-context* to be bound by caller
-    (abort-spin-chain! sid err)))
+                                       :cljs (js/Date.))})
+        ;; Requires *execution-context* to be bound by caller
+        ctx   (ec/current-execution-context)
+        conts (ec/get-state [:await-conts sid])]
+    ;; (1) Cache the cancel result + dirty observers. Makes `spin-is-cancelled?`
+    ;; true, so a RUNNING spin rejects at its next await (cooperative), and any
+    ;; awaiting parents are re-notified.
+    (abort-spin-chain! sid err)
+    ;; (2) A SUSPENDED spin will never reach another await on its own, so step (1)
+    ;; alone strands it: its body never resumes and its `try/finally` cleanup never
+    ;; runs (and the parked continuation + external reader leak). Actively unwind it
+    ;; by delivering the cancellation into its parked await continuation — the
+    ;; structured-concurrency contract (`finally`/`ensure` runs on cancel).
+    (doseq [[cont-id cont] conts]
+      (case (:kind cont)
+        ;; Parked on a Deferred / Mailbox / async-thunk: invoking the cont's reject
+        ;; continuation resumes the body into its reject path so catch/finally run.
+        ;; Then arm the external-resource cancellation gate (so a later delivery on
+        ;; the abandoned reader is a no-op) and drop the now-spent cont.
+        :external-await
+        (do (try
+              (binding [ec/*execution-context* ctx
+                        ec/*spin-id*          sid
+                        pcps-async/*in-trampoline* false]
+                (when-let [rj (:reject-fn cont)] (rj err)))
+              (catch #?(:clj Throwable :cljs :default) _ nil))
+            (when-let [c! (:cancel! cont)]
+              (try (c! ctx) (catch #?(:clj Throwable :cljs :default) _ nil)))
+            (ec/swap-state! [:await-conts sid] (fn [m] (dissoc m cont-id))))
+        ;; Parked awaiting a child spin: cascade — cancel the child; its cancelled
+        ;; completion resumes THIS parent into reject via the normal :spin-completion
+        ;; path (which restores slice-state), so the parent's finally runs too.
+        (:await-once :await-reactive)
+        (when-let [child (:awaited-spin cont)]
+          (cancel-spin! child))
+        nil))))
 
 (defn cleanup-spin!
   "Manually clean up a spin, removing it from the runtime.

--- a/test/org/replikativ/spindel/engine/cont_cancellation_test.cljc
+++ b/test/org/replikativ/spindel/engine/cont_cancellation_test.cljc
@@ -31,7 +31,7 @@
             [org.replikativ.spindel.spin.sync :as sync]
             [org.replikativ.spindel.effects.track :refer [track]]
             [org.replikativ.spindel.effects.await :refer [await]]
-            [org.replikativ.spindel.core :as sp])
+            [org.replikativ.spindel.core :as sp]))
 
 #?(:clj
    (deftest no-double-side-effect-after-track-resume-mid-deferred-await

--- a/test/org/replikativ/spindel/engine/cont_cancellation_test.cljc
+++ b/test/org/replikativ/spindel/engine/cont_cancellation_test.cljc
@@ -30,7 +30,8 @@
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.spin.sync :as sync]
             [org.replikativ.spindel.effects.track :refer [track]]
-            [org.replikativ.spindel.effects.await :refer [await]]))
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.core :as sp])
 
 #?(:clj
    (deftest no-double-side-effect-after-track-resume-mid-deferred-await
@@ -314,3 +315,39 @@
            (finally
              (reset! hold [])
              (ctx/close-context! parent-ctx)))))))
+
+#?(:clj
+   (deftest cancel-unwinds-suspended-finally
+     (testing "cancel-spin! on a spin SUSPENDED at (await deferred) resumes its body
+            into the reject path so try/finally cleanup runs — the
+            structured-concurrency contract. Previously cancel only cached the
+            error + dirtied observers, stranding the parked body (finally never ran,
+            continuation + deferred reader leaked)."
+       (binding [ec/*execution-context* (ctx/create-execution-context)]
+         (let [cleaned (atom false)
+               d (sync/deferred)
+               s (spin (try (await d) (finally (reset! cleaned true))))]
+           (sp/spawn! s)
+           (Thread/sleep 100)
+           (is (false? @cleaned) "finally has not run while suspended")
+           (spin-core/cancel-spin! s)
+           (Thread/sleep 150)
+           (is (true? @cleaned) "finally RAN when the suspended spin was cancelled")
+           (is (spin-core/spin-cancelled? s) "spin is marked cancelled"))))))
+
+#?(:clj
+   (deftest cancel-cascades-to-awaited-child-finally
+     (testing "cancelling a parent suspended at (await child) cascades: the child
+            (itself suspended on a deferred) is cancelled, and BOTH the child's and
+            the parent's finally blocks run."
+       (binding [ec/*execution-context* (ctx/create-execution-context)]
+         (let [pf (atom false) cf (atom false)
+               d (sync/deferred)
+               child  (spin (try (await d)     (finally (reset! cf true))))
+               parent (spin (try (await child) (finally (reset! pf true))))]
+           (sp/spawn! parent)
+           (Thread/sleep 100)
+           (spin-core/cancel-spin! parent)
+           (Thread/sleep 200)
+           (is (true? @cf) "child finally ran (cascade)")
+           (is (true? @pf) "parent finally ran"))))))


### PR DESCRIPTION
## Problem

Cancellation was **cooperative-at-await-entry only**. `cancel-spin!` → `abort-spin-chain!` caches the cancel error + dirties observers, and `check-cancellation!` throws at the *next* await of a **running** spin. But a spin **suspended (parked) at an await** never reaches another await on its own, so it was **stranded**:

- its body never resumed → its `try/finally` cleanup never ran,
- the parked continuation + the external reader (`Deferred` `:pending`, `Mailbox` waiter) leaked.

This diverges from every structured-concurrency system (core.async, Kotlin coroutines, Trio/asyncio), where cancelling a suspended task runs its `finally`/`ensure`. (`partial-cps` already CPS-transforms `try/finally` correctly — the gap was purely that the engine never resumed the parked body on cancel.)

## Fix

After the existing mark+dirty, `cancel-spin!` now actively unwinds a suspended spin by delivering the cancellation into its **parked await continuation**:

- **`:external-await`** (Deferred / Mailbox / async-thunk): invoke the cont's reject continuation with the cancel error → the body resumes into its reject path (catch/finally run); then arm the resource's cancellation gate (a later delivery on the abandoned reader no-ops) and drop the spent cont.
- **`:await-once` / `:await-reactive`** (awaiting a child spin): cascade — cancel the child; its cancelled completion resumes the parent into reject via the normal `:spin-completion` path (slice-state restored), so the parent's `finally` runs too.

Reuses existing machinery (the cont's reject route + the external-await gate) — no new event type or resume path.

## Why it matters

This is the missing primitive under all cleanup-on-cancel: a cancelled task can now release resources / unsubscribe in a plain `finally`. It's the foundation for cancellable background tasks, per-turn cancellation, and subagent lifecycle in downstream consumers.

## Tests

+2 regression tests (`cancel-unwinds-suspended-finally`, `cancel-cascades-to-awaited-child-finally`). Full suite green: **816 tests / 2759 assertions, 0 failures, 0 errors** — no regressions.