### PR TITLE
fix(engine): don't GC-reap a spin suspended on a spin-await (lost-wakeup hang)

### DIFF
--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -806,6 +806,16 @@
                   dedup-key [parent-id tid generation]
                   already-resumed? (when (and generation batch)
                                      (contains? @(:resumed-conts batch) dedup-key))]
+              ;; A completion whose subscription exists but whose cont entry is
+              ;; MISSING is a dropped wakeup — the parent spin will never
+              ;; resume. This must be loud, not a silent skip: it has cost
+              ;; days of debugging as an unexplained hang. Known cause:
+              ;; a fork's [:await-conts] snapshot (context.cljc fork-context)
+              ;; not containing a cont the parent registered post-fork.
+              (when (and (nil? cont) (not already-resumed?))
+                (log/warn :engine/spin-completion-cont-missing
+                          {:parent-id parent-id :cont-id cont-id :child-id tid
+                           :fork-id (:fork-id context)}))
               (when (and cont (not already-resumed?))
                 ;; Mark [parent child generation] as resumed
                 (when (and generation batch)
@@ -1450,6 +1460,35 @@
    (some (fn [[_k v]] (= :external-await (:kind v)))
          (rtp/get-state context [:await-conts spin-id]))))
 
+(defn- has-live-spin-await?
+  "True if `spin-id` has an await continuation on a child spin that has
+  NOT yet completed — the body is suspended mid-await and the child's
+  eventual `:spin-completion` needs this spin's cont + node to resume.
+
+  This closes the AWAITER half of the GC-reap hole that
+  `has-live-external-await?` closed for external resources: `:awaited-spin`
+  keeps the CHILD reachable through the parent's cont, but nothing keeps
+  the PARENT `Spin` object reachable — only the user's local binding does.
+  A parent parked in `@deref` (HotSpot liveness can drop the reference
+  mid-park) or a fire-and-forget awaiting chain becomes Cleaner-eligible
+  while genuinely suspended; reaping it deletes the node + conts +
+  subscriptions, so the child's completion dispatches into
+  `:parent-spin-ids nil` and is silently dropped — the awaiter never
+  resumes, no error. (Manifested as the dvergr llm-agent ask hang:
+  ~50 % under normal GC, deterministic under forced GC mid-turn.)
+
+  A cont whose child has ALREADY completed is not counted — its one-shot
+  event has fired (once-conts linger until the generation sweep); counting
+  those would block legitimate cascade cleanup of completed pairs."
+  [context spin-id]
+  (boolean
+   (some (fn [[_k v]]
+           (let [[ev-kind child-id] (:event-key v)]
+             (and (= :spin/complete ev-kind)
+                  (when-let [child (rtp/get-state context [:nodes child-id])]
+                    (not (:completed? child))))))
+         (rtp/get-state context [:await-conts spin-id]))))
+
 (defn try-gc-cleanup-spin!
   "Called from GC callback. Attempts full cleanup if safe, otherwise marks
   the spin as orphaned for deferred cleanup.
@@ -1488,9 +1527,10 @@
     (when node ;; may already be cleaned
       (let [has-observers? (seq (nodes/get-observers node))
             live-signal-cont? (has-live-signal-cont? context spin-id)
-            live-external-await? (has-live-external-await? context spin-id)]
+            live-external-await? (has-live-external-await? context spin-id)
+            live-spin-await? (has-live-spin-await? context spin-id)]
         (cond
-          (or has-observers? live-signal-cont? live-external-await?)
+          (or has-observers? live-signal-cont? live-external-await? live-spin-await?)
           ;; Has observers, live signal continuations, or live external
           ;; awaits → mark orphaned and defer cleanup. The Cleaner has
           ;; run, so the Spin object itself is unreachable, but the
@@ -1515,7 +1555,8 @@
                            (:orphaned? dep-node)
                            (empty? (nodes/get-observers dep-node))
                            (not (has-live-signal-cont? context dep-id))
-                           (not (has-live-external-await? context dep-id)))
+                           (not (has-live-external-await? context dep-id))
+                           (not (has-live-spin-await? context dep-id)))
                   (full-cleanup-spin! context dep-id))))))))))
 
 (defn track-signal-dep!
@@ -1816,7 +1857,15 @@
                                         (assoc-in state' [:subscriptions event-key spin-id] spin-subs')
                                         (update-in state' [:subscriptions event-key] dissoc spin-id))))
                                   rt-state
-                                  await-conts))))))))
+                                  await-conts)))
+              ;; Deferred reap: a spin whose Cleaner fired while it was
+              ;; suspended on a spin-await was ORPHANED (not full-cleaned —
+              ;; see has-live-spin-await? / try-gc-cleanup-spin!). Now that
+              ;; it has completed and its ephemeral conts are cleared, this
+              ;; generation boundary is the natural point to drop the node
+              ;; for real — otherwise completed orphans accumulate.
+              (when (:orphaned? (rtp/get-state context [:nodes spin-id]))
+                (full-cleanup-spin! context spin-id)))))))
 
     ;; Spin observers (parent set) live on `:nodes[child-id]:observers`;
     ;; there is no separate `:await-dependents` index any longer.

