### PR TITLE
feat(fork): branch-based convergent forks + fully-async portable fork/merge

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
         ;; 0.1.60 ships the optional core.async adapter (is.simm.partial-cps.core-async)
         ;; that distributed.cps delegates to.
         is.simm/partial-cps {:mvn/version "0.1.60"}
-        org.replikativ/yggdrasil {:mvn/version "0.3.34"}
+        org.replikativ/yggdrasil {:mvn/version "0.3.35"}
         org.replikativ/hasch {:mvn/version "0.4.99"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         anglican/anglican {:mvn/version "1.1.0"}

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -400,7 +400,7 @@
   - Fork-local state (continuations, engine queue/timers) doesn't fall back
   - Bindings are merged (child overrides parent)
   - Process-id auto-increments for Elle compatibility"
-  [parent-ctx & {:keys [state-updates bindings metadata process-id mode snapshots]
+  [parent-ctx & {:keys [state-updates bindings metadata process-id mode snapshots convergent-fork]
                  :or {state-updates {}
                       bindings {}
                       metadata nil
@@ -431,7 +431,9 @@
                            (if-let [pnode (rtp/get-state parent-ctx [:nodes sig-id])]
                              (let [directive  (if-let [snap (get snapshots sig-id)]
                                                 {:fork :snapshot :snapshot snap}
-                                                {:fork :overlay :mode mode})
+                                                ;; :convergent-fork (:branch default | :overlay) is
+                                                ;; opaque to the engine; the ygg bridge interprets it.
+                                                {:fork :overlay :mode mode :convergent-fork convergent-fork})
                                    forked-val (rtp/fork-value (nodes/get-value pnode)
                                                               fork-id directive)]
                                (assoc! m sig-id

--- a/src/org/replikativ/spindel/seq/core.cljc
+++ b/src/org/replikativ/spindel/seq/core.cljc
@@ -18,12 +18,21 @@
 ;; Extend nil to PAsyncSeq (spin-based anext)
 ;; =============================================================================
 
+;; nil terminates an async sequence. Return a PLAIN partial-cps thunk (as
+;; partial-cps.sequence's own nil impl and every other extension here do) — NOT a
+;; `make-spin`. `make-spin` calls `spin-register!` → `current-execution-context`,
+;; which THROWS when no spindel context is bound. Because `PAsyncSeq` is a SHARED
+;; protocol (referred from partial-cps.sequence) and `extend-type` is global
+;; last-writer-wins, a spin-based nil terminator poisoned EVERY partial-cps
+;; async-seq iteration (e.g. konserve/PSS drains inside a durable yggdrasil op)
+;; that runs OUTSIDE a bound spindel context — the exact cljs failure of a durable
+;; convergent fork/merge driven async. A plain thunk needs no context and is
+;; `await`-able identically (the ifn-await path).
 (extend-type nil
   PAsyncSeq
   (anext [_]
-    (spin-core/make-spin
-     (fn [resolve _reject]
-       (resolve nil)))))
+    (fn [resolve _reject]
+      (resolve nil))))
 
 ;; =============================================================================
 ;; yield - Breakpoint for async sequence generation

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -23,6 +23,15 @@
    - merge-to-parent! / discard-from-parent!: parent-controlled merge-down /
      discard of the fork's per-system overlays.
 
+   ASYNC+SYNC (portability, Design B): the engine stays synchronous and every
+   fn that drives a DURABLE yggdrasil op (`fork!`, merge/discard/diff/conflicts)
+   is written `async+sync` — SYNC on the JVM (returns a value, byte-identical to
+   before) and a partial-cps CONTINUATION on cljs (each durable call `await`ed).
+   So a DURABLE convergent-CRDT BRANCH fork works on cljs too; call these fns
+   inside a partial-cps `async` and `await` (`<?`) their result on cljs. Plain
+   engine reads (`system`, `@yref`, `registered-systems`, `set-node-value!`) stay
+   synchronous. Snapshot forks remain JVM-first (see `fork-value`).
+
    Naming convention: Prefix YggRef vars with 'y' (e.g., ygit, ydb) to signal
    deref needed.
 
@@ -53,7 +62,12 @@
             [yggdrasil.convergent :as yc]
             [yggdrasil.convergent.overlay :as ovl]
             [clojure.string :as str]
-            #?@(:clj [[yggdrasil.gc :as ygg-gc]])))
+            #?(:clj  [is.simm.partial-cps.async :refer [async await]]
+               :cljs [is.simm.partial-cps.async :refer [await]])
+            #?(:clj [yggdrasil.macros :refer [async+sync]])
+            #?@(:clj [[yggdrasil.gc :as ygg-gc]]))
+  #?(:cljs (:require-macros [yggdrasil.macros :refer [async+sync]]
+                            [is.simm.partial-cps.async :refer [async]])))
 
 ;; =============================================================================
 ;; Index keys
@@ -123,8 +137,12 @@
   "BRANCH fork (the DEFAULT for convergent systems): a REAL branched system as the
    fork value — inherits the parent tip, so `@kref`/`g/elements`/`g/conj` operate on
    it directly (no overlay footguns). `fork-id` is the engine-assigned `:fork-<uuid>`
-   keyword, used as the branch name. Threads the platform default mode (JVM sync;
-   durable branch-fork on cljs is async — a follow-up lifts the sync engine hook)."
+   keyword, used as the branch name.
+
+   JVM-ONLY: the engine's `fork-value` hook is synchronous, but durable `branch!`/
+   `checkout` are SYNC on the JVM (values) and ASYNC on cljs (CPS). So on the JVM
+   `fork-value` branch-forks here directly; on cljs `fork-value` DEFERS (returns the
+   parent system unchanged) and `fork!` finishes the branch in an AWAITED post-pass."
   [sys fork-id]
   (-> sys (ygg/branch! fork-id) (ygg/checkout fork-id)))
 
@@ -139,16 +157,22 @@
       (ovl/overlay? this)
       (rtp/fork-value (ovl/overlay-system this) fork-id directive)
 
-      ;; SNAPSHOT fork (pin a fixed value) — any Snapshotable, versioned or convergent
+      ;; SNAPSHOT fork (pin a fixed value) — any Snapshotable, versioned or convergent.
+      ;; JVM-FIRST: `snapshot-fork` calls durable `branch!`/`checkout` synchronously, which
+      ;; only yields a value on the JVM (cljs returns a CPS). Snapshot forks stay JVM-first;
+      ;; the async lift (Design B) covers the DEFAULT branch-fork path, not snapshot forks.
       (and (= :snapshot (:fork directive)) (satisfies? ygg/Snapshotable this))
       (snapshot-fork this fork-id (:snapshot directive))
 
       ;; CONVERGENT + genuinely branchable → BRANCH fork by DEFAULT.
       ;; `:convergent-fork :overlay` forces the (optional) live-:following overlay.
+      ;; `fork-value` is a SYNC engine hook, but durable branch-fork is async on cljs, so
+      ;; on cljs we DEFER (return `this` unchanged) and let `fork!`'s awaited post-pass
+      ;; branch it; the JVM branch-forks here directly (a value).
       (convergent-branchable? this)
       (if (= :overlay (:convergent-fork directive))
         (overlay-fork this directive)
-        (branch-fork this fork-id))
+        #?(:clj (branch-fork this fork-id) :cljs this))
 
       ;; CONVERGENT but not branchable (cdvcs) → overlay if it has one, else FAIL LOUD
       ;; (rather than NPE deep in a GSet op on a non-branchable value).
@@ -379,18 +403,39 @@
        (merge-fork! fork))"
   ([] (fork! {}))
   ([opts]
-   (let [parent-ctx (ec/current-execution-context)
-         ;; translate :snapshots from SYSTEM-id keys (what callers know) to the
-         ;; SIGNAL-id keys fork-context forks by.
-         snaps  (when-let [s (:snapshots opts)]
-                  (into {} (keep (fn [[sid snap]]
-                                   (when-let [sr (get (registry parent-ctx) sid)]
-                                     [(:id sr) snap])))
-                        s))
-         opts   (cond-> opts snaps (assoc :snapshots snaps))
-         child-ctx  (apply ctx/fork-context parent-ctx (mapcat identity opts))
-         fork-id    (:fork-id child-ctx)]
-     (->ForkHandle child-ctx parent-ctx fork-id))))
+   (async+sync
+    (:sync? (merge yc/default-opts opts))
+    (async
+     (let [parent-ctx (ec/current-execution-context)
+           ;; translate :snapshots from SYSTEM-id keys (what callers know) to the
+           ;; SIGNAL-id keys fork-context forks by.
+           snaps  (when-let [s (:snapshots opts)]
+                    (into {} (keep (fn [[sid snap]]
+                                     (when-let [sr (get (registry parent-ctx) sid)]
+                                       [(:id sr) snap])))
+                          s))
+           fopts  (cond-> opts snaps (assoc :snapshots snaps))
+           child-ctx  (apply ctx/fork-context parent-ctx (mapcat identity fopts))
+           fork-id    (:fork-id child-ctx)
+           popts  (merge yc/default-opts opts)]
+       ;; POST-PASS (Design B async lift): the engine's `fork-context`/`fork-value`
+       ;; hook is SYNCHRONOUS, so a convergent BRANCH fork — durable `branch!`/`checkout`
+       ;; that only yield a value synchronously on the JVM — is done here, AWAITED, over
+       ;; the parent's branchable-convergent signals. On the JVM `fork-value` already
+       ;; branched each (its `current-branch` is a `fork-<uuid>`), so the guard makes this
+       ;; a NO-OP; on cljs `fork-value` deferred (left the parent value), so this branches
+       ;; each and seats the branched system as the fork's value. ONE code path, both
+       ;; platforms (async+sync collapses to `do` on the JVM).
+       (loop [ps (seq (shared-pairs child-ctx parent-ctx))]
+         (when ps
+           (let [[_sid sig-ref cval _psys] (first ps)]
+             (when (and (convergent-branchable? cval)
+                        (not (fork-branch-name? (ygg/current-branch cval))))
+               (let [_        (await (ygg/branch! cval fork-id (ygg/current-branch cval) popts))
+                     branched (await (ygg/checkout cval fork-id popts))]
+                 (set-node-value! child-ctx sig-ref branched))))
+           (recur (next ps))))
+       (->ForkHandle child-ctx parent-ctx fork-id))))))
 
 ;; `with-fork` is a JVM-only convenience macro. On cljs use the engine form it
 ;; expands to directly: `(ec/with-context (:child-ctx fork) …)`.
@@ -412,15 +457,25 @@
    Resolves everything to SNAPSHOT-IDS (git sha / datahike db hash). `fsys` is
    the fork's writable system (the overlay's overlay-system)."
   [fsys psys]
