### PR TITLE
fix(dom): render :style maps; lost-wakeup instrumentation + docs

### DIFF
--- a/src/org/replikativ/spindel/dom/browser.cljs
+++ b/src/org/replikativ/spindel/dom/browser.cljs
@@ -68,6 +68,17 @@
         (= attr-name :class)
         (.setAttribute el "class" value-str)
 
+        ;; Handle style maps: {:height "227px" :max-width "50%"} →
+        ;; "height: 227px; max-width: 50%". Without this branch a map
+        ;; falls through to :else and setAttribute receives the EDN
+        ;; string, which the browser silently rejects — :style maps
+        ;; never render. String styles pass through :else unchanged.
+        (and (= attr-name :style) (map? attr-value))
+        (.setAttribute el "style"
+                       (->> attr-value
+                            (map (fn [[k v]] (str (name k) ": " v)))
+                            (str/join "; ")))
+
         ;; Handle innerHTML (raw HTML injection — use with trusted content only)
         (= attr-name :innerHTML)
         (set! (.-innerHTML el) attr-value)

--- a/src/org/replikativ/spindel/dom/foreach.cljc
+++ b/src/org/replikativ/spindel/dom/foreach.cljc
@@ -265,7 +265,21 @@
       The render-fn may return a vnode or a spin. When it returns a
       spin, ifor-each's outer return is a spin (awaiting all child
       spins). When it returns a plain vnode, the outer return is a
-      KeyedFragment."
+      KeyedFragment.
+
+      MEMOIZATION CONTRACT: per-key renders are memoized on ITEM
+      equality (plain-element vnodes only; spin-returning render-fns
+      are never memoized). If an item is `=` to its previous value, the
+      cached vnode is reused and render-fn is NOT called — closure
+      variables captured by render-fn (a selected id, a lookup map) are
+      invisible to the diff. Anything that must trigger a re-render has
+      to be part of the item itself:
+
+        ;; WRONG — selected-id changes never re-render old items:
+        (ifor-each :id items #(row % (= (:id %) selected-id)))
+        ;; RIGHT — encode it in the item:
+        (ifor-each :id (mapv #(assoc % :selected? (= (:id %) selected-id)) items)
+          #(row % (:selected? %)))"
      [key-fn items render-fn]
      (let [source-loc {:file *file*
                        :line (:line (meta &form))


### PR DESCRIPTION
Two clean changes left over after #25 (v0.1.28).

## Fix
- **`fix(dom): render :style maps`** — a `:style` map fell through to `setAttribute` and was serialized as EDN instead of being rendered as CSS.

## Docs
- **`docs(foreach): document ifor-each's memoization contract loudly`**.

Version auto-derives from commit count; merging to main cuts and deploys the next release (CircleCI `clojars-deploy`, `branches: only: main`).

The lost-wakeup mailbox/continuation instrumentation from the same simmis debugging session was dropped from this PR: it logs at WARN on routine reactive events (race/timeout waiter cancellation, cont displacement on re-run), and the bug it was chasing is already fixed in #24/#25. Preserved locally on branch `fix/gc-reap-quiescence-serialized` if a properly-leveled version is wanted later. A related design note lives in the gitignored `.internal/`.