--- a/test/org/replikativ/spindel/gc_liveness_test.clj
+++ b/test/org/replikativ/spindel/gc_liveness_test.clj
@@ -1,0 +1,64 @@
+(ns org.replikativ.spindel.gc-liveness-test
+  "JVM Cleaner vs suspended spins — the awaiter-reap regression.
+
+   Every reactive spin registers a `java.lang.ref.Cleaner` that full-cleans
+   its engine node when the Spin JAVA OBJECT becomes unreachable
+   (spin/core.cljc). The engine holds a suspended spin's continuations in
+   context state, but nothing holds the Spin OBJECT itself — only the user's
+   local binding does, and HotSpot liveness can drop that mid-`@deref`-park
+   or after the last source-level use (fire-and-forget chains).
+
+   `try-gc-cleanup-spin!` guards observers / signal-conts / EXTERNAL awaits,
+   but historically exempted SPIN-awaits (`[:spin/complete _]`) — reasoning
+   that `:awaited-spin` keeps the pair reachable. That keeps the CHILD
+   reachable through the parent's cont; it does nothing for the PARENT.
+   A parent suspended awaiting a still-running child could thus be reaped
+   alive: node + conts + subscriptions deleted, the child's completion
+   dispatched into `:parent-spin-ids nil`, silently dropped — the awaiter
+   never resumed, no error. Manifested as the dvergr llm-agent ask hang
+   (~50 % under organic GC, deterministic with forced GC mid-turn).
+
+   Fixed by `has-live-spin-await?`: an await cont on a NOT-yet-completed
+   child marks the spin live (orphan, don't full-clean); the generation
+   sweep (`clear-all-await-continuations!`) reaps completed orphans."
+  (:refer-clojure :exclude [await])
+  (:require [clojure.test :refer [deftest testing is]]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.spin.sync :as sync]
+            [org.replikativ.spindel.effects.await :refer [await]]))
+
+(defn- build-suspended-chain!
+  "Construct parent→child→deferred awaiting chain and START it CPS-style,
+   delivering into `result`. Runs in its own fn scope so that on return NO
+   caller-reachable reference to either Spin object remains — the engine's
+   context state is the only thing keeping the suspended chain alive, which
+   is exactly the condition under which the Cleaner used to reap the parent."
+  [result]
+  (let [d      (sync/deferred)
+        child  (spin (await d))
+        parent (spin (inc (await child)))]
+    ;; Fire-and-forget CPS start: parent suspends awaiting child, child
+    ;; suspends awaiting the deferred.
+    (parent (fn [v] (deliver result [:ok v]))
+            (fn [e] (deliver result [:err e])))
+    d))
+
+(deftest test-gc-does-not-reap-suspended-spin-awaiter
+  (testing "a parent suspended on a spin-await survives GC of its Spin object;
+            the child's eventual completion still resumes it"
+    (let [c (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* c]
+          (let [result (promise)
+                d      (build-suspended-chain! result)]
+            ;; The parent/child Spin objects are now unreachable from user
+            ;; code. Force the Cleaner's hand.
+            (dotimes [_ 3] (System/gc) (Thread/sleep 100))
+            ;; Deliver the external resource — must propagate child→parent.
+            (sync/deliver! d 41)
+            (is (= [:ok 42] (deref result 10000 ::timeout))
+                "the awaiter must resume after GC; ::timeout = it was reaped alive")))
+        (finally
+          (ctx/stop-context! c))))))


### PR DESCRIPTION
## The bug

The JVM `Cleaner` (registered per reactive spin in `spin/core.cljc`) full-cleans a spin's engine node when its Spin **Java object** becomes unreachable. `try-gc-cleanup-spin!` guarded observers, signal-conts, and **external** awaits — but exempted **spin-awaits** (`[:spin/complete _]`), reasoning that the cont's `:awaited-spin` field keeps the awaiter/awaitee pair reachable.

That keeps the **child** reachable through the parent's cont. Nothing keeps the **parent** Spin object reachable except the user's local binding — which HotSpot liveness analysis can drop mid-`@deref`-park (the classic premature-finalization hazard) or after last source-level use in fire-and-forget chains.

Result: a parent genuinely suspended awaiting a **still-running** child was reaped alive — node + conts + subscriptions deleted. The child's eventual completion dispatched into `:parent-spin-ids nil` and was **silently dropped**. The awaiter never resumes; no error; even `comb/timeout` can't save the caller (the timer fires, but the spin it would wake no longer exists).

Manifested downstream as the dvergr llm-agent ask hang: **~50% of asks** under organic GC (any room — fork or plain), **deterministic** with `System/gc` forced mid-turn, near-always for real multi-second LLM turns. Same bug class as the earlier `discourse.llm-test` ~20% flake, whose fix covered external awaits only.

## The fix

- **`has-live-spin-await?`** — an await cont on a **not-yet-completed** child marks the spin live: `try-gc-cleanup-spin!` orphans it instead of full-cleaning (also added to the cascade recheck). Conts whose child already completed remain reapable (their one-shot event has fired), so legitimate cascade cleanup of completed pairs is preserved.
- **Deferred reap** — `clear-all-await-continuations!` full-cleans orphaned spins once they've completed and their ephemeral conts are cleared (the generation sweep is the natural reap point; prevents completed-orphan accumulation).
- **Loud drop** — the `:spin-completion` handler now WARNs (`:engine/spin-completion-cont-missing`) when a completion's subscription exists but its cont is gone. A dropped wakeup manifests as an unexplained hang and must never be silent.

## Validation

- New `gc_liveness_test`: constructs a suspended parent→child→deferred chain in a discarded fn scope (no user refs), forces GC, then delivers — **fails with `::timeout` on the old code, passes with the fix** (validated in both directions).
- dvergr end-to-end harness (real participant machinery, stubbed turn, `System/gc` forced every turn): was hang-on-first-attempt → **14/14 clean**, fork and plain alike.
- Full JVM suite: **882 tests / 3030 assertions / 0 failures**.
- The originally-failing scenario — a real-LLM subagent hired into a fork-room via dvergr's `hire!` — completes and merges.