### PR TITLE
fix(cancel): propagate cancellation through race/parallel/timeout into children

### DIFF
--- a/src/org/replikativ/spindel/spin/combinators.cljc
+++ b/src/org/replikativ/spindel/spin/combinators.cljc
@@ -86,39 +86,44 @@
         ;; reads/updates THAT (per-context, overlay-copied → fork-isolated).
         results-atom (atom (vec (repeat n nil)))]
     (binding [ec/*execution-context* execution-context]
-      (spin-core/make-spin
-       (fn [resolve reject]
+      (let [parallel-spin
+            (spin-core/make-spin
+             (fn [resolve reject]
          ;; Start each child using CPS (no deref). The child will invoke our callbacks
          ;; when it completes; we coordinate final resolution here.
-         (doseq [[i child-spin] (map-indexed vector spin-vec)]
-           (let [on-ok (fn [v]
+               (doseq [[i child-spin] (map-indexed vector spin-vec)]
+                 (let [on-ok (fn [v]
                          ;; Update this child's slot in the local accumulator
                          ;; (atomic swap! — children complete concurrently).
-                         (swap! results-atom assoc i v)
-                         (when (= n (swap! completed inc))
+                               (swap! results-atom assoc i v)
+                               (when (= n (swap! completed inc))
                            ;; All children completed initially
-                           (when (compare-and-set! done? false true)
+                                 (when (compare-and-set! done? false true)
+                             ;; Initial fan-out done: from here children are tracked
+                             ;; as reactive await-conts (below), so the normal cascade
+                             ;; covers cancel — release the owned-spins ownership edge.
+                                   (spin-core/set-owned-spins! parallel-spin-id nil)
                              ;; Capture initial values BEFORE registering continuations
                              ;; Used to distinguish initial completion events (already in queue)
                              ;; from re-completions (should trigger notifications)
-                             (let [initial-results @results-atom]
+                                   (let [initial-results @results-atom]
                                ;; Register continuations for reactive child re-completions
                                ;; This makes parallel reactive: when children re-run due to
                                ;; tracked signal changes, parallel will update and notify awaiters
                                ;; Only register for actual Spins (not deferreds which are one-shot)
-                               (doseq [[j t] (map-indexed vector spin-vec)]
-                                 (when (satisfies? spin-core/PSpin t)
-                                   (let [t-id (spin-core/spin-id t)
-                                         initial-val (get initial-results j)
-                                         captured-bindings (bindings/capture-bindings)
-                                         resolve-fn (fn [new-val]
+                                     (doseq [[j t] (map-indexed vector spin-vec)]
+                                       (when (satisfies? spin-core/PSpin t)
+                                         (let [t-id (spin-core/spin-id t)
+                                               initial-val (get initial-results j)
+                                               captured-bindings (bindings/capture-bindings)
+                                               resolve-fn (fn [new-val]
                                                       ;; Child re-completed :ok — `new-val` is its
                                                       ;; payload. Only notify if it differs from the
                                                       ;; initial value: initial completion events are
                                                       ;; still in the queue and carry `initial-val`;
                                                       ;; re-completions due to signal changes carry a
                                                       ;; different value.
-                                                      (when (not= new-val initial-val)
+                                                            (when (not= new-val initial-val)
                                                         ;; Reactive phase: the parallel's result vector
                                                         ;; now lives on the node's cached result (which is
                                                         ;; per-context engine state, overlay-copied on fork
@@ -129,33 +134,33 @@
                                                         ;; `initial-results` is the fallback if the node
                                                         ;; result isn't a vector yet (shouldn't happen post
                                                         ;; initial completion, but keeps us robust).
-                                                        (let [cached (ec/spin-current-result parallel-spin-id)
-                                                              base (let [p (when cached (:payload cached))]
-                                                                     (if (vector? p) p initial-results))
-                                                              updated (assoc base j new-val)]
+                                                              (let [cached (ec/spin-current-result parallel-spin-id)
+                                                                    base (let [p (when cached (:payload cached))]
+                                                                           (if (vector? p) p initial-results))
+                                                                    updated (assoc base j new-val)]
                                                           ;; Re-cache parallel's result to notify our awaiters
-                                                          (ec/spin-cache-result!
-                                                           parallel-spin-id
-                                                           (spin-core/ok updated))
+                                                                (ec/spin-cache-result!
+                                                                 parallel-spin-id
+                                                                 (spin-core/ok updated))
                                                           ;; Fire completion event to resume awaiting spins
-                                                          (ec/enqueue-event!
-                                                           {:type :spin-completion :id parallel-spin-id}))))
-                                         reject-fn (fn [e]
+                                                                (ec/enqueue-event!
+                                                                 {:type :spin-completion :id parallel-spin-id}))))
+                                               reject-fn (fn [e]
                                                      ;; Child re-completed :error — propagate the
                                                      ;; failure. parallel re-completes :error,
                                                      ;; consistent with its fail-fast initial
                                                      ;; behavior (a re-failing child fails parallel).
-                                                     (ec/spin-cache-result!
-                                                      parallel-spin-id
-                                                      (spin-core/error e))
-                                                     (ec/enqueue-event!
-                                                      {:type :spin-completion :id parallel-spin-id}))
-                                         cont-map {:event-key [:spin/complete t-id]
+                                                           (ec/spin-cache-result!
+                                                            parallel-spin-id
+                                                            (spin-core/error e))
+                                                           (ec/enqueue-event!
+                                                            {:type :spin-completion :id parallel-spin-id}))
+                                               cont-map {:event-key [:spin/complete t-id]
                                                    ;; Persistent reactive cont — parallel re-fires when a
                                                    ;; child re-completes; never reaped at generation bounds.
-                                                   :kind :await-reactive
-                                                   :resolve-fn resolve-fn
-                                                   :reject-fn reject-fn
+                                                         :kind :await-reactive
+                                                         :resolve-fn resolve-fn
+                                                         :reject-fn reject-fn
                                                    ;; await is monadic: `:on-resume` fetches the
                                                    ;; child's cached `Result` and `:resume-fn`
                                                    ;; pattern-matches its `:variant`, routing an
@@ -165,38 +170,44 @@
                                                    ;; child would be re-cached as `(ok <the-error>)`
                                                    ;; instead of propagating the failure — see the
                                                    ;; standard await cont in effects/await.cljc.
-                                                   :resume-fn (fn [child-result]
-                                                                (if (= (:variant child-result) :ok)
-                                                                  (spin-core/resume resolve-fn (:payload child-result))
-                                                                  (spin-core/resume reject-fn (:payload child-result))))
-                                                   :bindings captured-bindings
-                                                   :on-resume (fn [_]
-                                                                (ec/spin-current-result t-id))}]
-                                     (ec/continuation-add! parallel-spin-id cont-map))))
+                                                         :resume-fn (fn [child-result]
+                                                                      (if (= (:variant child-result) :ok)
+                                                                        (spin-core/resume resolve-fn (:payload child-result))
+                                                                        (spin-core/resume reject-fn (:payload child-result))))
+                                                         :bindings captured-bindings
+                                                         :on-resume (fn [_]
+                                                                      (ec/spin-current-result t-id))}]
+                                           (ec/continuation-add! parallel-spin-id cont-map))))
                                ;; Initial resolve with the accumulated results. The
                                ;; engine caches this vector on the parallel's node;
                                ;; the reactive conts above update that cached value.
-                               (spin-core/resume resolve @results-atom)))))
+                                     (spin-core/resume resolve @results-atom)))))
 
-                 on-err (fn [e]
+                       on-err (fn [e]
                           ;; First error wins; cancel siblings and reject
-                          (when (compare-and-set! done? false true)
-                            (doseq [[j other] (map-indexed vector spin-vec)]
-                              (when (not= i j)
-                                (spin-core/cancel-spin! other)))
-                            (spin-core/resume reject e)))]
+                                (when (compare-and-set! done? false true)
+                                  (spin-core/set-owned-spins! parallel-spin-id nil)
+                                  (doseq [[j other] (map-indexed vector spin-vec)]
+                                    (when (not= i j)
+                                      (spin-core/cancel-spin! other)))
+                                  (spin-core/resume reject e)))]
              ;; Invoke child spin via execution-context scheduling to enable parallelism
              ;; Must explicitly bind *execution-context* because CLJS capture-bindings excludes it
              ;; to avoid circular references
-             (executor/execute! (:executor execution-context)
-                                (executor/alive-fn execution-context
-                                                   (fn []
-                                                     (binding [ec/*execution-context* execution-context]
-                                                       (child-spin on-ok on-err)))))))
+                   (executor/execute! (:executor execution-context)
+                                      (executor/alive-fn execution-context
+                                                         (fn []
+                                                           (binding [ec/*execution-context* execution-context]
+                                                             (child-spin on-ok on-err)))))))
 
          ;; Async coordination; parent suspends
-         spin-core/incomplete)
-       parallel-spin-id))))
+               spin-core/incomplete)
+             parallel-spin-id)]
+        ;; Ownership edge for external cancel during the initial fan-out window
+        ;; (children are started via the executor callbacks above, not via
+        ;; `await`, so they're outside the await-cont graph until `done?` flips).
+        (spin-core/set-owned-spins! parallel-spin-id spin-vec)
+        parallel-spin))))
 
 ;; =============================================================================
 ;; Delay Primitive
@@ -272,40 +283,51 @@
     (throw (ex-info "race requires at least one spin" {})))
   ;; Capture execution-context at creation time (like parallel does)
   ;; This ensures bindings are captured before any async scheduling
-  (let [execution-context (ec/current-execution-context)]
+  (let [execution-context (ec/current-execution-context)
+        ;; Generate ID upfront so we can record the ownership edge (parallel does
+        ;; the same) — lets an external cancel reach the racing children.
+        race-spin-id (keyword (gensym "race-"))
+        spin-vec (vec spins)]
     (binding [ec/*execution-context* execution-context]
-      (spin-core/make-spin
-       (fn [resolve reject]
-         (let [done? (atom false)
-               spin-vec (vec spins)]
-           (doseq [[idx t] (map-indexed vector spin-vec)]
-             (let [on-ok (fn [v]
-                           (when (compare-and-set! done? false true)
+      (let [race-spin
+            (spin-core/make-spin
+             (fn [resolve reject]
+               (let [done? (atom false)]
+                 (doseq [[idx t] (map-indexed vector spin-vec)]
+                   (let [on-ok (fn [v]
+                                 (when (compare-and-set! done? false true)
+                             ;; Race is terminal once won — release the ownership edge.
+                                   (spin-core/set-owned-spins! race-spin-id nil)
                              ;; Cancel losing spins cooperatively
                              ;; Wrap in try-catch to handle any synchronous exceptions
                              ;; from the cancellation machinery
-                             (doseq [[j other-t] (map-indexed vector spin-vec)]
-                               (when (not= idx j)
-                                 (try
-                                   (spin-core/cancel-spin! other-t)
-                                   (catch #?(:clj Throwable :cljs :default) _
+                                   (doseq [[j other-t] (map-indexed vector spin-vec)]
+                                     (when (not= idx j)
+                                       (try
+                                         (spin-core/cancel-spin! other-t)
+                                         (catch #?(:clj Throwable :cljs :default) _
                                      ;; Ignore cancellation errors - already handled
                                      ;; by the on-err callback's ex-data check
-                                     nil))))
-                             (spin-core/resume resolve v)))
-                   on-err (fn [e]
+                                           nil))))
+                                   (spin-core/resume resolve v)))
+                         on-err (fn [e]
                             ;; Ignore cancellation errors from losing spins
                             ;; (they're expected when a winner cancels them)
-                            (when-not (= spin-core/spin-cancelled (:type (ex-data e)))
-                              (when (compare-and-set! done? false true)
-                                (spin-core/resume reject e))))]
+                                  (when-not (= spin-core/spin-cancelled (:type (ex-data e)))
+                                    (when (compare-and-set! done? false true)
+                                      (spin-core/set-owned-spins! race-spin-id nil)
+                                      (spin-core/resume reject e))))]
                ;; Use captured execution-context, and bind it for the spin execution
-               (executor/execute! (:executor execution-context)
-                                  (executor/alive-fn execution-context
-                                                     (fn []
-                                                       (binding [ec/*execution-context* execution-context]
-                                                         (t on-ok on-err)))))))
-           spin-core/incomplete))))))
+                     (executor/execute! (:executor execution-context)
+                                        (executor/alive-fn execution-context
+                                                           (fn []
+                                                             (binding [ec/*execution-context* execution-context]
+                                                               (t on-ok on-err)))))))
+                 spin-core/incomplete))
+             race-spin-id)]
+        ;; Ownership edge for external cancel during the in-flight race window.
+        (spin-core/set-owned-spins! race-spin-id spin-vec)
+        race-spin))))
 
 ;; =============================================================================
 ;; Rate Control Combinators

--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -594,6 +594,28 @@
   (let [cached (ec/spin-current-result (spin-id spin))]
     (boolean (and cached (error? cached)))))
 
+(defn ^:no-doc set-owned-spins!
+  "Record the child spins a fan-out combinator (`race`/`parallel`) owns during
+   its initial concurrent fan-out, so an external `cancel-spin!` of the
+   combinator cascades into those still-in-flight children.
+
+   The children are started via manual `make-spin` callbacks, NOT `await`, so
+   they sit outside the await-cont graph that `cancel-spin!` normally walks —
+   without this edge an external cancel can't reach them (the structured-
+   concurrency gap).
+
+   Stored ON the combinator's own node (`:nodes[sid]:owned-spins`), so it is
+   reclaimed for free when `full-cleanup-spin!` drops the node — no separate
+   top-level registry to keep in sync across cleanup/fork/GC sites. `spins`
+   nil/empty CLEARS the edge (called when the combinator's `done?` flips: a
+   resolved `race` is terminal, and a completed `parallel` has by then
+   registered its children as `:await-reactive` conts which the normal cascade
+   covers)."
+  [sid spins]
+  (when-let [ctx (ec/current-execution-context)]
+    (rtp/swap-state! ctx [:nodes sid :owned-spins]
+                     (constantly (when (seq spins) (vec spins))))))
+
 (defn cancel-spin!
   "Cancel a spin and all its observers (cooperative cancellation).
 
@@ -639,13 +661,36 @@
             (when-let [c! (:cancel! cont)]
               (try (c! ctx) (catch #?(:clj Throwable :cljs :default) _ nil)))
             (ec/swap-state! [:await-conts sid] (fn [m] (dissoc m cont-id))))
-        ;; Parked awaiting a child spin: cascade — cancel the child; its cancelled
-        ;; completion resumes THIS parent into reject via the normal :spin-completion
-        ;; path (which restores slice-state), so the parent's finally runs too.
+        ;; Parked awaiting a child spin (incl. a reactive aseq/PSpin): resume THIS
+        ;; parent into reject directly — the cont's :reject-fn is the parent body's
+        ;; raw reject continuation, so invoking it unwinds the parent's try/finally
+        ;; without depending on the child driving a :spin-completion resume (which a
+        ;; reactive await won't, on cancel). Then cascade-cancel the awaited child so
+        ;; it terminates too, and drop the spent cont.
         (:await-once :await-reactive)
-        (when-let [child (:awaited-spin cont)]
-          (cancel-spin! child))
-        nil))))
+        (do (try
+              (binding [ec/*execution-context* ctx
+                        ec/*spin-id*          sid
+                        pcps-async/*in-trampoline* false]
+                (when-let [rj (:reject-fn cont)] (rj err)))
+              (catch #?(:clj Throwable :cljs :default) _ nil))
+            (when-let [child (:awaited-spin cont)]
+              (cancel-spin! child))
+            (ec/swap-state! [:await-conts sid] (fn [m] (dissoc m cont-id))))
+        nil))
+    ;; (3) Cascade into combinator-owned children. A fan-out combinator
+    ;; (`race`/`parallel`) starts its children via manual `make-spin` callbacks,
+    ;; so during the initial fan-out window they are held outside the await-cont
+    ;; graph — steps (1)/(2) never reach them and they (plus any `finally` they
+    ;; guard) leak on an external cancel. The combinator records them on its node
+    ;; via `set-owned-spins!`; cancel each that is still in flight. The
+    ;; cached-result guard skips a child that already terminated (e.g. a race
+    ;; winner), so we never overwrite a completed result — and the combinator
+    ;; clears this edge when `done?` flips, so post-completion cancels find it
+    ;; empty regardless.
+    (doseq [child (ec/get-state [:nodes sid :owned-spins])]
+      (when (and child (nil? (ec/spin-current-result (spin-id child))))
+        (cancel-spin! child)))))
 
 (defn cleanup-spin!
   "Manually clean up a spin, removing it from the runtime.

--- a/test/org/replikativ/spindel/engine/cont_cancellation_test.cljc
+++ b/test/org/replikativ/spindel/engine/cont_cancellation_test.cljc
@@ -31,6 +31,9 @@
             [org.replikativ.spindel.spin.sync :as sync]
             [org.replikativ.spindel.effects.track :refer [track]]
             [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.seq.core :refer [gen-aseq]]
+            [org.replikativ.spindel.spin.combinators :as comb]
+            [is.simm.partial-cps.sequence :refer [anext]]
             [org.replikativ.spindel.core :as sp]))
 
 #?(:clj
@@ -351,3 +354,122 @@
            (Thread/sleep 200)
            (is (true? @cf) "child finally ran (cascade)")
            (is (true? @pf) "parent finally ran"))))))
+
+#?(:clj
+   (deftest cancel-unwinds-finally-awaiting-aseq-element
+     (testing "cancel-spin! on a spin SUSPENDED at (await (anext gen)) — the exact
+            shape `dvergr.discourse/ask` uses (await one item off a bus
+            subscription's async-seq) — resumes the body into reject so try/finally
+            cleanup runs. The awaited child is an `anext` step-spin parked on its own
+            per-step deferred; cancelling the parent must unwind the parent's finally
+            (the asker-unsubscribe in dvergr) even though the parked generator never
+            yields and so never drives a normal :spin-completion resume."
+       (binding [ec/*execution-context* (ctx/create-execution-context)]
+         (let [cleaned (atom false)
+               ;; A generator whose first step parks forever on an undelivered
+               ;; deferred BEFORE yielding — so (anext gen) suspends and never
+               ;; completes on its own.
+               block (sync/deferred)
+               gen   (gen-aseq
+                      (let [_ (await block)]
+                        (org.replikativ.spindel.seq.core/yield :never)))
+               consumer (spin
+                         (try
+                           (let [[item _] (await (anext gen))]
+                             item)
+                           (finally (reset! cleaned true))))]
+           (sp/spawn! consumer)
+           (Thread/sleep 120)
+           (is (false? @cleaned) "finally has not run while parked on (anext gen)")
+           (spin-core/cancel-spin! consumer)
+           (Thread/sleep 200)
+           (is (true? @cleaned)
+               "finally RAN when the spin parked on an aseq element was cancelled")
+           (is (spin-core/spin-cancelled? consumer) "spin is marked cancelled"))))))
+
+;; ===========================================================================
+;; Combinator cancellation propagation (the structured-concurrency gap):
+;; race/parallel start children via manual make-spin callbacks, so the children
+;; live outside the await-cont graph that cancel walks. The `:owned-spins`
+;; ownership edge (recorded on the combinator's node, cleared when `done?`
+;; flips) lets an external cancel of the combinator reach its in-flight
+;; children — closing the leak where `(cancel-spin! (timeout (ask …)))` left
+;; the inner ask running and its `finally` unrun.
+;; ===========================================================================
+
+#?(:clj
+   (deftest cancel-propagates-through-timeout-into-child
+     (testing "cancel of a spin awaiting (comb/timeout child …) — the exact shape
+            dvergr's background spawn-task! uses to wrap d/ask — propagates into
+            the child so the child's try/finally runs and the child is cancelled."
+       (binding [ec/*execution-context* (ctx/create-execution-context)]
+         (let [cleaned (atom false)
+               d (sync/deferred)
+               child  (spin (try (await d) (finally (reset! cleaned true))))
+               parent (spin (await (comb/timeout child 60000 ::to)))]
+           (sp/spawn! parent)
+           (Thread/sleep 120)
+           (is (false? @cleaned) "child still parked before cancel")
+           (spin-core/cancel-spin! parent)
+           (Thread/sleep 220)
+           (is (true? @cleaned) "child finally RAN (cancel reached through timeout)")
+           (is (spin-core/spin-cancelled? child) "child was cancelled"))))))
+
+#?(:clj
+   (deftest cancel-propagates-through-race-into-losing-children
+     (testing "cancel of a spin awaiting (comb/race a b) — both arms parked — cancels
+            BOTH children and runs BOTH finally blocks (owned-spins reaches the
+            fan-out children that aren't in the await graph)."
+       (binding [ec/*execution-context* (ctx/create-execution-context)]
+         (let [ca (atom false) cb (atom false)
+               da (sync/deferred) db (sync/deferred)
+               a (spin (try (await da) (finally (reset! ca true))))
+               b (spin (try (await db) (finally (reset! cb true))))
+               parent (spin (await (comb/race a b)))]
+           (sp/spawn! parent)
+           (Thread/sleep 120)
+           (spin-core/cancel-spin! parent)
+           (Thread/sleep 220)
+           (is (true? @ca) "race arm A finally ran")
+           (is (true? @cb) "race arm B finally ran"))))))
+
+#?(:clj
+   (deftest cancel-propagates-through-parallel-into-children
+     (testing "cancel of a spin awaiting (comb/parallel a b) during initial fan-out
+            (both arms parked) cancels both children and runs both finally blocks."
+       (binding [ec/*execution-context* (ctx/create-execution-context)]
+         (let [ca (atom false) cb (atom false)
+               da (sync/deferred) db (sync/deferred)
+               a (spin (try (await da) (finally (reset! ca true))))
+               b (spin (try (await db) (finally (reset! cb true))))
+               parent (spin (await (comb/parallel a b)))]
+           (sp/spawn! parent)
+           (Thread/sleep 120)
+           (spin-core/cancel-spin! parent)
+           (Thread/sleep 220)
+           (is (true? @ca) "parallel arm A finally ran")
+           (is (true? @cb) "parallel arm B finally ran"))))))
+
+#?(:clj
+   (deftest race-winner-result-survives-later-cancel-of-completed-race
+     (testing "When a race has already resolved (winner cached), the owned-spins edge
+            was cleared as `done?` flipped — so a later cancel of the (completed)
+            race does NOT re-cancel/overwrite the winner child's cached result."
+       (binding [ec/*execution-context* (ctx/create-execution-context)]
+         (let [dwin (sync/deferred)
+               dlose (sync/deferred)
+               winner (spin (await dwin))
+               loser  (spin (await dlose))
+               r (comb/race winner loser)]
+           (sp/spawn! r)
+           (Thread/sleep 80)
+           (sync/deliver! dwin :won)
+           (Thread/sleep 150)
+           (is (= :won @r) "race resolved to the winner")
+           ;; Cancelling the already-complete race must not disturb the winner's
+           ;; cached :ok result (owned-spins was cleared when done? flipped).
+           (spin-core/cancel-spin! r)
+           (Thread/sleep 100)
+           (let [res (ec/get-state [:nodes (spin-core/spin-id winner) :result])]
+             (is (or (nil? res) (= :ok (:variant res)))
+                 "winner child's cached result was not overwritten by a stray cancel")))))))


### PR DESCRIPTION
## Problem

Two structured-concurrency gaps left a cancelled spin's descendants running and their `try/finally` cleanup unrun. This surfaced in dvergr as a leaked `d/ask` bus subscription whenever a background task (an `ask` wrapped in `comb/timeout`) was cancelled.

`cancel-spin!` propagates by walking the **await-cont graph**. Two kinds of child are *not* on that graph:

1. **Reactive awaits.** A parent suspended at `(await child)` got an `:await-reactive` cont. Cancel only cascaded to the child and relied on the child's cancelled *completion* to drive the parent's resume — but a reactive await (aseq/PSpin) doesn't drive that on cancel, so the parent's `finally` never ran.
2. **Combinator fan-out children.** `race`/`parallel` (and therefore `timeout`) start their children via manual `make-spin` callbacks, **not** `await`. The children live entirely outside the await-cont graph, so an external cancel of the combinator never reached them at all (`child-cancelled = nil` in a probe).

## Fix

1. For `:await-once`/`:await-reactive` conts, **reject-resume the parent body directly** (the cont's `:reject-fn` is the parent's raw reject continuation), unwinding its `try/finally` regardless of whether the child drives a completion — then still cascade-cancel the child.

2. A single **ownership edge** recorded *on the combinator's own node*, `:nodes[sid]:owned-spins`. `cancel-spin!` cascades into it (guarded by a cached-result check so a completed race winner isn't overwritten). The combinator **clears** the edge when `done?` flips — a resolved `race` is terminal, and a completed `parallel` has by then registered its children as reactive await-conts the normal cascade covers.

### Why node-attached, not a new registry

`full-cleanup-spin!` already hand-enumerates 8+ state locations to scrub per spin. A new top-level `:spin-children` map would be a 9th location to keep in sync across cleanup / fork-CoW / GC-safety predicates — a real leak surface. Node-attached state is dropped wholesale by `full-cleanup-spin!`'s `(update :nodes dissoc spin-id)`, so the edge is reclaimed for free with **zero new cleanup sites** (same pattern `make-spin` uses for `:spin-scope`).

## Tests

New regression tests in `cont_cancellation_test`:
- cancel unwinds `finally` through `timeout`, `race`, `parallel`, and through an aseq element (`anext` — the exact `d/ask` shape)
- a completed `race` winner's result survives a later cancel of the (terminal) race

## Verification

- Full CLJ suite **823 tests / 2774 assertions, 0 failures**
- `shadow-cljs compile ci` clean (227 files, 0 warnings)
- `cljfmt` clean
- End-to-end in dvergr (against this branch via `:local`): cancelling a `timeout`-wrapped `d/ask` leaves the room's participants map with zero `ask-*` askers