### PR TITLE
fix(sci): inject the whole partial-cps runtime ns into SCI (fixes runtime/thunk?)

### DIFF
--- a/src/org/replikativ/spindel/sci/core.clj
+++ b/src/org/replikativ/spindel/sci/core.clj
@@ -37,10 +37,13 @@
   [sci-ctx]
   (require 'is.simm.partial-cps.runtime)
   ;; Native runtime namespace — one canonical compiled Thunk class.
+  ;; Inject the WHOLE runtime ns (all publics, native) — the interpreted async/seq CPS
+  ;; macros reference runtime/thunk?, runtime/force-thunk, … (added in partial-cps 0.1.57).
+  ;; A hand-picked subset silently breaks whenever partial-cps adds a runtime helper the
+  ;; macros emit (this bit the SCI spin/gen-aseq path via `runtime/thunk?`). All runtime
+  ;; publics are plain native fns / the ONE compiled Thunk ctor, so this stays canonical.
   (sci/add-namespace! sci-ctx 'is.simm.partial-cps.runtime
-                      {'bound-fn @(resolve 'is.simm.partial-cps.runtime/bound-fn)
-                       '->thunk  @(resolve 'is.simm.partial-cps.runtime/->thunk)
-                       '->Thunk  @(resolve 'is.simm.partial-cps.runtime/->Thunk)})
+                      (update-vals (ns-publics 'is.simm.partial-cps.runtime) deref))
   (let [ioc-src (slurp (clojure.java.io/resource "is/simm/partial_cps/ioc.clj"))
         async-src (slurp (clojure.java.io/resource "is/simm/partial_cps/async.cljc"))]
     (sci/eval-string* sci-ctx ioc-src)


### PR DESCRIPTION
Bugfix follow-up to #22 (already released).

## Symptom
A `spin` / `gen-aseq` evaluated **inside SCI** (e.g. an agent's sandbox) throws at runtime:
`Unable to resolve symbol: runtime/thunk?`. dvergr hit this at daemon startup once its spindel dep picked up the current partial-cps.

## Cause
`sci/core/load-partial-cps!` injects `is.simm.partial-cps.runtime` into the SCI env as a NATIVE namespace, but with a **hand-picked** var set — `{bound-fn ->thunk ->Thunk}`. The interpreted `async.cljc` (loaded into SCI via `eval-string*`) and the seq CPS machinery reference `runtime/thunk?` and `runtime/force-thunk`, which partial-cps added in **0.1.57**. Those weren't in the injected map, so the alias resolves to nothing inside SCI.

## Fix
Inject the WHOLE runtime ns (all publics, native) instead of a hand-picked subset, so the set can't drift whenever partial-cps adds a runtime helper the macros emit:
```clojure
(sci/add-namespace! sci-ctx 'is.simm.partial-cps.runtime
                    (update-vals (ns-publics 'is.simm.partial-cps.runtime) deref))
```
All runtime publics are plain native fns / the one compiled `Thunk` ctor, so the canonical-compiled-Thunk-class guarantee (the reason this ns is injected natively rather than interpreted) is preserved.

Verified against a live SCI spin: `@(spin (+ 1 (await (spin 41))))` now CPS-transforms + runs (previously threw `runtime/thunk?`).