-  (let [psnap (ygg/snapshot-id psys)
-        fsnap (ygg/snapshot-id fsys)]
-    (or (try
-          (let [base (ygg/common-ancestor fsys psnap fsnap)]
-            (when base (ygg/diff fsys base fsnap)))
-          (catch #?(:clj Throwable :cljs :default) _ nil))
-        (try (ygg/diff fsys psnap fsnap)
-             (catch #?(:clj Throwable :cljs :default) t
-               (ygt/diff-error psnap fsnap (ex-message t)))))))
+  (async+sync
+   (:sync? yc/default-opts)
+   (async
+    (let [psnap (await (ygg/snapshot-id psys))
+          fsnap (await (ygg/snapshot-id fsys))]
+      ;; `snapshot-id`/`common-ancestor` are always-async (await). `diff` is a plain value
+      ;; for conflict-free convergent CRDTs (`{}`) but async CPS for versioned systems —
+      ;; await ONLY when it is a continuation (a fn).
+      (or (try
+            (let [base (await (ygg/common-ancestor fsys psnap fsnap))]
+              (when base
+                (let [d (ygg/diff fsys base fsnap)]
+                  (if (fn? d) (await d) d))))
+            (catch #?(:clj Throwable :cljs :default) _ nil))
+          (try
+            (let [d (ygg/diff fsys psnap fsnap)]
+              (if (fn? d) (await d) d))
+            (catch #?(:clj Throwable :cljs :default) t
+              (ygt/diff-error psnap fsnap (ex-message t)))))))))
 
 (defn context-diff
   "Per-system delta of a forked context vs its parent — the unified diff a
@@ -428,30 +483,47 @@
    DiffError)}. nil when the context has no parent. Non-Mergeable systems are
    omitted."
   [child-ctx]
-  (when-let [parent-ctx (:parent-ctx child-ctx)]
-    (into {}
-          (keep (fn [[sid _ cval psys]]
-                  (let [fsys (ys/effective-system cval)]
-                    (when (and (satisfies? ygg/Mergeable fsys)
-                               (satisfies? ygg/Graphable fsys))
-                      [sid (system-merge-base-diff fsys psys)]))))
-          (shared-pairs child-ctx parent-ctx))))
+  (async+sync
+   (:sync? yc/default-opts)
+   (async
+    (when-let [parent-ctx (:parent-ctx child-ctx)]
+      ;; accumulating loop (not `into`/`keep`) — `system-merge-base-diff` is awaited.
+      (loop [ps (seq (shared-pairs child-ctx parent-ctx)) acc {}]
+        (if ps
+          (let [[sid _ cval psys] (first ps)
+                fsys (ys/effective-system cval)
+                acc* (if (and (satisfies? ygg/Mergeable fsys)
+                              (satisfies? ygg/Graphable fsys))
+                       (assoc acc sid (await (system-merge-base-diff fsys psys)))
+                       acc)]
+            (recur (next ps) acc*))
+          acc))))))
 
 (defn context-conflicts
   "Per-system conflicts of a forked context vs its parent, each tagged
    `:system`. nil when the context has no parent."
   [child-ctx]
-  (when-let [parent-ctx (:parent-ctx child-ctx)]
-    (into []
-          (mapcat (fn [[sid _ cval psys]]
-                    (let [fsys (ys/effective-system cval)]
-                      (when (satisfies? ygg/Mergeable fsys)
-                        (try (map #(assoc % :system sid)
-                                  (ygg/conflicts psys
-                                                 (ygg/snapshot-id psys)
-                                                 (ygg/snapshot-id fsys)))
-                             (catch #?(:clj Throwable :cljs :default) _ nil))))))
-          (shared-pairs child-ctx parent-ctx))))
+  (async+sync
+   (:sync? yc/default-opts)
+   (async
+    (when-let [parent-ctx (:parent-ctx child-ctx)]
+      ;; accumulating loop (not `into`/`mapcat`) — `snapshot-id` is awaited, `conflicts`
+      ;; awaited only when it is a continuation (versioned) vs a plain value (convergent).
+      (loop [ps (seq (shared-pairs child-ctx parent-ctx)) acc []]
+        (if ps
+          (let [[sid _ cval psys] (first ps)
+                fsys (ys/effective-system cval)
+                more (if (satisfies? ygg/Mergeable fsys)
+                       (try
+                         (let [pres (ygg/conflicts psys
+                                                   (await (ygg/snapshot-id psys))
+                                                   (await (ygg/snapshot-id fsys)))
+                               cs   (if (fn? pres) (await pres) pres)]
+                           (mapv #(assoc % :system sid) cs))
+                         (catch #?(:clj Throwable :cljs :default) _ nil))
+                       nil)]
+            (recur (next ps) (into acc (or more []))))
+          acc))))))
 
 ;; =============================================================================
 ;; Merge / Discard (Parent-Controlled)
@@ -478,66 +550,81 @@
    Returns: {:merged [sys-id …] :child-only [sys-id …]} or nil if no parent."
   ([child-ctx] (merge-to-parent! child-ctx {}))
   ([child-ctx opts]
-   (when-let [parent-ctx (:parent-ctx child-ctx)]
-     (let [pairs (shared-pairs child-ctx parent-ctx)]
-       ;; 1. conflict pre-check (FAIL-SAFE: a throwing detector counts as an
-       ;; indeterminate conflict so the gate aborts rather than blind-merges).
-       (when-not (or (:strategy opts) (:force opts))
-         (let [confs (mapcat (fn [[sid _ cval psys]]
-                               (let [fsys (ys/effective-system cval)]
-                                 (when (satisfies? ygg/Mergeable fsys)
-                                   (try (map #(assoc % :system sid)
-                                             (ygg/conflicts psys
-                                                            (ygg/snapshot-id psys)
-                                                            (ygg/snapshot-id fsys)))
-                                        (catch #?(:clj Throwable :cljs :default) e
-                                          [{:system sid :indeterminate? true
-                                            :error (ex-message e)}])))))
-                             pairs)]
-           (when (seq confs)
-             (throw (ex-info "context merge has conflicts; aborting (pass :strategy or :force)"
-                             {:conflicts (vec confs)})))))
-       ;; 2. merge each overlay down, repoint the parent ygg-signal, discard.
-       (let [merged (reduce
-                     (fn [acc [sid sig-ref cval psys]]
-                       (cond
-                         ;; OVERLAY fork (convergent :overlay opt + datahike/git): join back.
-                         (ovl/overlay? cval)
-                         (let [m (ygg/merge-down! cval opts)]
-                           (set-node-value! parent-ctx sig-ref m)
-                           (ygg/discard! cval)
-                           (conj acc sid))
+   (async+sync
+    (:sync? (merge yc/default-opts opts))
+    (async
+     (when-let [parent-ctx (:parent-ctx child-ctx)]
+       (let [pairs (shared-pairs child-ctx parent-ctx)]
+         ;; 1. conflict pre-check (FAIL-SAFE: a throwing detector counts as an
+         ;; indeterminate conflict so the gate aborts rather than blind-merges).
+         ;; `snapshot-id` is always-async (await it); `conflicts` is a plain value for
+         ;; conflict-free convergent CRDTs (`[]`) but async CPS for versioned systems —
+         ;; await ONLY when it is a continuation (a fn), else use it directly.
+         (when-not (or (:strategy opts) (:force opts))
+           (let [confs (loop [ps (seq pairs) acc []]
+                         (if ps
+                           (let [[sid _ cval psys] (first ps)
+                                 fsys (ys/effective-system cval)
+                                 more (if (satisfies? ygg/Mergeable fsys)
+                                        (try
+                                          (let [pres (ygg/conflicts psys
+                                                                    (await (ygg/snapshot-id psys))
+                                                                    (await (ygg/snapshot-id fsys)))
+                                                cs   (if (fn? pres) (await pres) pres)]
+                                            (mapv #(assoc % :system sid) cs))
+                                          (catch #?(:clj Throwable :cljs :default) e
+                                            [{:system sid :indeterminate? true
+                                              :error (ex-message e)}]))
+                                        [])]
+                             (recur (next ps) (into acc more)))
+                           acc))]
+             (when (seq confs)
+               (throw (ex-info "context merge has conflicts; aborting (pass :strategy or :force)"
+                               {:conflicts (vec confs)})))))
+         ;; 2. merge each overlay down, repoint the parent ygg-signal, discard.
+         ;; ROLLBACK SEMANTICS PRESERVED: each merged value is COMPUTED first, and the
+         ;; parent ygg-signal is repointed only AFTER; a throwing/rejecting durable op
+         ;; leaves that system's parent untouched and propagates (git/datahike have no
+         ;; cross-store 2PC — the pre-check makes mid-merge failure unlikely).
+         (let [merged (loop [ps (seq pairs) acc []]
+                        (if ps
+                          (let [[sid sig-ref cval psys] (first ps)
+                                acc* (cond
+                                       ;; OVERLAY fork (convergent :overlay opt + datahike/git): join back.
+                                       (ovl/overlay? cval)
+                                       (let [m (await (ygg/merge-down! cval opts))]
+                                         (set-node-value! parent-ctx sig-ref m)
+                                         (ygg/discard! cval)
+                                         (conj acc sid))
 
-                         ;; BRANCH-forked convergent: `cval` is a real system on `:fork-<uuid>`.
-                         ;; Check out the parent branch (loads its LIVE head for durable stores),
-                         ;; `merge!` the fork branch in, drop the fork branch. Thread `:sync?` —
-                         ;; `opts` is a merge-opts map without it, else the JVM async branch would
-                         ;; seat a CPS continuation as the parent's value.
-                         (and (satisfies? yc/PConvergent cval)
-                              (fork-branch-name? (ygg/current-branch cval)))
-                         (let [mopts   (merge yc/default-opts opts)
-                               fbranch (ygg/current-branch cval)
-                               pbranch (ygg/current-branch psys)
-                               m       (-> cval
-                                           (ygg/checkout pbranch mopts)
-                                           (ygg/merge! fbranch mopts)
-                                           (ygg/delete-branch! fbranch mopts))]
-                           (set-node-value! parent-ctx sig-ref m)
-                           (conj acc sid))
+                                       ;; BRANCH-forked convergent: `cval` is a real system on `:fork-<uuid>`.
+                                       ;; Check out the parent branch (loads its LIVE head for durable stores),
+                                       ;; `merge!` the fork branch in, drop the fork branch. Await each (can't
+                                       ;; thread-first through CPS on cljs); `mopts` threads `:sync?`.
+                                       (and (satisfies? yc/PConvergent cval)
+                                            (fork-branch-name? (ygg/current-branch cval)))
+                                       (let [mopts   (merge yc/default-opts opts)
+                                             fbranch (ygg/current-branch cval)
+                                             pbranch (ygg/current-branch psys)
+                                             co      (await (ygg/checkout cval pbranch mopts))
+                                             mg      (await (ygg/merge! co fbranch mopts))
+                                             m       (await (ygg/delete-branch! mg fbranch mopts))]
+                                         (set-node-value! parent-ctx sig-ref m)
+                                         (conj acc sid))
 
-                         :else acc))
-                     []
-                     pairs)
-             ;; 3. carry child-only systems into the parent registry + nodes.
-             co (child-only child-ctx parent-ctx)]
-         (doseq [[sid sig-ref] co]
-           (rtp/swap-state! parent-ctx [registry-key] #(assoc (or % {}) sid sig-ref))
-           (rtp/swap-state! parent-ctx [:forkable-signals] #(conj (or % #{}) (:id sig-ref)))
-           (set-node-value! parent-ctx sig-ref (node-value child-ctx sig-ref)))
-         (when-let [cb (:on-merge opts)]
-           (cb {:merged merged :child-only (vec (keys co))
-                :parent-ctx parent-ctx :child-ctx child-ctx}))
-         {:merged merged :child-only (vec (keys co))})))))
+                                       :else acc)]
+                            (recur (next ps) acc*))
+                          acc))
+               ;; 3. carry child-only systems into the parent registry + nodes.
+               co (child-only child-ctx parent-ctx)]
+           (doseq [[sid sig-ref] co]
+             (rtp/swap-state! parent-ctx [registry-key] #(assoc (or % {}) sid sig-ref))
+             (rtp/swap-state! parent-ctx [:forkable-signals] #(conj (or % #{}) (:id sig-ref)))
+             (set-node-value! parent-ctx sig-ref (node-value child-ctx sig-ref)))
+           (when-let [cb (:on-merge opts)]
+             (cb {:merged merged :child-only (vec (keys co))
+                  :parent-ctx parent-ctx :child-ctx child-ctx}))
+           {:merged merged :child-only (vec (keys co))})))))))
 
 (defn discard-from-parent!
   "Discard a forked context's per-system overlays without merging — `discard!`
@@ -552,23 +639,31 @@
    Returns: nil"
   ([child-ctx] (discard-from-parent! child-ctx {}))
   ([child-ctx opts]
-   (when-let [parent-ctx (:parent-ctx child-ctx)]
-     (doseq [[_ _ cval _] (shared-pairs child-ctx parent-ctx)]
-       (cond
-         (ovl/overlay? cval) (ygg/discard! cval)
-         ;; branch-forked convergent: drop the fork branch (its nodes GC later).
-         (and (satisfies? yc/PConvergent cval)
-              (fork-branch-name? (ygg/current-branch cval)))
-         (ygg/delete-branch! cval (ygg/current-branch cval) (merge yc/default-opts opts))))
-     (when-let [cb (:on-discard opts)]
-       (let [co (child-only child-ctx parent-ctx)]
-         (cb {:child-only (vec (keys co))
-              :child-only-systems (into {} (keep (fn [[sid sr]]
-                                                   (when-let [s (ys/effective-system (node-value child-ctx sr))]
-                                                     [sid s])))
-                                        co)
-              :child-ctx child-ctx}))))
-   nil))
+   (async+sync
+    (:sync? (merge yc/default-opts opts))
+    (async
+     (when-let [parent-ctx (:parent-ctx child-ctx)]
+       ;; `discard!` on an overlay is a synchronous no-op (returns nil); `delete-branch!`
+       ;; is async — await it. Loop (not doseq) so the await threads on cljs.
+       (loop [ps (seq (shared-pairs child-ctx parent-ctx))]
+         (when ps
+           (let [[_ _ cval _] (first ps)]
+             (cond
+               (ovl/overlay? cval) (ygg/discard! cval)
+               ;; branch-forked convergent: drop the fork branch (its nodes GC later).
+               (and (satisfies? yc/PConvergent cval)
+                    (fork-branch-name? (ygg/current-branch cval)))
+               (await (ygg/delete-branch! cval (ygg/current-branch cval) (merge yc/default-opts opts)))))
+           (recur (next ps))))
+       (when-let [cb (:on-discard opts)]
+         (let [co (child-only child-ctx parent-ctx)]
+           (cb {:child-only (vec (keys co))
+                :child-only-systems (into {} (keep (fn [[sid sr]]
+                                                     (when-let [s (ys/effective-system (node-value child-ctx sr))]
+                                                       [sid s])))
+                                          co)
+                :child-ctx child-ctx}))))
+     nil))))
 
 ;; ForkHandle variants (delegate to the ctx-based ops)
 
@@ -599,25 +694,31 @@
    Returns: nil"
   ([child-ctx] (merge-from-parent! child-ctx {}))
   ([child-ctx opts]
-   (when-let [parent-ctx (:parent-ctx child-ctx)]
-     (doseq [[_ sig-ref cval psys] (shared-pairs child-ctx parent-ctx)]
-       (let [fsys (ys/effective-system cval)]
-         (when (and (satisfies? ygg/Branchable fsys)
-                    (satisfies? ygg/Mergeable fsys))
-           (let [cbranch (ygg/current-branch fsys)
-                 pbranch (ygg/current-branch psys)
-                 ;; thread :sync? — `opts` is a merge-opts map without it; else the
-                 ;; JVM async branch seats a CPS continuation (the finding-#3 twin).
-                 mopts   (merge yc/default-opts {:message (str "Merge from " (name pbranch))} opts)
-                 m (-> fsys
-                       (ygg/checkout cbranch mopts)
-                       (ygg/merge! pbranch mopts))]
-             ;; repoint: if cval is an overlay, update its writable system in
-             ;; place; else repoint the node.
-             (if (ovl/overlay? cval)
-               (ovl/reseat-overlay! cval m)
-               (set-node-value! child-ctx sig-ref m)))))))
-   nil))
+   (async+sync
+    (:sync? (merge yc/default-opts opts))
+    (async
+     (when-let [parent-ctx (:parent-ctx child-ctx)]
+       ;; Loop (not doseq) so `checkout`/`merge!` await-thread on cljs.
+       (loop [ps (seq (shared-pairs child-ctx parent-ctx))]
+         (when ps
+           (let [[_ sig-ref cval psys] (first ps)
+                 fsys (ys/effective-system cval)]
+             (when (and (satisfies? ygg/Branchable fsys)
+                        (satisfies? ygg/Mergeable fsys))
+               (let [cbranch (ygg/current-branch fsys)
+                     pbranch (ygg/current-branch psys)
+                     ;; thread :sync? — `opts` is a merge-opts map without it; else the
+                     ;; JVM async branch seats a CPS continuation (the finding-#3 twin).
+                     mopts   (merge yc/default-opts {:message (str "Merge from " (name pbranch))} opts)
+                     co      (await (ygg/checkout fsys cbranch mopts))
+                     m       (await (ygg/merge! co pbranch mopts))]
+                 ;; repoint: if cval is an overlay, update its writable system in
+                 ;; place; else repoint the node. (both sync)
+                 (if (ovl/overlay? cval)
+                   (ovl/reseat-overlay! cval m)
+                   (set-node-value! child-ctx sig-ref m)))))
+           (recur (next ps)))))
+     nil))))
 
 (defn merge-fork-from-parent!
   "Merge parent's current state into a fork (ForkHandle variant)."

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -50,7 +50,9 @@
             ;; yggdrasil.gc is JVM-only (it backs gc!/gc-system!, which stay :clj).
             [yggdrasil.protocols :as ygg]
             [yggdrasil.types :as ygt]
+            [yggdrasil.convergent :as yc]
             [yggdrasil.convergent.overlay :as ovl]
+            [clojure.string :as str]
             #?@(:clj [[yggdrasil.gc :as ygg-gc]])))
 
 ;; =============================================================================
@@ -101,20 +103,67 @@
       (-> sys (ygg/branch! new-branch snap-id) (ygg/checkout new-branch)))
     sys))
 
+(defn- caps [sys]
+  (when (satisfies? ygg/SystemIdentity sys) (ygg/capabilities sys)))
+
+(defn- convergent-branchable?
+  "A convergent system that is GENUINELY branchable — the CAPABILITY, not mere
+   protocol satisfaction (cdvcs satisfies Branchable as no-ops but is `:branchable
+   false`). These fork as a real yggdrasil BRANCH."
+  [sys]
+  (and (satisfies? yc/PConvergent sys)
+       (boolean (:branchable (caps sys)))))
+
+(defn- fork-branch-name?
+  "True if `b` is a fork branch (engine fork-ids are `:fork-<uuid>` keywords)."
+  [b]
+  (and b (str/starts-with? (name b) "fork-")))
+
+(defn- branch-fork
+  "BRANCH fork (the DEFAULT for convergent systems): a REAL branched system as the
+   fork value — inherits the parent tip, so `@kref`/`g/elements`/`g/conj` operate on
+   it directly (no overlay footguns). `fork-id` is the engine-assigned `:fork-<uuid>`
+   keyword, used as the branch name. Threads the platform default mode (JVM sync;
+   durable branch-fork on cljs is async — a follow-up lifts the sync engine hook)."
+  [sys fork-id]
+  (-> sys (ygg/branch! fork-id) (ygg/checkout fork-id)))
+
 ;; `Object`/`default`: extend the engine's PForkable to ALL values so a forkable
-;; ygg-signal's value is overlay/snapshot-forked; non-yggdrasil values fall to
+;; ygg-signal's value is branch/overlay/snapshot-forked; non-yggdrasil values fall to
 ;; identity. cljs has no `Object` root — use the `default` dispatch.
 (extend-protocol rtp/PForkable
   #?(:clj Object :cljs default)
   (fork-value [this fork-id directive]
     (cond
       ;; nested fork (fork of a fork) → fork the overlay's effective system
-      (ovl/overlay? this) (rtp/fork-value (ovl/overlay-system this) fork-id directive)
-      ;; a yggdrasil system → overlay (default) or snapshot fork
+      (ovl/overlay? this)
+      (rtp/fork-value (ovl/overlay-system this) fork-id directive)
+
+      ;; SNAPSHOT fork (pin a fixed value) — any Snapshotable, versioned or convergent
+      (and (= :snapshot (:fork directive)) (satisfies? ygg/Snapshotable this))
+      (snapshot-fork this fork-id (:snapshot directive))
+
+      ;; CONVERGENT + genuinely branchable → BRANCH fork by DEFAULT.
+      ;; `:convergent-fork :overlay` forces the (optional) live-:following overlay.
+      (convergent-branchable? this)
+      (if (= :overlay (:convergent-fork directive))
+        (overlay-fork this directive)
+        (branch-fork this fork-id))
+
+      ;; CONVERGENT but not branchable (cdvcs) → overlay if it has one, else FAIL LOUD
+      ;; (rather than NPE deep in a GSet op on a non-branchable value).
+      (satisfies? yc/PConvergent this)
+      (if (satisfies? ygg/Overlayable this)
+        (overlay-fork this directive)
+        (throw (ex-info "Cannot fork this convergent system: neither :branchable (no branch-fork) nor Overlayable (no overlay-fork)."
+                        {:system-type (ygg/system-type this)
+                         :system-id   (ygg/system-id this)
+                         :hint "Implement Branchable or Overlayable for it, or fork a branchable convergent CRDT."})))
+
+      ;; VERSIONED, non-convergent (datahike/git) → existing overlay path (UNCHANGED)
       (satisfies? ygg/Snapshotable this)
-      (if (= :snapshot (:fork directive))
-        (snapshot-fork this fork-id (:snapshot directive))
-        (overlay-fork this directive))
+      (overlay-fork this directive)
+
       ;; not a yggdrasil value → identity (the engine default)
       :else this)))
 
@@ -313,6 +362,10 @@
    opts (optional): forwarded to `ctx/fork-context` —
      :mode      :following (default) | :frozen — overlay fork relation to parent
      :snapshots {system-id -> snapshot-id} — pin those systems at fixed values
+     :convergent-fork :branch (default) | :overlay — a CONVERGENT CRDT forks as a
+       real yggdrasil BRANCH by default (the natural CRDT API works in the fork: read
+       `@ref`, write `g/conj`, `merge-fork!` folds back). `:overlay` forces the live-
+       `:following` overlay workspace instead. datahike/git always overlay-fork.
 
    Permission model:
    - An agent CAN fork from its current context (creating children).
@@ -446,13 +499,33 @@
                              {:conflicts (vec confs)})))))
        ;; 2. merge each overlay down, repoint the parent ygg-signal, discard.
        (let [merged (reduce
-                     (fn [acc [sid sig-ref cval _psys]]
-                       (if (ovl/overlay? cval)
+                     (fn [acc [sid sig-ref cval psys]]
+                       (cond
+                         ;; OVERLAY fork (convergent :overlay opt + datahike/git): join back.
+                         (ovl/overlay? cval)
                          (let [m (ygg/merge-down! cval opts)]
                            (set-node-value! parent-ctx sig-ref m)
                            (ygg/discard! cval)
                            (conj acc sid))
-                         acc))
+
+                         ;; BRANCH-forked convergent: `cval` is a real system on `:fork-<uuid>`.
+                         ;; Check out the parent branch (loads its LIVE head for durable stores),
+                         ;; `merge!` the fork branch in, drop the fork branch. Thread `:sync?` —
+                         ;; `opts` is a merge-opts map without it, else the JVM async branch would
+                         ;; seat a CPS continuation as the parent's value.
+                         (and (satisfies? yc/PConvergent cval)
+                              (fork-branch-name? (ygg/current-branch cval)))
+                         (let [mopts   (merge yc/default-opts opts)
+                               fbranch (ygg/current-branch cval)
+                               pbranch (ygg/current-branch psys)
+                               m       (-> cval
+                                           (ygg/checkout pbranch mopts)
+                                           (ygg/merge! fbranch mopts)
+                                           (ygg/delete-branch! fbranch mopts))]
+                           (set-node-value! parent-ctx sig-ref m)
+                           (conj acc sid))
+
+                         :else acc))
                      []
                      pairs)
              ;; 3. carry child-only systems into the parent registry + nodes.
@@ -481,7 +554,12 @@
   ([child-ctx opts]
    (when-let [parent-ctx (:parent-ctx child-ctx)]
      (doseq [[_ _ cval _] (shared-pairs child-ctx parent-ctx)]
-       (when (ovl/overlay? cval) (ygg/discard! cval)))
+       (cond
+         (ovl/overlay? cval) (ygg/discard! cval)
+         ;; branch-forked convergent: drop the fork branch (its nodes GC later).
+         (and (satisfies? yc/PConvergent cval)
+              (fork-branch-name? (ygg/current-branch cval)))
+         (ygg/delete-branch! cval (ygg/current-branch cval) (merge yc/default-opts opts))))
      (when-let [cb (:on-discard opts)]
        (let [co (child-only child-ctx parent-ctx)]
          (cb {:child-only (vec (keys co))
@@ -528,10 +606,12 @@
                     (satisfies? ygg/Mergeable fsys))
            (let [cbranch (ygg/current-branch fsys)
                  pbranch (ygg/current-branch psys)
+                 ;; thread :sync? — `opts` is a merge-opts map without it; else the
+                 ;; JVM async branch seats a CPS continuation (the finding-#3 twin).
+                 mopts   (merge yc/default-opts {:message (str "Merge from " (name pbranch))} opts)
                  m (-> fsys
-                       (ygg/checkout cbranch)
-                       (ygg/merge! pbranch
-                                   (merge {:message (str "Merge from " (name pbranch))} opts)))]
+                       (ygg/checkout cbranch mopts)
+                       (ygg/merge! pbranch mopts))]
              ;; repoint: if cval is an overlay, update its writable system in
              ;; place; else repoint the node.
              (if (ovl/overlay? cval)

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -62,6 +62,7 @@
             [yggdrasil.convergent :as yc]
             [yggdrasil.convergent.overlay :as ovl]
             [clojure.string :as str]
+            [is.simm.partial-cps.async :as pcps]
             #?(:clj  [is.simm.partial-cps.async :refer [async await]]
                :cljs [is.simm.partial-cps.async :refer [await]])
             #?(:clj [yggdrasil.macros :refer [async+sync]])
@@ -369,6 +370,39 @@
                                           (inc (or (:generation node) 0))))))
 
 ;; =============================================================================
+;; Async context conveyance
+;; =============================================================================
+
+(defn- convey-context
+  "Wrap a durable-op partial-cps thunk so its resolve/reject re-bind the
+   *execution-context* captured NOW. spindel deliberately EXCLUDES
+   *execution-context* from partial-cps binding capture (engine/bindings.cljc):
+   it is re-bound only by the engine on a spin resume. So when a spin `await`s a
+   durable bridge op, the op's INTERNAL konserve await resolves on a foreign
+   thread (JVM) / a later microtask (cljs) and the spin's continuation would
+   otherwise resume with NO context bound — `@yref`, `system-signal`,
+   `resolve-system` (and the spin's own result-caching) all read the context and
+   would throw. Re-binding around resolve/reject carries the captured context
+   into that continuation, so the NATURAL fork API works fully async through a
+   spin (mirrors distributed/core's `chan->spin` rebind).
+
+   Returns a THUNK (partial-cps-compatible), so a raw `async`/`<?` caller keeps
+   working too (and also gains the re-bind, dropping the manual post-await
+   `binding` those call sites used). On the JVM SYNC path the arg is a plain
+   VALUE (not a fn) and is returned unchanged — byte-identical sync behavior."
+  [x]
+  (if (fn? x)
+    (let [ctx ec/*execution-context*]
+      (fn [resolve reject]
+        ;; `*in-trampoline* false` forces a FRESH synchronous trampoline for the
+        ;; resume so the continuation runs to its next suspend WITHIN this binding
+        ;; (on cljs a live outer trampoline would otherwise bounce it to a later
+        ;; microtask, escaping the binding) — mirrors distributed/core `chan->spin`.
+        (x (fn [v] (binding [ec/*execution-context* ctx pcps/*in-trampoline* false] (resolve v)))
+           (fn [e] (binding [ec/*execution-context* ctx pcps/*in-trampoline* false] (reject e))))))
+    x))
+
+;; =============================================================================
 ;; Fork Handle (explicit control)
 ;; =============================================================================
 
@@ -403,21 +437,22 @@
        (merge-fork! fork))"
   ([] (fork! {}))
   ([opts]
-   (async+sync
-    (:sync? (merge yc/default-opts opts))
-    (async
-     (let [parent-ctx (ec/current-execution-context)
+   (convey-context
+    (async+sync
+     (:sync? (merge yc/default-opts opts))
+     (async
+      (let [parent-ctx (ec/current-execution-context)
            ;; translate :snapshots from SYSTEM-id keys (what callers know) to the
            ;; SIGNAL-id keys fork-context forks by.
-           snaps  (when-let [s (:snapshots opts)]
-                    (into {} (keep (fn [[sid snap]]
-                                     (when-let [sr (get (registry parent-ctx) sid)]
-                                       [(:id sr) snap])))
-                          s))
-           fopts  (cond-> opts snaps (assoc :snapshots snaps))
-           child-ctx  (apply ctx/fork-context parent-ctx (mapcat identity fopts))
-           fork-id    (:fork-id child-ctx)
-           popts  (merge yc/default-opts opts)]
+            snaps  (when-let [s (:snapshots opts)]
+                     (into {} (keep (fn [[sid snap]]
+                                      (when-let [sr (get (registry parent-ctx) sid)]
+                                        [(:id sr) snap])))
+                           s))
+            fopts  (cond-> opts snaps (assoc :snapshots snaps))
+            child-ctx  (apply ctx/fork-context parent-ctx (mapcat identity fopts))
+            fork-id    (:fork-id child-ctx)
+            popts  (merge yc/default-opts opts)]
        ;; POST-PASS (Design B async lift): the engine's `fork-context`/`fork-value`
        ;; hook is SYNCHRONOUS, so a convergent BRANCH fork — durable `branch!`/`checkout`
        ;; that only yield a value synchronously on the JVM — is done here, AWAITED, over
@@ -426,16 +461,16 @@
        ;; a NO-OP; on cljs `fork-value` deferred (left the parent value), so this branches
        ;; each and seats the branched system as the fork's value. ONE code path, both
        ;; platforms (async+sync collapses to `do` on the JVM).
-       (loop [ps (seq (shared-pairs child-ctx parent-ctx))]
-         (when ps
-           (let [[_sid sig-ref cval _psys] (first ps)]
-             (when (and (convergent-branchable? cval)
-                        (not (fork-branch-name? (ygg/current-branch cval))))
-               (let [_        (await (ygg/branch! cval fork-id (ygg/current-branch cval) popts))
-                     branched (await (ygg/checkout cval fork-id popts))]
-                 (set-node-value! child-ctx sig-ref branched))))
-           (recur (next ps))))
-       (->ForkHandle child-ctx parent-ctx fork-id))))))
+        (loop [ps (seq (shared-pairs child-ctx parent-ctx))]
+          (when ps
+            (let [[_sid sig-ref cval _psys] (first ps)]
+              (when (and (convergent-branchable? cval)
+                         (not (fork-branch-name? (ygg/current-branch cval))))
+                (let [_        (await (ygg/branch! cval fork-id (ygg/current-branch cval) popts))
+                      branched (await (ygg/checkout cval fork-id popts))]
+                  (set-node-value! child-ctx sig-ref branched))))
+            (recur (next ps))))
+        (->ForkHandle child-ctx parent-ctx fork-id)))))))
 
 ;; `with-fork` is a JVM-only convenience macro. On cljs use the engine form it
 ;; expands to directly: `(ec/with-context (:child-ctx fork) …)`.
@@ -460,13 +495,16 @@
   (async+sync
    (:sync? yc/default-opts)
    (async
-    (let [psnap (await (ygg/snapshot-id psys))
-          fsnap (await (ygg/snapshot-id fsys))]
-      ;; `snapshot-id`/`common-ancestor` are always-async (await). `diff` is a plain value
-      ;; for conflict-free convergent CRDTs (`{}`) but async CPS for versioned systems —
-      ;; await ONLY when it is a continuation (a fn).
+    (let [psnap (let [v (ygg/snapshot-id psys)] (if (fn? v) (await v) v))
+          fsnap (let [v (ygg/snapshot-id fsys)] (if (fn? v) (await v) v))]
+      ;; `snapshot-id`/`common-ancestor`/`diff` are `async+sync` on the system's DEFAULT
+      ;; opts (no opts arity) — a partial-cps CONTINUATION on cljs / under async, but a
+      ;; plain VALUE on the JVM (default `:sync? true`). So `await` ONLY when the result is
+      ;; a continuation (a fn); awaiting a plain value crashes the JVM async path (partial-
+      ;; cps would invoke the value as `(v resolve reject)`).
       (or (try
-            (let [base (await (ygg/common-ancestor fsys psnap fsnap))]
+            (let [v (ygg/common-ancestor fsys psnap fsnap)
+                  base (if (fn? v) (await v) v)]
               (when base
                 (let [d (ygg/diff fsys base fsnap)]
                   (if (fn? d) (await d) d))))
@@ -483,47 +521,50 @@
    DiffError)}. nil when the context has no parent. Non-Mergeable systems are
    omitted."
   [child-ctx]
-  (async+sync
-   (:sync? yc/default-opts)
-   (async
-    (when-let [parent-ctx (:parent-ctx child-ctx)]
+  (convey-context
+   (async+sync
+    (:sync? yc/default-opts)
+    (async
+     (when-let [parent-ctx (:parent-ctx child-ctx)]
       ;; accumulating loop (not `into`/`keep`) — `system-merge-base-diff` is awaited.
-      (loop [ps (seq (shared-pairs child-ctx parent-ctx)) acc {}]
-        (if ps
-          (let [[sid _ cval psys] (first ps)
-                fsys (ys/effective-system cval)
-                acc* (if (and (satisfies? ygg/Mergeable fsys)
-                              (satisfies? ygg/Graphable fsys))
-                       (assoc acc sid (await (system-merge-base-diff fsys psys)))
-                       acc)]
-            (recur (next ps) acc*))
-          acc))))))
+       (loop [ps (seq (shared-pairs child-ctx parent-ctx)) acc {}]
+         (if ps
+           (let [[sid _ cval psys] (first ps)
+                 fsys (ys/effective-system cval)
+                 acc* (if (and (satisfies? ygg/Mergeable fsys)
+                               (satisfies? ygg/Graphable fsys))
+                        (assoc acc sid (await (system-merge-base-diff fsys psys)))
+                        acc)]
+             (recur (next ps) acc*))
+           acc)))))))
 
 (defn context-conflicts
   "Per-system conflicts of a forked context vs its parent, each tagged
    `:system`. nil when the context has no parent."
   [child-ctx]
-  (async+sync
-   (:sync? yc/default-opts)
-   (async
-    (when-let [parent-ctx (:parent-ctx child-ctx)]
-      ;; accumulating loop (not `into`/`mapcat`) — `snapshot-id` is awaited, `conflicts`
-      ;; awaited only when it is a continuation (versioned) vs a plain value (convergent).
-      (loop [ps (seq (shared-pairs child-ctx parent-ctx)) acc []]
-        (if ps
-          (let [[sid _ cval psys] (first ps)
-                fsys (ys/effective-system cval)
-                more (if (satisfies? ygg/Mergeable fsys)
-                       (try
-                         (let [pres (ygg/conflicts psys
-                                                   (await (ygg/snapshot-id psys))
-                                                   (await (ygg/snapshot-id fsys)))
-                               cs   (if (fn? pres) (await pres) pres)]
-                           (mapv #(assoc % :system sid) cs))
-                         (catch #?(:clj Throwable :cljs :default) _ nil))
-                       nil)]
-            (recur (next ps) (into acc (or more []))))
-          acc))))))
+  (convey-context
+   (async+sync
+    (:sync? yc/default-opts)
+    (async
+     (when-let [parent-ctx (:parent-ctx child-ctx)]
+      ;; accumulating loop (not `into`/`mapcat`) — `snapshot-id`/`conflicts` are `await`ed
+      ;; ONLY when a continuation (a fn): default-opts `snapshot-id` is a plain value on the
+      ;; JVM but a CPS on cljs; `conflicts` is `[]` for conflict-free CRDTs, CPS for versioned.
+       (loop [ps (seq (shared-pairs child-ctx parent-ctx)) acc []]
+         (if ps
+           (let [[sid _ cval psys] (first ps)
+                 fsys (ys/effective-system cval)
+                 more (if (satisfies? ygg/Mergeable fsys)
+                        (try
+                          (let [ps1  (let [v (ygg/snapshot-id psys)] (if (fn? v) (await v) v))
+                                fs1  (let [v (ygg/snapshot-id fsys)] (if (fn? v) (await v) v))
+                                pres (ygg/conflicts psys ps1 fs1)
+                                cs   (if (fn? pres) (await pres) pres)]
+                            (mapv #(assoc % :system sid) cs))
+                          (catch #?(:clj Throwable :cljs :default) _ nil))
+                        nil)]
+             (recur (next ps) (into acc (or more []))))
+           acc)))))))
 
 ;; =============================================================================
 ;; Merge / Discard (Parent-Controlled)
@@ -550,81 +591,82 @@
    Returns: {:merged [sys-id …] :child-only [sys-id …]} or nil if no parent."
   ([child-ctx] (merge-to-parent! child-ctx {}))
   ([child-ctx opts]
-   (async+sync
-    (:sync? (merge yc/default-opts opts))
-    (async
-     (when-let [parent-ctx (:parent-ctx child-ctx)]
-       (let [pairs (shared-pairs child-ctx parent-ctx)]
+   (convey-context
+    (async+sync
+     (:sync? (merge yc/default-opts opts))
+     (async
+      (when-let [parent-ctx (:parent-ctx child-ctx)]
+        (let [pairs (shared-pairs child-ctx parent-ctx)]
          ;; 1. conflict pre-check (FAIL-SAFE: a throwing detector counts as an
          ;; indeterminate conflict so the gate aborts rather than blind-merges).
-         ;; `snapshot-id` is always-async (await it); `conflicts` is a plain value for
-         ;; conflict-free convergent CRDTs (`[]`) but async CPS for versioned systems —
-         ;; await ONLY when it is a continuation (a fn), else use it directly.
-         (when-not (or (:strategy opts) (:force opts))
-           (let [confs (loop [ps (seq pairs) acc []]
-                         (if ps
-                           (let [[sid _ cval psys] (first ps)
-                                 fsys (ys/effective-system cval)
-                                 more (if (satisfies? ygg/Mergeable fsys)
-                                        (try
-                                          (let [pres (ygg/conflicts psys
-                                                                    (await (ygg/snapshot-id psys))
-                                                                    (await (ygg/snapshot-id fsys)))
-                                                cs   (if (fn? pres) (await pres) pres)]
-                                            (mapv #(assoc % :system sid) cs))
-                                          (catch #?(:clj Throwable :cljs :default) e
-                                            [{:system sid :indeterminate? true
-                                              :error (ex-message e)}]))
-                                        [])]
-                             (recur (next ps) (into acc more)))
-                           acc))]
-             (when (seq confs)
-               (throw (ex-info "context merge has conflicts; aborting (pass :strategy or :force)"
-                               {:conflicts (vec confs)})))))
+         ;; `snapshot-id`/`conflicts` are `await`ed ONLY when a continuation (a fn):
+         ;; default-opts `snapshot-id` is a plain value on the JVM but a CPS on cljs;
+         ;; `conflicts` is `[]` for conflict-free convergent CRDTs, CPS for versioned.
+          (when-not (or (:strategy opts) (:force opts))
+            (let [confs (loop [ps (seq pairs) acc []]
+                          (if ps
+                            (let [[sid _ cval psys] (first ps)
+                                  fsys (ys/effective-system cval)
+                                  more (if (satisfies? ygg/Mergeable fsys)
+                                         (try
+                                           (let [ps1  (let [v (ygg/snapshot-id psys)] (if (fn? v) (await v) v))
+                                                 fs1  (let [v (ygg/snapshot-id fsys)] (if (fn? v) (await v) v))
+                                                 pres (ygg/conflicts psys ps1 fs1)
+                                                 cs   (if (fn? pres) (await pres) pres)]
+                                             (mapv #(assoc % :system sid) cs))
+                                           (catch #?(:clj Throwable :cljs :default) e
+                                             [{:system sid :indeterminate? true
+                                               :error (ex-message e)}]))
+                                         [])]
+                              (recur (next ps) (into acc more)))
+                            acc))]
+              (when (seq confs)
+                (throw (ex-info "context merge has conflicts; aborting (pass :strategy or :force)"
+                                {:conflicts (vec confs)})))))
          ;; 2. merge each overlay down, repoint the parent ygg-signal, discard.
          ;; ROLLBACK SEMANTICS PRESERVED: each merged value is COMPUTED first, and the
          ;; parent ygg-signal is repointed only AFTER; a throwing/rejecting durable op
          ;; leaves that system's parent untouched and propagates (git/datahike have no
          ;; cross-store 2PC — the pre-check makes mid-merge failure unlikely).
-         (let [merged (loop [ps (seq pairs) acc []]
-                        (if ps
-                          (let [[sid sig-ref cval psys] (first ps)
-                                acc* (cond
+          (let [merged (loop [ps (seq pairs) acc []]
+                         (if ps
+                           (let [[sid sig-ref cval psys] (first ps)
+                                 acc* (cond
                                        ;; OVERLAY fork (convergent :overlay opt + datahike/git): join back.
-                                       (ovl/overlay? cval)
-                                       (let [m (await (ygg/merge-down! cval opts))]
-                                         (set-node-value! parent-ctx sig-ref m)
-                                         (ygg/discard! cval)
-                                         (conj acc sid))
+                                        (ovl/overlay? cval)
+                                        (let [m (await (ygg/merge-down! cval opts))]
+                                          (set-node-value! parent-ctx sig-ref m)
+                                          (ygg/discard! cval)
+                                          (conj acc sid))
 
                                        ;; BRANCH-forked convergent: `cval` is a real system on `:fork-<uuid>`.
                                        ;; Check out the parent branch (loads its LIVE head for durable stores),
                                        ;; `merge!` the fork branch in, drop the fork branch. Await each (can't
                                        ;; thread-first through CPS on cljs); `mopts` threads `:sync?`.
-                                       (and (satisfies? yc/PConvergent cval)
-                                            (fork-branch-name? (ygg/current-branch cval)))
-                                       (let [mopts   (merge yc/default-opts opts)
-                                             fbranch (ygg/current-branch cval)
-                                             pbranch (ygg/current-branch psys)
-                                             co      (await (ygg/checkout cval pbranch mopts))
-                                             mg      (await (ygg/merge! co fbranch mopts))
-                                             m       (await (ygg/delete-branch! mg fbranch mopts))]
-                                         (set-node-value! parent-ctx sig-ref m)
-                                         (conj acc sid))
+                                        (and (satisfies? yc/PConvergent cval)
+                                             (fork-branch-name? (ygg/current-branch cval)))
+                                        (let [mopts   (merge yc/default-opts opts)
+                                              fbranch (ygg/current-branch cval)
+                                              pbranch (ygg/current-branch psys)
+                                              co      (await (ygg/checkout cval pbranch mopts))
+                                              mg      (await (ygg/merge! co fbranch mopts))
+                                              m       (await (ygg/delete-branch! mg fbranch mopts))]
+                                          (set-node-value! parent-ctx sig-ref m)
+                                          (conj acc sid))
 
-                                       :else acc)]
-                            (recur (next ps) acc*))
-                          acc))
+                                        :else acc)]
+                             (recur (next ps) acc*))
+                           acc))
                ;; 3. carry child-only systems into the parent registry + nodes.
-               co (child-only child-ctx parent-ctx)]
-           (doseq [[sid sig-ref] co]
-             (rtp/swap-state! parent-ctx [registry-key] #(assoc (or % {}) sid sig-ref))
-             (rtp/swap-state! parent-ctx [:forkable-signals] #(conj (or % #{}) (:id sig-ref)))
-             (set-node-value! parent-ctx sig-ref (node-value child-ctx sig-ref)))
-           (when-let [cb (:on-merge opts)]
-             (cb {:merged merged :child-only (vec (keys co))
-                  :parent-ctx parent-ctx :child-ctx child-ctx}))
-           {:merged merged :child-only (vec (keys co))})))))))
+                co (child-only child-ctx parent-ctx)]
+            (doseq [[sid sig-ref] co]
+              (rtp/swap-state! parent-ctx [registry-key] #(assoc (or % {}) sid sig-ref))
+              (rtp/swap-state! parent-ctx [:forkable-signals] #(conj (or % #{}) (:id sig-ref)))
+              (set-node-value! parent-ctx sig-ref (node-value child-ctx sig-ref)))
+            (when-let [cb (:on-merge opts)]
+              (cb {:merged merged :child-only (vec (keys co))
+                   :parent-ctx parent-ctx :child-ctx child-ctx}))
+            {:merged merged :child-only (vec (keys co))}))))))))
 
 (defn discard-from-parent!
   "Discard a forked context's per-system overlays without merging — `discard!`
@@ -639,31 +681,32 @@
    Returns: nil"
   ([child-ctx] (discard-from-parent! child-ctx {}))
   ([child-ctx opts]
-   (async+sync
-    (:sync? (merge yc/default-opts opts))
-    (async
-     (when-let [parent-ctx (:parent-ctx child-ctx)]
+   (convey-context
+    (async+sync
+     (:sync? (merge yc/default-opts opts))
+     (async
+      (when-let [parent-ctx (:parent-ctx child-ctx)]
        ;; `discard!` on an overlay is a synchronous no-op (returns nil); `delete-branch!`
        ;; is async — await it. Loop (not doseq) so the await threads on cljs.
-       (loop [ps (seq (shared-pairs child-ctx parent-ctx))]
-         (when ps
-           (let [[_ _ cval _] (first ps)]
-             (cond
-               (ovl/overlay? cval) (ygg/discard! cval)
+        (loop [ps (seq (shared-pairs child-ctx parent-ctx))]
+          (when ps
+            (let [[_ _ cval _] (first ps)]
+              (cond
+                (ovl/overlay? cval) (ygg/discard! cval)
                ;; branch-forked convergent: drop the fork branch (its nodes GC later).
-               (and (satisfies? yc/PConvergent cval)
-                    (fork-branch-name? (ygg/current-branch cval)))
-               (await (ygg/delete-branch! cval (ygg/current-branch cval) (merge yc/default-opts opts)))))
-           (recur (next ps))))
-       (when-let [cb (:on-discard opts)]
-         (let [co (child-only child-ctx parent-ctx)]
-           (cb {:child-only (vec (keys co))
-                :child-only-systems (into {} (keep (fn [[sid sr]]
-                                                     (when-let [s (ys/effective-system (node-value child-ctx sr))]
-                                                       [sid s])))
-                                          co)
-                :child-ctx child-ctx}))))
-     nil))))
+                (and (satisfies? yc/PConvergent cval)
+                     (fork-branch-name? (ygg/current-branch cval)))
+                (await (ygg/delete-branch! cval (ygg/current-branch cval) (merge yc/default-opts opts)))))
+            (recur (next ps))))
+        (when-let [cb (:on-discard opts)]
+          (let [co (child-only child-ctx parent-ctx)]
+            (cb {:child-only (vec (keys co))
+                 :child-only-systems (into {} (keep (fn [[sid sr]]
+                                                      (when-let [s (ys/effective-system (node-value child-ctx sr))]
+                                                        [sid s])))
+                                           co)
+                 :child-ctx child-ctx}))))
+      nil)))))
 
 ;; ForkHandle variants (delegate to the ctx-based ops)
 
@@ -694,31 +737,32 @@
    Returns: nil"
   ([child-ctx] (merge-from-parent! child-ctx {}))
   ([child-ctx opts]
-   (async+sync
-    (:sync? (merge yc/default-opts opts))
-    (async
-     (when-let [parent-ctx (:parent-ctx child-ctx)]
+   (convey-context
+    (async+sync
+     (:sync? (merge yc/default-opts opts))
+     (async
+      (when-let [parent-ctx (:parent-ctx child-ctx)]
        ;; Loop (not doseq) so `checkout`/`merge!` await-thread on cljs.
-       (loop [ps (seq (shared-pairs child-ctx parent-ctx))]
-         (when ps
-           (let [[_ sig-ref cval psys] (first ps)
-                 fsys (ys/effective-system cval)]
-             (when (and (satisfies? ygg/Branchable fsys)
-                        (satisfies? ygg/Mergeable fsys))
-               (let [cbranch (ygg/current-branch fsys)
-                     pbranch (ygg/current-branch psys)
+        (loop [ps (seq (shared-pairs child-ctx parent-ctx))]
+          (when ps
+            (let [[_ sig-ref cval psys] (first ps)
+                  fsys (ys/effective-system cval)]
+              (when (and (satisfies? ygg/Branchable fsys)
+                         (satisfies? ygg/Mergeable fsys))
+                (let [cbranch (ygg/current-branch fsys)
+                      pbranch (ygg/current-branch psys)
                      ;; thread :sync? — `opts` is a merge-opts map without it; else the
                      ;; JVM async branch seats a CPS continuation (the finding-#3 twin).
-                     mopts   (merge yc/default-opts {:message (str "Merge from " (name pbranch))} opts)
-                     co      (await (ygg/checkout fsys cbranch mopts))
-                     m       (await (ygg/merge! co pbranch mopts))]
+                      mopts   (merge yc/default-opts {:message (str "Merge from " (name pbranch))} opts)
+                      co      (await (ygg/checkout fsys cbranch mopts))
+                      m       (await (ygg/merge! co pbranch mopts))]
                  ;; repoint: if cval is an overlay, update its writable system in
                  ;; place; else repoint the node. (both sync)
-                 (if (ovl/overlay? cval)
-                   (ovl/reseat-overlay! cval m)
-                   (set-node-value! child-ctx sig-ref m)))))
-           (recur (next ps)))))
-     nil))))
+                  (if (ovl/overlay? cval)
+                    (ovl/reseat-overlay! cval m)
+                    (set-node-value! child-ctx sig-ref m)))))
+            (recur (next ps)))))
+      nil)))))
 
 (defn merge-fork-from-parent!
   "Merge parent's current state into a fork (ForkHandle variant)."

--- a/test/org/replikativ/spindel/test_async.cljc
+++ b/test/org/replikativ/spindel/test_async.cljc
@@ -1,8 +1,19 @@
 (ns org.replikativ.spindel.test-async
   "Async test utilities for spindel.
 
-  Provides await-drain for waiting for reactive event processing to complete."
-  (:require [org.replikativ.spindel.engine.impl.simple :as simple]))
+  Provides `await-drain` for waiting for reactive event processing to complete,
+  plus a `deftest-async`/`<?`/`sync?` trio (ported from `yggdrasil.test-async`)
+  for portable tests over the partial-cps `async+sync` substrate: ONE test body
+  runs synchronously on the JVM (durable ops opened `:sync? true` return values)
+  and as a single partial-cps `async` block on cljs (each durable op suspends on
+  konserve IO). Wrap ONLY genuinely-async ops in `<?` (on cljs `await` on a
+  non-CPS value errors); thread `sync?` into the durable factory's `:sync?`."
+  (:require [org.replikativ.spindel.engine.impl.simple :as simple]
+            #?(:clj  [clojure.test]
+               :cljs [cljs.test])
+            [is.simm.partial-cps.async])
+  #?(:cljs (:require-macros [org.replikativ.spindel.test-async]
+                            [is.simm.partial-cps.async])))
 
 (defn await-drain
   "Wait for async drain to complete on the given execution context.
@@ -30,3 +41,56 @@
                        {:type ::drain-timeout
                         :context-fork-id (:fork-id context)
                         :timeout-ms timeout-ms})))))
+
+;; =============================================================================
+;; Portable async-test trio (partial-cps async+sync) — see yggdrasil.test-async
+;; =============================================================================
+
+(defn- cljs-env? [env] (some? (:ns env)))
+
+(def sync?
+  "Platform default sync-mode for durable ops: `true` (blocking values) on the
+   JVM, `false` (partial-cps CPS) on cljs. Thread into a durable factory's
+   `:sync?` so the record carries the right mode."
+  #?(:clj true :cljs false))
+
+#?(:clj
+   (defmacro <?
+     "Resolve an async durable op portably. On cljs, `await` the partial-cps CPS
+      (valid only inside a `deftest-async` body's `async` block). On the JVM the op
+      already returned its value (sync mode) so this is identity. Wrap ONLY async
+      ops — awaiting a plain value errors on cljs."
+     [x]
+     (if (cljs-env? &env)
+       `(is.simm.partial-cps.async/await ~x)
+       x)))
+
+#?(:clj
+   (defmacro deftest-async
+     "Like `clojure.test/deftest`, but the body may use `<?` to resolve async
+      durable (partial-cps) ops uniformly. On the JVM the body runs synchronously in
+      a plain `deftest` (`<?` is identity). On cljs the body is driven as ONE
+      partial-cps `async` block under `cljs.test/async`, so each `<?` suspends on
+      konserve IO and the test completes via `done`."
+     [tname & body]
+     (if (cljs-env? &env)
+       `(cljs.test/deftest ~tname
+          (cljs.test/async done#
+                           ;; Reset `*in-trampoline*` at this foreign-driver boundary so the
+                           ;; next cljs.test block self-trampolines (see yggdrasil.test-async).
+                           (let [done!# (fn []
+                                          (binding [is.simm.partial-cps.async/*in-trampoline* false]
+                                            (done#)))]
+                             ((is.simm.partial-cps.async/async
+                               (try ~@body
+                                    (catch :default e#
+                                      (cljs.test/is false (str "deftest-async threw: "
+                                                               (or (.-message e#) e#) "\n"
+                                                               (.-stack e#))))))
+                              (fn [_#] (done!#))
+                              (fn [e#]
+                                (cljs.test/is false (str "deftest-async rejected: "
+                                                         (or (.-message e#) e#) "\n"
+                                                         (when (and e# (.-stack e#)) (.-stack e#))))
+                                (done!#))))))
+       `(clojure.test/deftest ~tname ~@body))))

--- a/test/org/replikativ/spindel/ygg_bridge_portable_test.cljc
+++ b/test/org/replikativ/spindel/ygg_bridge_portable_test.cljc
@@ -6,10 +6,14 @@
    Uses a trivial SystemIdentity system so the test exercises the bridge's
    ygg-signal plumbing without dragging in async durable storage; the durable
    fork/merge path is covered separately."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [is testing]]
+            [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.yggdrasil :as ygg]
             [org.replikativ.spindel.test-helpers :as th]
-            [yggdrasil.protocols :as yp]))
+            [org.replikativ.spindel.test-async :refer [deftest-async <?]]
+            [yggdrasil.protocols :as yp])
+  #?(:cljs (:require-macros [org.replikativ.spindel.test-helpers]
+                            [org.replikativ.spindel.test-async :refer [deftest-async <?]])))
 
 (defrecord TinySys [id]
   yp/SystemIdentity
@@ -17,8 +21,8 @@
   (system-type [_] :tiny)
   (capabilities [_] nil))
 
-(deftest register-resolve-unregister
-  (th/with-ctx [_ctx]
+(deftest-async register-resolve-unregister
+  (th/with-ctx [ctx]
     (let [s    (->TinySys "kb")
           yref (ygg/register! s)]
       (testing "resolve by domain id and via the YggRef (both work on cljs now)"
@@ -28,12 +32,18 @@
       (testing "enumerate registered systems"
         (is (= {"kb" s} (ygg/registered-systems))))
       (testing "fork! works on cljs (was a hard throw before) — TinySys is not
-                Snapshotable, so it identity-forks; the fork plumbing still runs"
-        (let [fork (ygg/fork!)]
+                Snapshotable, so it identity-forks; the fork plumbing still runs.
+                fork! is now async on cljs (`<?`); it reads the context in its sync
+                prefix, so the surrounding with-ctx binding suffices at the call."
+        (let [fork (<? (ygg/fork!))]
           (is (ygg/fork-handle? fork))
           (is (some? (:child-ctx fork)))
           (is (some? (:fork-id fork)))))
+      ;; post-await: the with-ctx binding has exited across the fork! await (partial-cps
+      ;; hands a thunk to its trampoline, so `binding` does not convey), so RE-BIND the
+      ;; context for these context-reading ops.
       (testing "unregister removes it"
-        (is (true? (ygg/unregister! "kb")))
-        (is (nil? (ygg/system "kb")))
-        (is (= {} (ygg/registered-systems)))))))
+        (binding [ec/*execution-context* ctx]
+          (is (true? (ygg/unregister! "kb")))
+          (is (nil? (ygg/system "kb")))
+          (is (= {} (ygg/registered-systems))))))))

--- a/test/org/replikativ/spindel/ygg_convergent_fork_portable_test.cljc
+++ b/test/org/replikativ/spindel/ygg_convergent_fork_portable_test.cljc
@@ -1,33 +1,47 @@
 (ns org.replikativ.spindel.ygg-convergent-fork-portable-test
   "PORTABLE proof (JVM + cljs/node) that a DURABLE convergent-CRDT ygg-signal forks
-   as a REAL yggdrasil BRANCH on cljs too — the payoff of the Design-B `async+sync`
-   lift of the spindel↔yggdrasil bridge.
+   as a REAL yggdrasil BRANCH — the payoff of the Design-B `async+sync` lift of the
+   spindel↔yggdrasil bridge.
 
-   WHY SYNC MODE ON CLJS (`{:sync? true}`): the bridge is now `async+sync`, so on cljs
-   its ops CAN return a partial-cps continuation. But DRIVING that async path across an
-   internal durable await needs `*execution-context*` bound through the resume — and
-   spindel deliberately re-binds the context only via its ENGINE (spin resume),
-   EXCLUDING it from raw partial-cps binding capture (see engine/bindings.cljc). A raw
-   `binding`/`set!` does NOT survive a partial-cps await; a durable async drain
-   (`g/elements`) even spawns spins that read the context mid-drain. So the async path
-   with internal awaits is a spin/engine concern (a higher layer). Here we pin
-   `{:sync? true}` — in-memory konserve reads synchronously on cljs (a plain `Iter`,
-   no async-seq) — which runs the bridge's SYNC branch and, crucially, exercises the
-   CLJS-SPECIFIC new logic that the JVM never runs: `fork-value` DEFERS on cljs
-   (`#?(:cljs this)`) and `fork!`'s post-pass branches the convergent system. `binding`
-   is valid here precisely because no op suspends. (The async CPS branch itself is
-   compile-validated on cljs, and `ygg-bridge-portable-test` runs it at runtime for a
-   no-internal-await system.)"
+   TWO deftests, two regimes:
+
+   1. `convergent-branch-fork-portable` — the SYNC branch (`{:sync? true}`). In-memory
+      konserve reads synchronously on cljs (a plain `Iter`, no async-seq), so the WHOLE
+      flow runs the bridge's SYNC branch and exercises the CLJS-SPECIFIC new logic the
+      JVM never runs: `fork-value` DEFERS on cljs (`#?(:cljs this)`) and `fork!`'s
+      post-pass branches the convergent system. A raw `binding` is valid here because no
+      op suspends.
+
+   2. `convergent-branch-fork-async-through-spin` — the ASYNC continuation, driven THROUGH
+      A SPIN so the ENGINE conveys `*execution-context*` across the suspending durable
+      awaits. `fork!`/`merge-fork!` run `{:sync? false}` (a partial-cps CPS on cljs, and a
+      FOREIGN konserve thread on the JVM — so the JVM exercises the real async path too,
+      no browser needed). This SUPERSEDES the sync test's async gap: it proves the natural
+      fork API (`@kref` inherits, `g/conj` writes, `merge-fork!` folds) works fully async.
+
+      The load-bearing bridge fix (`org.replikativ.spindel.yggdrasil/convey-context`):
+      spindel EXCLUDES `*execution-context*` from partial-cps binding capture (it is
+      re-bound only by the engine on spin resume — see `engine/bindings.cljc`). So a raw
+      `(async … (await (fork!)) … @kref …)` loses the context after the suspending await.
+      `convey-context` wraps each durable bridge op's resolve/reject to re-bind the
+      captured context, carrying it into the awaiting spin's continuation — so the
+      natural reads/writes AFTER an `await` resolve against the right context."
   (:require [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.yggdrasil :as ygg]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.effects.await :refer [await]]
             [org.replikativ.spindel.test-async :refer [deftest-async]]
-            [clojure.test :refer [is testing]]
+            [org.replikativ.spindel.test-helpers :refer [async with-ctx run-spin!]]
+            #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
             [yggdrasil.convergent.gset :as g])
-  #?(:cljs (:require-macros [org.replikativ.spindel.test-async :refer [deftest-async]])))
+  #?(:cljs (:require-macros [org.replikativ.spindel.test-async :refer [deftest-async]]
+                            [org.replikativ.spindel.spin.cps :refer [spin]]
+                            [org.replikativ.spindel.test-helpers :refer [async with-ctx]])))
 
 (deftest-async convergent-branch-fork-portable
-  (testing "a durable G-Set forks as a branch on BOTH platforms; @kref inherits, g/conj writes, merge folds"
+  (testing "SYNC branch: a durable G-Set forks as a branch on BOTH platforms; @kref inherits, g/conj writes, merge folds"
     (let [ctx (sp/create-execution-context)]
       (binding [ec/*execution-context* ctx]
         (let [g1   (-> (g/gset "kb" {:store-config {:backend :memory :id (random-uuid)}} {:sync? true})
@@ -50,3 +64,45 @@
           (ygg/merge-fork! fh {:sync? true})
           (is (= #{:shared :fork-fact} (g/elements @kref {:sync? true}))
               "merge-fork! folds the fork's write into the parent (natural read)"))))))
+
+(deftest convergent-branch-fork-async-through-spin
+  ;; ASYNC continuation, driven THROUGH A SPIN. `fork!`/`merge-fork!` are `{:sync? false}`
+  ;; — a real suspending durable op (foreign konserve thread on the JVM, a later microtask
+  ;; on cljs). The engine conveys *execution-context* across the awaits via the bridge's
+  ;; `convey-context`, so the NATURAL fork API works after each suspend.
+  (async done
+         (with-ctx [ctx]
+           (let [g1   (-> (g/gset "kb" {:store-config {:backend :memory :id (random-uuid)}} {:sync? true})
+                          (g/conj :shared {:sync? true}))
+                 yref (ygg/register! g1)
+                 flow (spin
+                       (let [;; SUSPENDING durable branch-fork (async path)
+                             fh        (await (ygg/fork! {:sync? false}))
+                         ;; inside the fork: read inherited tip, write a fork-only fact.
+                         ;; ctx conveyed by the bridge → binding the child ctx resolves @yref there.
+                             in-fork   (binding [ec/*execution-context* (:child-ctx fh)]
+                                         (let [inherited (g/elements @yref {:sync? true})]
+                                           (reset! (ygg/system-signal "kb")
+                                                   (g/conj @yref :fork-fact {:sync? true}))
+                                           [inherited (g/elements @yref {:sync? true})]))
+                         ;; back in the parent continuation (ctx conveyed by fork!): parent isolated
+                             parent-iso (g/elements @yref {:sync? true})
+                         ;; SUSPENDING durable merge (conflict pre-check runs — no :force)
+                             _          (await (ygg/merge-fork! fh {:sync? false}))
+                             merged     (g/elements @yref {:sync? true})]
+                         {:inherited (first in-fork) :fork-after (second in-fork)
+                          :parent-iso parent-iso :merged merged}))]
+             (run-spin! flow
+                        (fn [r]
+                          (is (= #{:shared} (:inherited r))
+                              "fork inherited the parent tip via branch! (async, @yref read after suspend)")
+                          (is (= #{:shared :fork-fact} (:fork-after r))
+                              "g/conj write visible in the fork branch (async)")
+                          (is (= #{:shared} (:parent-iso r))
+                              "parent isolated during the fork (async continuation on parent ctx)")
+                          (is (= #{:shared :fork-fact} (:merged r))
+                              "merge-fork! folds the fork write into the parent (async, after conflict pre-check)")
+                          (done))
+                        (fn [e]
+                          (is false (str "async fork/merge spin rejected: " e))
+                          (done)))))))

--- a/test/org/replikativ/spindel/ygg_convergent_fork_portable_test.cljc
+++ b/test/org/replikativ/spindel/ygg_convergent_fork_portable_test.cljc
@@ -1,0 +1,52 @@
+(ns org.replikativ.spindel.ygg-convergent-fork-portable-test
+  "PORTABLE proof (JVM + cljs/node) that a DURABLE convergent-CRDT ygg-signal forks
+   as a REAL yggdrasil BRANCH on cljs too — the payoff of the Design-B `async+sync`
+   lift of the spindel↔yggdrasil bridge.
+
+   WHY SYNC MODE ON CLJS (`{:sync? true}`): the bridge is now `async+sync`, so on cljs
+   its ops CAN return a partial-cps continuation. But DRIVING that async path across an
+   internal durable await needs `*execution-context*` bound through the resume — and
+   spindel deliberately re-binds the context only via its ENGINE (spin resume),
+   EXCLUDING it from raw partial-cps binding capture (see engine/bindings.cljc). A raw
+   `binding`/`set!` does NOT survive a partial-cps await; a durable async drain
+   (`g/elements`) even spawns spins that read the context mid-drain. So the async path
+   with internal awaits is a spin/engine concern (a higher layer). Here we pin
+   `{:sync? true}` — in-memory konserve reads synchronously on cljs (a plain `Iter`,
+   no async-seq) — which runs the bridge's SYNC branch and, crucially, exercises the
+   CLJS-SPECIFIC new logic that the JVM never runs: `fork-value` DEFERS on cljs
+   (`#?(:cljs this)`) and `fork!`'s post-pass branches the convergent system. `binding`
+   is valid here precisely because no op suspends. (The async CPS branch itself is
+   compile-validated on cljs, and `ygg-bridge-portable-test` runs it at runtime for a
+   no-internal-await system.)"
+  (:require [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [org.replikativ.spindel.test-async :refer [deftest-async]]
+            [clojure.test :refer [is testing]]
+            [yggdrasil.convergent.gset :as g])
+  #?(:cljs (:require-macros [org.replikativ.spindel.test-async :refer [deftest-async]])))
+
+(deftest-async convergent-branch-fork-portable
+  (testing "a durable G-Set forks as a branch on BOTH platforms; @kref inherits, g/conj writes, merge folds"
+    (let [ctx (sp/create-execution-context)]
+      (binding [ec/*execution-context* ctx]
+        (let [g1   (-> (g/gset "kb" {:store-config {:backend :memory :id (random-uuid)}} {:sync? true})
+                       (g/conj :shared {:sync? true}))
+              kref (ygg/register! g1)
+              fh   (ygg/fork! {:sync? true})]
+          ;; INSIDE the fork — @kref resolves against the fork's child context. On cljs,
+          ;; fork-value DEFERRED (returned the parent value) and fork!'s post-pass branched
+          ;; the convergent system; on the JVM fork-value branched it directly.
+          (binding [ec/*execution-context* (:child-ctx fh)]
+            (is (= #{:shared} (g/elements @kref {:sync? true}))
+                "fork inherited the parent tip via branch! (natural @kref read)")
+            (reset! (ygg/system-signal "kb") (g/conj @kref :fork-fact {:sync? true}))
+            (is (= #{:shared :fork-fact} (g/elements @kref {:sync? true}))
+                "natural conj write works on the fork branch"))
+          ;; the parent is isolated during the fork
+          (is (= #{:shared} (g/elements @kref {:sync? true}))
+              "parent isolated during the fork")
+          ;; fold the fork back
+          (ygg/merge-fork! fh {:sync? true})
+          (is (= #{:shared :fork-fact} (g/elements @kref {:sync? true}))
+              "merge-fork! folds the fork's write into the parent (natural read)"))))))

--- a/test/org/replikativ/spindel/ygg_convergent_fork_test.clj
+++ b/test/org/replikativ/spindel/ygg_convergent_fork_test.clj
@@ -1,0 +1,69 @@
+(ns org.replikativ.spindel.ygg-convergent-fork-test
+  "Branch-based convergent forks: a convergent CRDT ygg-signal forks as a REAL yggdrasil
+   BRANCH (inherits the parent tip), so the NATURAL API works inside a fork — `@kref` reads
+   the actual set, `swap! + g/conj` writes, `merge-fork!` folds back — with none of the
+   `:following`-overlay footguns (empty-delta reads, Overlay write NPE, merge fn-seating).
+   Overlays remain reachable via `:convergent-fork :overlay`.
+
+   JVM-only for now: durable `branch!`/`checkout` are async on cljs and the engine's
+   `fork-context` is synchronous, so durable branch-fork is JVM-first until the async
+   fork-context lift lands (the in-mem ConflictFreeSystem forks sync on both platforms)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.core :as sp]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [yggdrasil.convergent.gset :as g]
+            [yggdrasil.convergent.overlay :as ovl]
+            [yggdrasil.convergent.cdvcs :as cdvcs]))
+
+(defn- mem-gset [id]
+  (g/gset id {:store-config {:backend :memory :id (random-uuid)}} {:sync? true}))
+
+(deftest convergent-branch-fork-roundtrip-natural-api
+  (testing "a durable G-Set forks as a branch; @kref inherits, g/conj writes, merge folds"
+    (let [ctx (sp/create-execution-context)]
+      (sp/with-context ctx
+        (let [kref (ygg/register! (-> (mem-gset "kb") (g/conj :shared)))
+              fh   (ygg/fork!)]
+          (ygg/with-fork fh
+            (is (= #{:shared} (g/elements @kref))
+                "fork inherits the parent tip via branch! (natural @kref read)")
+            (swap! (ygg/system-signal "kb") (fn [s] (g/conj s :fork-fact)))
+            (is (= #{:shared :fork-fact} (g/elements @kref))
+                "natural swap!+g/conj write works on the fork branch"))
+          (is (= #{:shared} (g/elements @kref)) "parent isolated during the fork")
+          (ygg/merge-fork! fh)
+          (is (= #{:shared :fork-fact} (g/elements @kref))
+              "merge-fork! folds the fork's write into the parent (natural read)"))))))
+
+(deftest convergent-fork-discard-drops-branch
+  (testing "discard-fork! abandons the fork without touching the parent"
+    (let [ctx (sp/create-execution-context)]
+      (sp/with-context ctx
+        (let [kref (ygg/register! (-> (mem-gset "kb") (g/conj :shared)))
+              fh   (ygg/fork!)]
+          (ygg/with-fork fh
+            (swap! (ygg/system-signal "kb") (fn [s] (g/conj s :discarded))))
+          (ygg/discard-fork! fh)
+          (is (= #{:shared} (g/elements @kref)) "parent unchanged after discard"))))))
+
+(deftest convergent-fork-overlay-opt-still-works
+  (testing ":convergent-fork :overlay forces the live-:following overlay path; merge still folds"
+    (let [ctx (sp/create-execution-context)]
+      (sp/with-context ctx
+        (let [kref (ygg/register! (-> (mem-gset "kb") (g/conj :shared)))
+              fh   (ygg/fork! {:convergent-fork :overlay})]
+          (ygg/with-fork fh
+            (is (ovl/overlay? @(ygg/system-signal "kb"))
+                "under :overlay the signal holds an Overlay, not a branched system")
+            (ovl/overlay-swap! @(ygg/system-signal "kb") (fn [s] (g/conj s :ov-fact))))
+          (ygg/merge-fork! fh)
+          (is (= #{:shared :ov-fact} (g/elements @kref))
+              "overlay merge folds into the parent (relies on merge-down! :sync? fix)"))))))
+
+(deftest non-branchable-convergent-fork-fails-loud
+  (testing "forking a cdvcs (convergent, :branchable false, no Overlayable) throws clearly, not NPE"
+    (let [ctx (sp/create-execution-context)]
+      (sp/with-context ctx
+        (ygg/register! (cdvcs/cdvcs "cd" {:store-config {:backend :memory :id (random-uuid)}} {:sync? true}))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"neither :branchable"
+                              (ygg/fork!)))))))

--- a/test/org/replikativ/spindel/ygg_convergent_fork_test.clj
+++ b/test/org/replikativ/spindel/ygg_convergent_fork_test.clj
@@ -5,9 +5,12 @@
    `:following`-overlay footguns (empty-delta reads, Overlay write NPE, merge fn-seating).
    Overlays remain reachable via `:convergent-fork :overlay`.
 
-   JVM-only for now: durable `branch!`/`checkout` are async on cljs and the engine's
-   `fork-context` is synchronous, so durable branch-fork is JVM-first until the async
-   fork-context lift lands (the in-mem ConflictFreeSystem forks sync on both platforms)."
+   JVM-flavoured suite (uses `with-fork` + `swap!`, both JVM-only): the bridge fork/merge
+   fns are now `async+sync`, so durable branch-fork ALSO works on cljs (the engine's
+   `fork-context` stays synchronous; the async lives in `fork!`'s awaited post-pass +
+   the merge/discard loops). The cross-platform proof lives in
+   `ygg-convergent-fork-portable-test` (a `.cljc` `deftest-async` exercising the real
+   cljs async path); this JVM suite keeps the ergonomic sync surface."
   (:require [clojure.test :refer [deftest is testing]]
             [org.replikativ.spindel.core :as sp]
             [org.replikativ.spindel.yggdrasil :as ygg]


### PR DESCRIPTION
Fixes how a spindel execution-context forks a ygg-signal holding a **convergent CRDT**. Previously such a fork produced a `:following` **overlay** whose writable system is an empty delta — three footguns: `@kref`/`g/elements` read empty, `swap!`+`g/conj` NPE'd (the signal held an Overlay, not a GSet), and merge seated a partial-cps continuation as the parent value (silent data-loss). The convergent-fork path through the bridge was untested (fork tests were git-only).

## What changed

**1. Branch-based convergent forks (default; overlays optional).** A genuinely-branchable convergent system (`PConvergent` + `:branchable` capability — not cdvcs, which is `:branchable false`) now forks as a REAL yggdrasil BRANCH (`branch!`+`checkout`, inheriting the parent tip). The fork value is an ordinary GSet, so the NATURAL API works in a fork with no bridge magic: `@kref` reads, `g/conj` writes, `merge-fork!` (= checkout parent + `merge!` fork-branch + `delete-branch!`) folds back. Uniform with datahike/git. `:convergent-fork :overlay` forces the live-`:following` overlay; cdvcs (non-branchable, no Overlayable) now FAILS LOUD instead of NPE-ing.

**2. Fully-async, portable fork/merge (Design B).** The engine stays synchronous and yggdrasil-free; the bridge (`fork!`/`merge-to-parent!`/`discard`/`merge-from-parent!`/`context-diff`/`context-conflicts`) is now `async+sync` — SYNC on the JVM (byte-identical; dvergr + all JVM callers unchanged) and a partial-cps continuation on cljs. So a DURABLE convergent branch-fork works on cljs when driven through the engine (a spin).
  - `convey-context` re-binds `*execution-context*` (+ `*in-trampoline* false`, mirroring `chan->spin`) around each durable op's resolve/reject — spindel excludes the context from partial-cps capture, so a spin awaiting a durable op would otherwise resume unbound. Returns a thunk (raw callers keep working; JVM sync unchanged).
  - Latent async-merge crash fixed: `snapshot-id`/`common-ancestor` are 1-arity (plain on JVM, CPS on cljs) — await only when a continuation.

**3. Pre-existing spindel bug (`seq/core.cljc`).** `(extend-type nil PAsyncSeq)` globally overrode the SHARED partial-cps nil terminator with a context-requiring `make-spin`, poisoning every async-seq drain outside a bound context. Fixed to a plain thunk (as partial-cps's own nil impl).

## Tests / validation
- New `ygg_convergent_fork_test.clj` (JVM natural-API round-trip, discard, overlay-opt, cdvcs fail-loud) + `ygg_convergent_fork_portable_test.cljc` (`.cljc`; a sync test for the cljs defer/post-pass, and `convergent-branch-fork-async-through-spin` driving durable `fork!`/`merge-fork!` at `:sync? false` through a REAL spin — the fully-async proof).
- Ported `deftest-async`/`<?`/`sync?` into `test_async.cljc`.
- **JVM 881/0, cljs 397/0**, cljfmt clean. On released yggdrasil `0.3.35`.

Depends on yggdrasil #13 (overlay `:sync?` fix, released as 0.3.35).