### PR TITLE
Engine fixes: cancel-token await path, zombie-cont prologue, mult fault-isolation, :style render

### DIFF
--- a/docs/engine-formalism.md
+++ b/docs/engine-formalism.md
@@ -91,6 +91,15 @@ regardless of how `await`s are grouped in source. **Holds (structural).**
 (`spin/core.cljc:345-381`, `:524-546`), which caches the error and
 marks observers dirty so they rediscover it. **Holds.**
 
+*Rendering consequence.* Because errors short-circuit every ancestor
+bind, a single body exception rejects the whole chain up to the root
+render effect, which produces **no vdom** — the UI freezes at the last
+resolved frame with one `:render/error` log line. Semantically correct,
+observationally near-silent (the simmis AsOfDB episode: a `contains?`
+probe threw inside the page-editor body and the app appeared to ignore
+all updates). Dev builds now surface this visibly
+(`dom/render.cljc::show-render-error-overlay!`).
+
 **Status: Holds (structural).** Not mechanized; CPS construction
 guarantees the monad laws the way any CPS encoding of a monad does.
 
@@ -439,15 +448,33 @@ behaviors are not a 4-tuple of caller-supplied flags.
 ```mermaid
 stateDiagram-v2
     [*] --> Registered: make-spin (3-arity) → register-spin! :computation
-    Registered --> Running: (spin r e) invoke Case 2 / :spin-execution
+    Registered --> Running: (spin r e) invoke Case 2 / :spin-execution / await slow path
     Running --> Completed: outer resolve → cache-result! (:clean, completed?, running?=false)
     Running --> Suspended: body returns the incomplete sentinel (await/track)
     Suspended --> Running: resume-body! (cont fires)
     Completed --> Dirty: dependency changed → mark-dirty! / cache-result! cascade
     Completed --> Completed: re-register with identical? captures (B-gate no-op)
-    Dirty --> Running: re-run (track resume / :spin-execution / B-gate re-register)
+    Dirty --> Running: re-run (track resume / :spin-execution / B-gate re-register / await slow path)
     Completed --> [*]: GC + no observers + no live signal cont → full-cleanup-spin!
 ```
+
+**Body-entry prologue invariant.** Every `Registered/Dirty → Running`
+transition that invokes the cps-fn from scratch MUST run the shared
+prologue `simple/enter-body!` (mark-running!, clear-created-spins!,
+clear-prior-body-conts!, seed-body-chain-head!; rebuild paths use the
+`:rebuild?` variant that leaves run-state untouched). The prologue
+maintains the invariant the dispatch rules silently assume: **at most
+one body-generation of continuations exists per spin.** Earliest-cont
+selection (§2.4 T2) and `truncate-stale-conts!` (§3.4) are sound only
+under it — a surviving earlier-generation cont always wins dispatch,
+and resuming it truncates the *live* body's conts and re-runs a frozen
+lexical closure (the zombie-repaint bug). The enumeration of body-entry
+sites is normative: `Spin -invoke` Case 2, `await-spin`'s slow path
+(the one entry that calls `.-spin-fn` directly — it bypassed the
+prologue until 71d5801), the `-invoke` rebuild branch, and `deref-spin`'s
+JVM rebuild path; `:spin-execution` events route through `-invoke`.
+Any NEW direct body invocation must call `enter-body!` — see its
+docstring's call-site list.
 
 ### 2.6 Resource-spin lifecycle
 

--- a/docs/engine-formalism.md
+++ b/docs/engine-formalism.md
@@ -647,6 +647,48 @@ an arbitrary one as "the" root. Escalation to *one* root is fine when
 the await graph is a tree; for a DAG with shared awaited children the
 "root" is non-deterministic. Flagged as a latent question.
 
+### 3.9 Rendering identity (delta-direct DOM)
+
+Rendering has **no tree diff**. `build-element` reconciles each element's attrs
+and children against caches keyed by its address, attaches the resulting
+`:deltas` to the vnode, and `update-render!` discharges those deltas against the
+DOM element **bound to that address**. Two consequences follow, and both were
+violated in practice before they were stated:
+
+**R1 — Identity is the address.** `reconcile-slot` decides "did this child slot
+change?" and `discharge-vnode!` decides "which DOM node do I write to." They must
+agree, and the only thing the DOM layer binds by is `:addr`. A vnode's address is
+`content-hash[source-loc, parent-addr, slot-index]`, and a keyed element's is
+`keyed-child-address(my-addr, key)` — so **addr equality implies key equality and
+structural position, but not conversely**. `:key` on a plain element is a
+*disambiguator* for siblings at one source location, never an identity token;
+position-independent identity is `ifor-each`'s job, and its items travel through
+the `:keyed` slot type. Letting `:key` override `:addr` in reconciliation makes
+the parent declare a child "unchanged" while the child's deltas address a node
+that was never created: the update vanishes with no error. (Regression:
+`dom/branch_flip_test.clj`.)
+
+**R2 — The root is unaddressable from above.** Every node except the mounted root
+is reachable through some parent's slot reconciliation. The root has no parent, so
+a spin whose body returns a *different* root element (a conditional at the top of
+the spin) cannot be updated by deltas at all — the new root's address has no bound
+element. `update-render!` detects a changed root identity and re-mounts, running
+the full teardown protocol first (`call-refs-on-unmount!` → `render-initial!` →
+`flush-pending-evictions!`) so foreign nodes release resources and dead caches are
+evicted, while addresses the new tree re-claims are spared by `(pending − live)`.
+
+**Corollary (unmount completeness).** Every address the render path writes must be
+reachable from the teardown walk. `flatten-slot` splices a `:keyed` slot's items
+into `:children` and drops the `KeyedFragment` itself, so the `ifor-each` call-site
+address — which holds `:by-key`, i.e. every rendered vnode and its handler closures
+— is on no vnode. `evict-cache!` therefore cascades through the evictee's slot
+cache into its keyed slots. Without that cascade, unmounting any subtree containing
+an `ifor-each` leaked the entire rendered list for the lifetime of the context.
+
+Because a changed root re-mounts (and thus loses DOM state), **keep a spin's root
+element structurally stable** and branch *inside* it. This is the loading-state
+idiom: one container with a stable key, `cond`/`if` on the content within.
+
 ### Invariant summary table
 
 | composition          | glitch-free | no double-exec | no stale-cache | no orphan cont | deterministic id |

--- a/src/org/replikativ/spindel/dom/browser.cljs
+++ b/src/org/replikativ/spindel/dom/browser.cljs
@@ -68,6 +68,17 @@
         (= attr-name :class)
         (.setAttribute el "class" value-str)
 
+        ;; Handle style maps: {:height "227px" :max-width "50%"} →
+        ;; "height: 227px; max-width: 50%". Without this branch a map
+        ;; falls through to :else and setAttribute receives the EDN
+        ;; string, which the browser silently rejects — :style maps
+        ;; never render. String styles pass through :else unchanged.
+        (and (= attr-name :style) (map? attr-value))
+        (.setAttribute el "style"
+                       (->> attr-value
+                            (map (fn [[k v]] (str (name k) ": " v)))
+                            (str/join "; ")))
+
         ;; Handle innerHTML (raw HTML injection — use with trusted content only)
         (= attr-name :innerHTML)
         (set! (.-innerHTML el) attr-value)

--- a/src/org/replikativ/spindel/dom/cache.cljc
+++ b/src/org/replikativ/spindel/dom/cache.cljc
@@ -12,7 +12,8 @@
   - :nil    - Slot is empty (conditional returned nil)
   - :single - Slot contains one vnode
   - :keyed  - Slot contains KeyedFragment (from ifor-each)"
-  (:require [org.replikativ.spindel.engine.core :as ec]
+  (:require [clojure.set]
+            [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.dom.core :as core]))
 
 ;; Forward declaration for KeyedFragment check
@@ -93,9 +94,22 @@
   - `:dom/cache`       — slot cache
   - `:dom/attr-cache`  — attribute cache
   - `:dom/keyed-cache` — `ifor-each` per-call-site keyed cache
-  - `:dom/foreign`     — foreign-node marker"
+  - `:dom/foreign`     — foreign-node marker
+
+  Cascades into `ifor-each` keyed caches held by this element's slots. A
+  `:keyed` slot stores a `KeyedFragment` whose `:addr` is the ifor-each CALL
+  SITE — an address that appears on no vnode, because `flatten-slot` splices
+  the fragment's items into `:children` and drops the fragment itself. Walking
+  the vnode tree therefore cannot reach it. Without this cascade, unmounting a
+  subtree containing an `ifor-each` retained `:by-key` (every rendered vnode,
+  with its event-handler closures) for the lifetime of the context — the
+  dominant leak in a long-lived session."
   [addr]
   (when addr
+    (doseq [slot (ec/get-state [:dom/cache addr])
+            :when (= :keyed (:type slot))]
+      (when-let [frag-addr (:addr (:value slot))]
+        (ec/swap-state! [:dom/keyed-cache] (fn [m] (dissoc m frag-addr)))))
     (ec/swap-state! [:dom/cache] (fn [m] (dissoc m addr)))
     (ec/swap-state! [:dom/attr-cache] (fn [m] (dissoc m addr)))
     (ec/swap-state! [:dom/keyed-cache] (fn [m] (dissoc m addr)))
@@ -189,7 +203,7 @@
 
       ;; single → single: update if changed
       ;; Compare vnodes semantically:
-      ;; - For element vnodes: same tag + same identity (via :key)
+      ;; - For element vnodes: same tag + same ADDRESS (see below)
       ;;   When unchanged, the child handles its own deltas via discharge-vnode!
       ;; - For text nodes: compare content directly
       ;; - Otherwise: use reference equality
@@ -200,29 +214,41 @@
               (and (core/text-node? prev-value) (core/text-node? new-result))
               (= (:content prev-value) (:content new-result))
 
-              ;; Both are element vnodes - check tag and key for identity
-              ;; The child element handles its own deltas via discharge-vnode!
+              ;; Both are element vnodes. Identity IS the address, because that
+              ;; is what `discharge-vnode!` binds DOM elements by. A keyed
+              ;; element's addr already embeds its key
+              ;; (`keyed-child-address(my-addr, key)`), so addr equality implies
+              ;; key equality AND structural position.
+              ;;
+              ;; Comparing keys alone (the old rule) declared a child
+              ;; "unchanged" whenever the key matched, emitting no delta on the
+              ;; assumption below. That assumption holds only if the child's
+              ;; addr is stable — and it is not: two branches of an `if` are
+              ;; distinct source locations, hence distinct addrs. The child's
+              ;; deltas then targeted an addr with no bound DOM element and
+              ;; vanished silently (a self-tracking child spin whose root
+              ;; branch flipped would freeze forever).
+              ;;
+              ;; `:key` on a plain element is a DISAMBIGUATOR, not an identity
+              ;; token — see `addressing/keyed-child-address`. Position-
+              ;; independent identity is `ifor-each`'s job, and its items travel
+              ;; through the `:keyed` slot type, never through here.
+              ;;
               ;; DO NOT check (:deltas new-result) - that would cause parent to
               ;; trigger :update which calls render-initial! and bypasses child deltas
               (and (core/vnode? prev-value) (core/vnode? new-result))
               (let [same-tag? (= (:tag prev-value) (:tag new-result))
-                    prev-key (:key prev-value)
-                    new-key (:key new-result)
-                    ;; Identity check:
-                    ;; - If both have explicit keys, they must match
-                    ;; - If neither has keys, compare addresses (different source = different element)
-                    ;; - If one has key and other doesn't, they're different elements
-                    same-identity? (cond
-                                     (and prev-key new-key) (= prev-key new-key)
-                                     (and (nil? prev-key) (nil? new-key))
-                                     (let [prev-addr (:addr prev-value)
-                                           new-addr (:addr new-result)]
-                                       ;; If both have addresses, they must match
-                                       ;; If either is missing addr (legacy), fall back to same
-                                       (if (and prev-addr new-addr)
-                                         (= prev-addr new-addr)
-                                         true))
-                                     :else false)]
+                    prev-addr (:addr prev-value)
+                    new-addr (:addr new-result)
+                    same-identity? (if (and prev-addr new-addr)
+                                     (= prev-addr new-addr)
+                                     ;; Legacy vnodes without addrs: fall back to
+                                     ;; the old key/no-key rule.
+                                     (let [prev-key (:key prev-value)
+                                           new-key (:key new-result)]
+                                       (if (and prev-key new-key)
+                                         (= prev-key new-key)
+                                         (and (nil? prev-key) (nil? new-key)))))]
                 (and same-tag? same-identity?))
 
               ;; Otherwise use reference equality

--- a/src/org/replikativ/spindel/dom/discharge.cljc
+++ b/src/org/replikativ/spindel/dom/discharge.cljc
@@ -259,6 +259,8 @@
 
 (defonce ^:private logged-collisions (atom #{}))
 
+(defonce ^:private logged-unbound (atom #{}))
+
 (defn register-addr!
   "Register an address as claimed during this render pass.
   Logs an error the first time we see a given collision address (across the
@@ -845,6 +847,24 @@
       (when-not (or is-rendered? is-applied?)
         (let [el (get-element discharge (:addr vnode))]
           (when-not el
+            ;; A vnode that CARRIES DELTAS but whose address has no bound DOM
+            ;; element means those updates are about to be dropped on the floor.
+            ;; That is never intentional: it is the signature of reconcile and
+            ;; discharge disagreeing about identity (the parent declared the
+            ;; child unchanged, so no element was ever created at the child's
+            ;; new address). Silently skipping it froze whole subtrees with a
+            ;; single debug line. Log loudly, once per address.
+            (when (and (seq (:deltas vnode))
+                       (not (contains? @logged-unbound (:addr vnode))))
+              (swap! logged-unbound conj (:addr vnode))
+              (log/error ::deltas-dropped-unbound-addr
+                         {:addr (:addr vnode)
+                          :tag (:tag vnode)
+                          :delta-count (count (:deltas vnode))
+                          :hint (str "This vnode's updates were discarded: no DOM "
+                                     "element is bound to its address. Usually a "
+                                     "structural change the parent's reconcile "
+                                     "did not emit a delta for.")}))
             (log/debug ::element-not-found {:addr (:addr vnode) :tag (:tag vnode)
                                             :delta-count (count (:deltas vnode))}))
           (when el
@@ -966,7 +986,7 @@
                                          :el el
                                          :error (str e)})))))
 
-(defn- call-refs-on-unmount!
+(defn ^:no-doc call-refs-on-unmount!
   "Recursively call ref callbacks with nil for a vnode and its descendants,
   and schedule their per-element caches for eviction. The eviction itself
   is deferred to end-of-cycle (see `*pending-evictions*` /
@@ -980,8 +1000,18 @@
       nil  ; Text nodes have no :addr and no refs
 
       (frag/keyed-fragment? vnode)
-      (doseq [item (frag/fragment-items vnode)]
-        (call-refs-on-unmount! item))
+      (do
+        ;; The fragment's own address (the `ifor-each` call site) holds the
+        ;; keyed cache — `:by-key` (every rendered vnode + its handler closures)
+        ;; and `:items-by-key`. That address appears on no item vnode, so it
+        ;; must be scheduled explicitly or the whole rendered list leaks for the
+        ;; lifetime of the context. `for-each*` stamps it via `:addr`.
+        (when-let [addr (:addr vnode)]
+          (if *pending-evictions*
+            (swap! *pending-evictions* conj addr)
+            (cache/evict-cache! addr)))
+        (doseq [item (frag/fragment-items vnode)]
+          (call-refs-on-unmount! item)))
 
       (core/vnode? vnode)
       (do

--- a/src/org/replikativ/spindel/dom/foreach.cljc
+++ b/src/org/replikativ/spindel/dom/foreach.cljc
@@ -126,8 +126,11 @@
           cleared))
 
       (frag/keyed-fragment? vnode)
-      (frag/keyed-fragment (mapv clear-stale-deltas (frag/fragment-items vnode))
-                           nil)
+      ;; Preserve `:addr` — it is what lets `call-refs-on-unmount!` evict the
+      ;; keyed cache at this ifor-each's call site.
+      (assoc (frag/keyed-fragment (mapv clear-stale-deltas (frag/fragment-items vnode))
+                                  nil)
+             :addr (:addr vnode))
 
       :else vnode)))
 
@@ -188,7 +191,14 @@
                                :items-by-key items-by-key
                                :order order
                                :was-sync? was-sync?})
-    (frag/keyed-fragment items deltas)))
+    ;; Stamp the ifor-each call-site address onto the fragment. The keyed cache
+    ;; lives at `[:dom/keyed-cache my-addr]`, and `my-addr` appears on NO vnode:
+    ;; items carry `keyed-child-address(my-addr, k)`. Without this stamp
+    ;; `call-refs-on-unmount!` walks the items and never learns the address that
+    ;; holds `:by-key` (every rendered vnode, with its event-handler closures)
+    ;; and `:items-by-key` — so unmounting a subtree containing an ifor-each
+    ;; retained the whole rendered list for the lifetime of the context.
+    (assoc (frag/keyed-fragment items deltas) :addr my-addr)))
 
 ;; =============================================================================
 ;; for-each*

--- a/src/org/replikativ/spindel/dom/foreach.cljc
+++ b/src/org/replikativ/spindel/dom/foreach.cljc
@@ -265,7 +265,21 @@
       The render-fn may return a vnode or a spin. When it returns a
       spin, ifor-each's outer return is a spin (awaiting all child
       spins). When it returns a plain vnode, the outer return is a
-      KeyedFragment."
+      KeyedFragment.
+
+      MEMOIZATION CONTRACT: per-key renders are memoized on ITEM
+      equality (plain-element vnodes only; spin-returning render-fns
+      are never memoized). If an item is `=` to its previous value, the
+      cached vnode is reused and render-fn is NOT called — closure
+      variables captured by render-fn (a selected id, a lookup map) are
+      invisible to the diff. Anything that must trigger a re-render has
+      to be part of the item itself:
+
+        ;; WRONG — selected-id changes never re-render old items:
+        (ifor-each :id items #(row % (= (:id %) selected-id)))
+        ;; RIGHT — encode it in the item:
+        (ifor-each :id (mapv #(assoc % :selected? (= (:id %) selected-id)) items)
+          #(row % (:selected? %)))"
      [key-fn items render-fn]
      (let [source-loc {:file *file*
                        :line (:line (meta &form))

--- a/src/org/replikativ/spindel/dom/render.cljc
+++ b/src/org/replikativ/spindel/dom/render.cljc
@@ -176,6 +176,36 @@
 ;; Integration with Spin System
 ;; =============================================================================
 
+#?(:cljs
+   (defn- clear-render-error-overlay! [container]
+     (when-let [el (.querySelector container "[data-spindel-render-error]")]
+       (.remove el))))
+
+#?(:cljs
+   (defn- show-render-error-overlay!
+     "Dev-only (goog.DEBUG) visible surface for a REJECTED render spin.
+      Without it, a body exception cascades monadically to the root and
+      the UI freezes at the last resolved frame with a single log line —
+      practically invisible. Updated in place on repeated rejects;
+      removed on the next successful resolve."
+     [container spin-id error]
+     (when ^boolean js/goog.DEBUG
+       (let [existing (.querySelector container "[data-spindel-render-error]")
+             el (or existing (.createElement js/document "div"))
+             msg (str (or (some-> error .-message) error))
+             stack (or (some-> error .-stack) "")]
+         (set! (.-cssText (.-style el))
+               (str "position:fixed;left:8px;right:8px;bottom:8px;z-index:99999;"
+                    "background:#3b0d0d;color:#ffb4b4;border:1px solid #a33;"
+                    "border-radius:6px;padding:10px 14px;font:12px/1.5 monospace;"
+                    "max-height:40vh;overflow:auto;white-space:pre-wrap;"))
+         (.setAttribute el "data-spindel-render-error" "true")
+         (set! (.-textContent el)
+               (str "spindel render REJECTED — UI frozen at last resolved frame\n"
+                    "spin: " spin-id "\n" msg
+                    (when (seq stack) (str "\n\n" stack))))
+         (when-not existing (.appendChild container el))))))
+
 (defn render-spin!
   "Execute a spin and render its vdom result.
 
@@ -211,10 +241,15 @@
       ;; resolve callback
      (fn [vdom]
        (log/trace :render/vdom-received {:spin-id spin-id :has-vdom (some? vdom)})
+       #?(:cljs (clear-render-error-overlay! container))
        (render-effect vdom))
-      ;; reject callback
+      ;; reject callback — a rejected render produces NO vdom: the whole
+      ;; tree silently freezes at the last resolved frame (correct Result-
+      ;; monad semantics, terrible observability — the sharp-edges 'silent
+      ;; wrong behavior' pattern). In dev builds, surface it visibly.
      (fn [error]
-       (log/error :render/error {:spin-id spin-id :error error})))
+       (log/error :render/error {:spin-id spin-id :error error})
+       #?(:cljs (show-render-error-overlay! container spin-id error))))
 
     ;; Return control map
     {:spin-id spin-id

--- a/src/org/replikativ/spindel/dom/render.cljc
+++ b/src/org/replikativ/spindel/dom/render.cljc
@@ -45,6 +45,28 @@
 ;; Render Cycle
 ;; =============================================================================
 
+(defn ^:no-doc root-identity-changed?
+  "True when the mounted root and the new root are not the same DOM node.
+
+  Deltas are discharged against DOM elements bound by `:addr`, and the mounted
+  root is the one node no parent slot can address. When a spin's body returns a
+  different root element — a conditional at the TOP of a spin, e.g.
+  `(if loading? (el/div …) (el/div …))` — the new root's addr has no element
+  bound to it, so every delta beneath it targets a node that was never created
+  and the whole render silently vanishes. Detect that and re-mount.
+
+  Only element vnodes carry an `:addr`. Compare addrs when both have them,
+  otherwise fall back to `:tag` so element↔text transitions also re-mount. A
+  first render (no `current-vdom`) is not a change — `initial-mount!` owns it."
+  [current-vdom new-vdom]
+  (boolean
+   (when (and current-vdom new-vdom)
+     (let [ca (:addr current-vdom)
+           na (:addr new-vdom)]
+       (if (and ca na)
+         (not= ca na)
+         (not= (:tag current-vdom) (:tag new-vdom)))))))
+
 (defn initial-mount!
   "Perform initial mount of vdom to container."
   [render-state vdom]
@@ -84,8 +106,34 @@
   DOM refs are stored by stable address (:addr on vnodes), so no transfer
   is needed between old and new vdom objects."
   [render-state new-vdom]
-  (let [{:keys [discharge]} render-state]
-    (if new-vdom
+  (let [{:keys [container discharge current-vdom]} render-state]
+    (cond
+      ;; No new vdom. The root spin produced nothing this cycle: keep the last
+      ;; frame rather than tearing the app down. A root that legitimately wants
+      ;; to render nothing should return an empty element, not nil.
+      (nil? new-vdom) render-state
+
+      ;; The root element itself changed. Tear the old tree down properly, then
+      ;; mount the new one — all inside ONE eviction pass, so that an address
+      ;; the new tree re-claims (A→B→A) is spared by `(pending - live)`.
+      (root-identity-changed? current-vdom new-vdom)
+      (do
+        (log/debug :render/root-replace {:old (:addr current-vdom)
+                                         :new (:addr new-vdom)})
+        (binding [disch/*rendered-vnodes* (atom #{})
+                  disch/*rendered-addrs* (atom {})
+                  disch/*pending-evictions* (atom #{})]
+          ;; Refs get their nil call and caches are SCHEDULED (not yet dropped):
+          ;; foreign nodes (TipTap et al.) rely on this to release resources.
+          (disch/call-refs-on-unmount! current-vdom)
+          (let [root-el (disch/render-initial! discharge new-vdom)]
+            (when container
+              (set! (.-innerHTML container) "")
+              (when root-el (.appendChild container root-el))))
+          (disch/flush-pending-evictions! discharge))
+        (assoc render-state :current-vdom (disch/clear-deltas-deep new-vdom)))
+
+      :else
       (do
         ;; Discharge deltas directly - no diffing needed
         ;; DOM refs found by address, no transfer needed
@@ -102,10 +150,7 @@
         ;; Clear deltas for next render cycle
         ;; No ref transfer needed — cleared vnodes carry same :addr values
         (let [cleared-vdom (disch/clear-deltas-deep new-vdom)]
-          (assoc render-state :current-vdom cleared-vdom)))
-
-      ;; No new vdom
-      render-state)))
+          (assoc render-state :current-vdom cleared-vdom))))))
 
 ;; =============================================================================
 ;; Render! API

--- a/src/org/replikativ/spindel/effects/await.cljc
+++ b/src/org/replikativ/spindel/effects/await.cljc
@@ -283,18 +283,34 @@
               child-ctx (if (seq spin-scope)
                           (update ctx :bindings merge spin-scope)
                           ctx)
+              ;; Body re-entry prologue — the FULL parity with `Spin`'s
+              ;; `-invoke` Case 2. The slow path runs the child by calling
+              ;; `.-spin-fn` directly (to inject child-resolve/child-reject),
+              ;; which bypasses `-invoke` and therefore its entire prologue.
+              ;;
+              ;; `clear-prior-body-conts!` is the load-bearing call: without
+              ;; it, every slow-path re-run APPENDS a fresh generation of
+              ;; track conts on top of the prior body's (track conts have no
+              ;; deterministic id — they gensym). Dispatch resumes the
+              ;; earliest cont by :order, i.e. always the STALE one, which
+              ;; then truncates the live body's conts and re-renders with its
+              ;; frozen lexical bindings onto the same element addresses —
+              ;; the zombie-repaint bug (simmis: opening a tab then firing
+              ;; any column-tracked signal reverted the column to its
+              ;; pre-tab-open DOM). Same-body re-entry through `-invoke` was
+              ;; fixed by clear-prior-body-conts! (dc96ab9); this is the
+              ;; missing await-slow-path wiring of that fix.
+              _ (simple/mark-running! ctx awaited-spin-id)
+              _ (simple/clear-created-spins! ctx awaited-spin-id)
+              _ (simple/clear-prior-body-conts! ctx awaited-spin-id)
               ;; Seed the child's per-spin chain-head slot before invoking
-              ;; its body — exactly what `Spin`'s `-invoke` Case 2 does.
-              ;; The slow path runs the child by calling `.-spin-fn`
-              ;; directly (to inject child-resolve/child-reject), which
-              ;; bypasses `-invoke` and therefore its chain-head seeding.
-              ;; Without this, the child body inherits the PARENT's
-              ;; chain-head, so the child's vnode addresses depend on
-              ;; where the `(await …)` sits in the parent's body — and
-              ;; shift whenever the parent re-runs from a different
-              ;; track continuation. Unstable addresses break the
-              ;; discharge's by-address element lookup (DISCH-NOTFOUND
-              ;; for the whole re-rendered subtree).
+              ;; its body. Without this, the child body inherits the
+              ;; PARENT's chain-head, so the child's vnode addresses depend
+              ;; on where the `(await …)` sits in the parent's body — and
+              ;; shift whenever the parent re-runs from a different track
+              ;; continuation. Unstable addresses break the discharge's
+              ;; by-address element lookup (DISCH-NOTFOUND for the whole
+              ;; re-rendered subtree).
               _ (addressing/seed-body-chain-head! ctx awaited-spin-id)
               _raw-result (binding [ec/*execution-context* child-ctx
                                     ec/*spin-id* awaited-spin-id

--- a/src/org/replikativ/spindel/effects/await.cljc
+++ b/src/org/replikativ/spindel/effects/await.cljc
@@ -552,14 +552,28 @@
       ;; produced (typically `incomplete` when the resolve was itself an
       ;; engine-level suspend, or the value otherwise). Forcing `incomplete`
       ;; here would short-circuit sync-resolving partial-cps async blocks.
+      ;;
+      ;; The cancel-token is bound around the invocation, exactly as in the
+      ;; Mailbox branch above. A thunk is opaque: it may itself hand our
+      ;; resolve/reject to a waiter-keeping resource. `(aseq/anext mbx)` does
+      ;; precisely that — it returns a closure that calls the Mailbox 2-arity —
+      ;; so dispatching on the thunk's type instead of its target would strand
+      ;; the waiter with `:cancel-token nil`. `post-inline!` could then no
+      ;; longer recognise a cancelled waiter, and would CONSUME the producer's
+      ;; message before handing it to a resolve that the gate turns into a
+      ;; no-op: message lost, consumer never re-armed (a permanently deaf
+      ;; mult pump). The token must accompany the INVOCATION, not the type
+      ;; dispatch. Contract: a resource registering a waiter must do so
+      ;; synchronously inside the thunk, so this dynamic binding is in scope.
       (ifn? awaitable)
-      (let [[wr wj _cancel-token]
+      (let [[wr wj cancel-token]
             (cancellable-external-pair
              spin-id resolve reject
              [::ifn #?(:clj (System/identityHashCode awaitable)
                        :cljs (or (.-name awaitable) (str awaitable)))]
              source-loc)]
-        (awaitable wr wj))
+        (binding [ec/*external-await-cancel-token* cancel-token]
+          (awaitable wr wj)))
 
       :else
       (reject (eff/type-error 'await "Spin, Deferred, or async thunk" awaitable)))

--- a/src/org/replikativ/spindel/effects/await.cljc
+++ b/src/org/replikativ/spindel/effects/await.cljc
@@ -283,35 +283,17 @@
               child-ctx (if (seq spin-scope)
                           (update ctx :bindings merge spin-scope)
                           ctx)
-              ;; Body re-entry prologue — the FULL parity with `Spin`'s
-              ;; `-invoke` Case 2. The slow path runs the child by calling
-              ;; `.-spin-fn` directly (to inject child-resolve/child-reject),
-              ;; which bypasses `-invoke` and therefore its entire prologue.
-              ;;
-              ;; `clear-prior-body-conts!` is the load-bearing call: without
-              ;; it, every slow-path re-run APPENDS a fresh generation of
-              ;; track conts on top of the prior body's (track conts have no
-              ;; deterministic id — they gensym). Dispatch resumes the
-              ;; earliest cont by :order, i.e. always the STALE one, which
-              ;; then truncates the live body's conts and re-renders with its
-              ;; frozen lexical bindings onto the same element addresses —
-              ;; the zombie-repaint bug (simmis: opening a tab then firing
-              ;; any column-tracked signal reverted the column to its
-              ;; pre-tab-open DOM). Same-body re-entry through `-invoke` was
-              ;; fixed by clear-prior-body-conts! (dc96ab9); this is the
-              ;; missing await-slow-path wiring of that fix.
-              _ (simple/mark-running! ctx awaited-spin-id)
-              _ (simple/clear-created-spins! ctx awaited-spin-id)
-              _ (simple/clear-prior-body-conts! ctx awaited-spin-id)
-              ;; Seed the child's per-spin chain-head slot before invoking
-              ;; its body. Without this, the child body inherits the
-              ;; PARENT's chain-head, so the child's vnode addresses depend
-              ;; on where the `(await …)` sits in the parent's body — and
-              ;; shift whenever the parent re-runs from a different track
-              ;; continuation. Unstable addresses break the discharge's
-              ;; by-address element lookup (DISCH-NOTFOUND for the whole
-              ;; re-rendered subtree).
-              _ (addressing/seed-body-chain-head! ctx awaited-spin-id)
+              ;; THE body re-entry prologue — full parity with `Spin`'s
+              ;; `-invoke` Case 2, via the shared simple/enter-body! (the
+              ;; slow path calls `.-spin-fn` directly to inject
+              ;; child-resolve/child-reject, bypassing `-invoke`, so it must
+              ;; run the prologue itself). History: only the chain-head
+              ;; seeding was duplicated here originally; the missing
+              ;; clear-prior-body-conts! let track conts accumulate across
+              ;; slow-path re-runs — earliest(-stale) cont won dispatch and
+              ;; repainted frozen state (zombie bug, fixed 71d5801). See
+              ;; enter-body!'s docstring for the invariant.
+              _ (simple/enter-body! ctx awaited-spin-id)
               _raw-result (binding [ec/*execution-context* child-ctx
                                     ec/*spin-id* awaited-spin-id
                                     pcps-async/*in-trampoline* false]

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -2052,6 +2052,35 @@
                        (nodes/->spin-node nil :clean false true #{} {} nil #{}))))
   true)
 
+(defn ^:no-doc enter-body!
+  "THE body (re-)entry prologue. Every path that invokes a spin's cps-fn
+  from scratch MUST run this first — the engine's dispatch and
+  truncation rules are sound only under the invariant that AT MOST ONE
+  body-generation of continuations exists per spin (earliest-cont
+  selection + truncate-stale-conts! both assume it; a stale earlier
+  generation wins dispatch and truncates the live body — the
+  zombie-repaint bug, fixed for the await slow path in 71d5801).
+
+  Call sites (keep this list exhaustive):
+  - `Spin` `-invoke` Case 2 (cache miss / dirty)     — full prologue
+  - `await-spin`'s slow path (dirty child under await) — full prologue
+  - `Spin` `-invoke` rebuild branch                   — `:rebuild? true`
+  - `deref-spin`'s JVM rebuild path                   — `:rebuild? true`
+  - (`:spin-execution` events route through `-invoke` — covered.)
+
+  `:rebuild? true` skips mark-running!/clear-created-spins!: rebuild
+  re-executes the body for side effects only (nested spin re-minting,
+  cont re-registration) and reuses the cached result, so node run-state
+  must not be touched."
+  ([context spin-id] (enter-body! context spin-id nil))
+  ([context spin-id {:keys [rebuild?]}]
+   (when-not rebuild?
+     (mark-running! context spin-id)
+     (clear-created-spins! context spin-id))
+   (clear-prior-body-conts! context spin-id)
+   (addressing/seed-body-chain-head! context spin-id)
+   true))
+
 (defn ^:no-doc try-claim-execution!
   "Atomically try to claim execution of a spin.
 

--- a/src/org/replikativ/spindel/incremental/interval.cljc
+++ b/src/org/replikativ/spindel/incremental/interval.cljc
@@ -179,9 +179,14 @@
    typed_combinators.cljc (`izip*`, `iflat-map*`). They satisfy
    `PInterval` via the map extension below — so consumers reading via
    `get-new` / `get-old` / `get-deltas` work uniformly across the
-   legacy `Interval` deftype and the new typed maps."
+   legacy `Interval` deftype and the new typed maps.
+
+   Records are excluded: typed-interval maps are plain maps, and
+   records may not implement `-contains-key?` (datahike's CLJS AsOfDB
+   throws on it — probing a record here rejected the consuming spin and
+   froze the UI at the last resolved frame)."
   [x]
-  (and (map? x) (contains? x :algebra)))
+  (and (map? x) (not (record? x)) (contains? x :algebra)))
 
 (defn no-change?
   "True when this interval explicitly reports 'nothing changed'.
@@ -252,8 +257,9 @@
 
     ;; Typed-interval map produced by the new combinators — already
     ;; satisfies PInterval via the IPersistentMap extension. Pass
-    ;; through unchanged.
-    (and (map? x) (contains? x :algebra))
+    ;; through unchanged. (Record guard lives in the predicate — see
+    ;; typed-interval-map?.)
+    (typed-interval-map? x)
     x
 
     ;; Deltaable collection - extract its deltas

--- a/src/org/replikativ/spindel/pubsub/mult.cljc
+++ b/src/org/replikativ/spindel/pubsub/mult.cljc
@@ -22,6 +22,28 @@
   #?(:cljs (:require-macros [org.replikativ.spindel.spin.cps :refer [spin]])))
 
 ;; =============================================================================
+;; Fault reporting (spindel carries no logging dep — loud by default, overridable)
+;; =============================================================================
+
+(defonce ^:private fault-reporter
+  ;; Default: stderr / console.error so a fault is never silently swallowed.
+  ;; Embedders route it into their own logging via `set-fault-reporter!`.
+  (atom (fn [event data]
+          #?(:clj  (binding [*out* *err*]
+                     (println "[spindel.mult]" event (pr-str data)))
+             :cljs (js/console.error "[spindel.mult]" (str event) (clj->js data))))))
+
+(defn set-fault-reporter!
+  "Override how mult reports isolated consumer faults (`::watcher-fault`) and
+   pump rejections (`::pump-rejected`). `f` is (fn [event-keyword data-map]).
+   Default writes to stderr / console.error. simmis routes these into Telemere."
+  [f] (reset! fault-reporter f))
+
+(defn- report-fault! [event data]
+  (try (@fault-reporter event data)
+       (catch #?(:clj Throwable :cljs :default) _ nil)))
+
+;; =============================================================================
 ;; Simple Promise for Coordination (no runtime required)
 ;; =============================================================================
 
@@ -51,9 +73,18 @@
                      (if (:delivered? s)
                        value  ;; Already delivered - no-op
                        (if (compare-and-set! state s {:delivered? true :value value :watchers []})
-                         ;; CAS succeeded - notify watchers from the state we replaced
+                         ;; CAS succeeded - notify watchers from the state we replaced.
+                         ;; Each watcher resumes a consumer spin; a watcher runs ON
+                         ;; THE PRODUCER'S STACK (the source pump), so an unguarded
+                         ;; throw there unwinds INTO the pump, cancels its await cont,
+                         ;; and wedges the whole bus (dossier: bug-bus-source-pump-
+                         ;; lost-waiter). Isolate each consumer fault: report it, keep
+                         ;; delivering to the other watchers, never propagate to the
+                         ;; producer.
                          (do (doseq [w (:watchers s)]
-                               (w value))
+                               (try (w value)
+                                    (catch #?(:clj Throwable :cljs :default) e
+                                      (report-fault! ::watcher-fault {:error e}))))
                              value)
                          ;; CAS failed (concurrent modification) - retry
                          (recur))))))
@@ -336,7 +367,18 @@
                         :spin pump
                         :execution-context context
                         :resolve-fn (fn [_] nil)
-                        :reject-fn (fn [_] nil)})
+                        ;; A pump rejection means the fan-out loop died — the mult
+                        ;; is now deaf. This was swallowed with zero logging; make
+                        ;; it loud. With consumer faults isolated (see deliver!) the
+                        ;; pump should never reject on a consumer's behalf, so any
+                        ;; rejection here is a genuine engine/source fault worth
+                        ;; surfacing (the embedder's watchdog can then rebuild the
+                        ;; bus). We do NOT auto-restart: the source position is lost
+                        ;; on reject, so a naive restart would replay from the head.
+                        :reject-fn (fn [reason]
+                                     (report-fault! ::pump-rejected
+                                                    {:reason reason
+                                                     :spin-id (spin-core/spin-id pump)}))})
     pump))
 
 (extend-type Mult

--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -173,10 +173,12 @@
          (and cached (ec/spin-result-clean? spin-id) rebuild-mode?)
          (do
            (log/debug :deref/rebuild-mode {:spin-id spin-id})
-           ;; Seed the per-spin chain-head slot before invoking spin-fn.
-           ;; See addressing.cljc — the cursor lives in ctx state, not a
-           ;; dynamic var, so it follows fork/snapshot semantics.
-           (addressing/seed-body-chain-head! runtime spin-id)
+           ;; Body re-entry prologue, rebuild variant (conts cleared +
+           ;; chain-head seeded; run-state untouched). Same scenario as
+           ;; -invoke's rebuild branch reached via deref — previously only
+           ;; seeded the chain-head, leaving stale :await-once conts from
+           ;; the original run alive. See simple/enter-body!.
+           (simple/enter-body! runtime spin-id {:rebuild? true})
            (binding [ec/*execution-context* runtime
                      ec/*spin-id* spin-id]
              (spin-fn (fn [_] nil) (fn [_] nil)))
@@ -239,14 +241,13 @@
             ;; Execute spin body for side effects (nested spin creation, continuation registration).
             ;; Fresh per-spin chain-head slot = nested spin minting reproduces the same id
             ;; sequence as the original run (rebuild's whole purpose).
-            ;; Drop the prior body's ephemeral await conts: in rebuild mode
-            ;; await-spin resolves synchronously and does NOT overwrite the
-            ;; cont, so without this an :await-once cont from the original
-            ;; run survives, fires on the next :spin-completion, and
-            ;; re-invokes the prior body's CPS chain (which closes over
-            ;; prior-run Spin instances). See clear-ephemeral-await-conts!.
-          (simple/clear-prior-body-conts! runtime spin-id)
-          (addressing/seed-body-chain-head! runtime spin-id)
+            ;; Body re-entry prologue, rebuild variant: conts cleared +
+            ;; chain-head seeded, but run-state untouched (cached result is
+            ;; reused; body runs for side effects only). Without the cont
+            ;; clear, an :await-once cont from the original run survives,
+            ;; fires on the next :spin-completion, and re-invokes the prior
+            ;; body's CPS chain. See simple/enter-body!.
+          (simple/enter-body! runtime spin-id {:rebuild? true})
           (binding [ec/*execution-context* runtime
                     ec/*spin-id* spin-id]
               ;; Execute with dummy callbacks - we'll use cached value anyway
@@ -294,33 +295,13 @@
 
           (log/debug :spin/start {:spin-id spin-id})
 
-            ;; Mark in-flight. With the unified-queue design, :running? denotes
-            ;; "body invocation has begun but has not yet resolved" — covering
-            ;; both actively-executing slices and suspensions on async resources
-            ;; (Deferred, Mailbox, executor tasks). It is cleared only when
-            ;; cache-result! fires (body resolved). This lets `running?` /
-            ;; `await-drain-complete` / `deref` correctly detect in-flight work
-            ;; without requiring a special Phase 2 wait.
-          (simple/mark-running! runtime spin-id)
+            ;; THE body re-entry prologue (mark-running! +
+            ;; clear-created-spins! + clear-prior-body-conts! +
+            ;; seed-body-chain-head!) — shared with the await slow path
+            ;; via simple/enter-body! so the contract cannot drift; see
+            ;; its docstring for the invariant it maintains.
+          (simple/enter-body! runtime spin-id)
           (log/trace :spin/executing-body {:spin-id spin-id :thread #?(:clj (.getName (Thread/currentThread)) :cljs "js")})
-
-            ;; Reset :created-spins for this body run; children are re-registered
-            ;; as the body runs, and register-spin! re-runs any whose captured
-            ;; environment changed (B) — no blanket invalidation needed.
-          (simple/clear-created-spins! runtime spin-id)
-
-            ;; Drop the prior body's ephemeral await conts at the same time.
-            ;; The new body run will register fresh conts at each (await …)
-            ;; via the slow path (deterministic cont-id would overwrite
-            ;; anyway in normal mode); clearing here keeps the rebuild path
-            ;; correct too (where the sync rebuild branch doesn't register).
-            ;; Persistent :await-reactive conts (parallel/race) are kept.
-          (simple/clear-prior-body-conts! runtime spin-id)
-
-            ;; Seed this body slice's per-spin chain-head slot with
-            ;; `body-start-chain-head spin-id` before invoking spin-fn —
-            ;; see addressing.cljc.
-          (addressing/seed-body-chain-head! runtime spin-id)
           (binding [ec/*execution-context* runtime
                     ec/*spin-id* spin-id]
             (let [result (spin-fn

--- a/test/org/replikativ/spindel/dom/branch_flip_test.clj
+++ b/test/org/replikativ/spindel/dom/branch_flip_test.clj
@@ -1,0 +1,148 @@
+(ns org.replikativ.spindel.dom.branch-flip-test
+  "Characterization: when does a conditional branch flip inside a spin body
+  actually reach the DOM?
+
+  Motivated by a simmis production bug: the wiki page editor rendered
+  `<div class=\"block-editor loading\"><p>Loading database...</p></div>` forever.
+  Its body re-ran with a real db (logged), but the DOM never changed — not even
+  the class attribute. Shape (block_editor.cljs `render-page-editor`, a
+  SELF-TRACKING child spin awaited by the column spin):
+
+      (if-not db-value
+        (el/div {:class \"block-editor loading\" :key K} (el/p \"Loading...\"))
+        (el/div {:class \"block-editor\"         :key K} ...the editor...))
+
+  Both branches emit the same tag and the SAME key. Rendering is delta-direct
+  (no tree diff): `update-render!` discharges only `nodes-with-deltas`, and DOM
+  elements are bound by address. A keyed element's address is
+  `hash([base-addr :keyed key])`, so both branches collapse onto ONE address
+  and the structural change produces no deltas at all — silently.
+
+  Findings encoded below:
+    A  branch at the root of the RENDER spin        -> 0 ops  (unsupported)
+    B  branch nested under a stable root element    -> works
+    C  same call site, only attrs/text differ       -> works
+    D  child spin root flip, SAME key on branches   -> 0 ops  (the prod bug)
+    D2 child spin root flip, DISTINCT keys          -> works
+    E  child spin with stable root, branch inside   -> works
+
+  A and D are the defects: a structural change is dropped with no error. Per
+  the sharp-edges cross-cutting rule (\"anything the engine can detect as
+  'probably not what the author meant' logs or throws in dev\"), these must
+  either discharge or fail loudly."
+  (:refer-clojure :exclude [await])
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.dom.discharge :as disch]
+            [org.replikativ.spindel.dom.elements :as el]
+            [org.replikativ.spindel.dom.render :as render]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.effects.track :refer [track]]
+            [org.replikativ.spindel.signal :as sig]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.test-async :refer [await-drain]]
+            [org.replikativ.spindel.test-helpers :refer [with-ctx]]))
+
+(defn- flip!
+  "Mount `mk`'s spin with the signal true, flip it to false, and report what the
+  flip discharged. Returns {:ops n :texts [...] :parent n :child n}."
+  [rt mk]
+  (let [{:keys [discharge log]} (disch/make-mock-discharge)
+        loading? (sig/signal true)
+        parent-runs (atom 0)
+        child-runs (atom 0)
+        the-spin (mk loading? parent-runs child-runs)]
+    (render/render-spin! nil the-spin discharge)
+    @the-spin
+    (is (some #{"LOADING"} (mapv :text (filter #(= :create-text (:op %)) @log)))
+        "initial mount must render the loading branch")
+    (reset! log [])
+    (reset! loading? false)
+    (await-drain rt)
+    {:ops (count @log)
+     :texts (mapv :text (filter #(= :create-text (:op %)) @log))
+     :parent @parent-runs
+     :child @child-runs}))
+
+(defn- loading-branch [k] (el/div {:class "block-editor loading" :key k} (el/p "LOADING")))
+(defn- loaded-branch  [k] (el/div {:class "block-editor" :key k}
+                                  (el/div {:class "blocks-list"} "CONTENT")))
+
+;; ---------------------------------------------------------------------------
+;; Working shapes — these pin the behaviour we rely on.
+;; ---------------------------------------------------------------------------
+
+(deftest test-branch-nested-under-stable-root-discharges
+  (testing "B: a branch below a stable root element discharges structurally"
+    (with-ctx [rt]
+      (let [{:keys [texts]} (flip! rt (fn [loading? parent-runs _]
+                                        (spin (do (swap! parent-runs inc)
+                                                  (el/div {:class "shell"}
+                                                          (if @(track loading?)
+                                                            (el/p "LOADING")
+                                                            (el/div {:class "blocks-list"} "CONTENT")))))))]
+        (is (some #{"CONTENT"} texts))))))
+
+(deftest test-child-spin-with-stable-root-discharges
+  (testing "E: self-tracking child spin, stable root, branch inside — the fix shape"
+    (with-ctx [rt]
+      (let [{:keys [texts parent child]}
+            (flip! rt (fn [loading? parent-runs child-runs]
+                        (spin (do (swap! parent-runs inc)
+                                  (el/div {:class "column-content"}
+                                          (await (spin (let [l? @(track loading?)]
+                                                         (swap! child-runs inc)
+                                                         (el/div {:class "block-editor" :key "page-view-abc"}
+                                                                 (if l?
+                                                                   (el/p "LOADING")
+                                                                   (el/div {:class "blocks-list"} "CONTENT")))))))))))]
+        (is (= 1 parent) "parent must not re-run; the child self-tracks")
+        (is (= 2 child))
+        (is (some #{"CONTENT"} texts))))))
+
+(deftest test-child-spin-root-flip-distinct-keys-discharges
+  (testing "D2: distinct keys give distinct addresses, so the swap discharges"
+    (with-ctx [rt]
+      (let [{:keys [texts]}
+            (flip! rt (fn [loading? parent-runs child-runs]
+                        (spin (do (swap! parent-runs inc)
+                                  (el/div {:class "column-content"}
+                                          (await (spin (let [l? @(track loading?)]
+                                                         (swap! child-runs inc)
+                                                         (if l?
+                                                           (loading-branch "page-view-abc-loading")
+                                                           (loaded-branch "page-view-abc-loaded"))))))))))]
+        (is (some #{"CONTENT"} texts))))))
+
+;; ---------------------------------------------------------------------------
+;; Defects — currently silent no-ops.
+;; ---------------------------------------------------------------------------
+
+(deftest test-child-spin-root-flip-same-key-discharges
+  (testing "D: THE PRODUCTION BUG — same key on both branches, change dropped"
+    (with-ctx [rt]
+      (let [{:keys [ops texts parent child]}
+            (flip! rt (fn [loading? parent-runs child-runs]
+                        (spin (do (swap! parent-runs inc)
+                                  (el/div {:class "column-content"}
+                                          (await (spin (let [l? @(track loading?)]
+                                                         (swap! child-runs inc)
+                                                         (if l?
+                                                           (loading-branch "page-view-abc")
+                                                           (loaded-branch "page-view-abc"))))))))))]
+        (is (= 1 parent))
+        (is (= 2 child) "the child body DID re-run")
+        (is (pos? ops)
+            "a structural change under one key must discharge (or throw), not vanish")
+        (is (some #{"CONTENT"} texts))))))
+
+(deftest test-render-spin-root-flip-discharges
+  (testing "A: a branch at the ROOT of the render spin cannot swap the mounted node"
+    (with-ctx [rt]
+      (let [{:keys [ops texts]}
+            (flip! rt (fn [loading? parent-runs _]
+                        (spin (do (swap! parent-runs inc)
+                                  (if @(track loading?)
+                                    (loading-branch "page-view-abc")
+                                    (loaded-branch "page-view-abc"))))))]
+        (is (pos? ops) "root swap must discharge (or throw), not vanish")
+        (is (some #{"CONTENT"} texts))))))

--- a/test/org/replikativ/spindel/dom/render_test.cljc
+++ b/test/org/replikativ/spindel/dom/render_test.cljc
@@ -84,16 +84,22 @@
 (deftest test-update-render-no-deltas
   (testing "Update render with same attrs does minimal work"
     (let [{:keys [discharge log]} (disch/make-mock-discharge)
-          v1 (el/div {:class "same"})
+          ;; Build BOTH roots from ONE call site. Identity is the address, and an
+          ;; address embeds the source location: two `el/div` forms on different
+          ;; lines are two different elements, and re-rendering "the same" root
+          ;; from a second call site is a genuine root swap (which now re-mounts).
+          ;; A real spin re-run rebuilds its root at the same call site with a
+          ;; reseeded chain, so its address is stable — that is what this models.
+          mk (fn [] (el/div {:class "same"}))
+          v1 (mk)
           container nil
           state (render/->RenderState container discharge nil false)
           mounted (render/initial-mount! state v1)
           _ (reset! log [])
-          v2 (el/div {:class "same"})
+          v2 (mk)
           _updated (render/update-render! mounted v2)]
-      ;; With context-aware addressing, vnodes at different source locations
-      ;; get different addresses, so transfer may re-apply attrs.
-      ;; At most one set-attr for the unchanged class.
+      (is (= (:addr v1) (:addr v2))
+          "same call site must yield a stable address across renders")
       (is (<= (count @log) 1)
           (str "Should do minimal work, got: " @log)))))
 

--- a/test/org/replikativ/spindel/dom/unmount_protocol_test.clj
+++ b/test/org/replikativ/spindel/dom/unmount_protocol_test.clj
@@ -1,0 +1,122 @@
+(ns org.replikativ.spindel.dom.unmount-protocol-test
+  "Unmount completeness: every address the render path writes must be reachable
+  from the teardown walk, and every removal vocabulary must call refs with nil.
+
+  Two defects these tests pin (both were live, both proven by probe):
+
+  1. **ifor-each keyed-cache leak.** `flatten-slot` splices a `:keyed` slot's
+     items into `:children` and drops the `KeyedFragment` itself, so the
+     ifor-each CALL-SITE address — which holds `:by-key` (every rendered vnode,
+     with its event-handler closures) and `:items-by-key` — appears on no vnode.
+     The teardown walk could never reach it, so unmounting any subtree containing
+     an `ifor-each` retained the whole rendered list for the lifetime of the
+     context. In simmis (87 ifor-each sites) every closed chat room leaked its
+     entire message list.
+
+  2. **Root swap without teardown.** A spin whose root element changes re-mounts
+     (formalism §3.9 R2). Without an explicit teardown the old tree's refs never
+     received their `nil` call — foreign nodes (TipTap) never released — and its
+     caches were never evicted.
+
+  See docs/engine-formalism.md §3.9."
+  (:refer-clojure :exclude [await])
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.dom.discharge :as disch]
+            [org.replikativ.spindel.dom.elements :as el]
+            [org.replikativ.spindel.dom.foreach :refer [ifor-each]]
+            [org.replikativ.spindel.dom.render :as render]
+            [org.replikativ.spindel.effects.track :refer [track]]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.signal :as sig]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.test-async :refer [await-drain]]
+            [org.replikativ.spindel.test-helpers :refer [with-ctx]]))
+
+(defn- state-size [k] (count (ec/get-state [k])))
+
+(deftest test-ifor-each-keyed-cache-is-evicted-on-unmount
+  (testing "unmounting a subtree containing an ifor-each drops its keyed cache"
+    (with-ctx [rt]
+      (let [{:keys [discharge]} (disch/make-mock-discharge)
+            show? (sig/signal true)
+            items [{:id 1 :t "a"} {:id 2 :t "b"} {:id 3 :t "c"}]
+            the-spin (spin (el/div {:class "shell"}
+                                   (when @(track show?)
+                                     (el/ul {:class "list"}
+                                            (ifor-each :id items (fn [i] (el/li (:t i))))))))]
+        (render/render-spin! nil the-spin discharge)
+        @the-spin
+        (is (pos? (state-size :dom/keyed-cache)) "mounted: keyed cache present")
+        (let [mounted-slots (state-size :dom/cache)]
+          (is (pos? mounted-slots))
+
+          (reset! show? false)
+          (await-drain rt)
+
+          (is (zero? (state-size :dom/keyed-cache))
+              "ifor-each keyed cache must be evicted — it holds every rendered vnode")
+          (is (< (state-size :dom/cache) mounted-slots)
+              "slot caches of the unmounted subtree must be evicted"))))))
+
+(deftest test-ifor-each-cache-survives-when-subtree-stays-mounted
+  (testing "the eviction cascade must not drop a LIVE ifor-each's cache"
+    (with-ctx [rt]
+      (let [{:keys [discharge]} (disch/make-mock-discharge)
+            flag (sig/signal true)
+            items [{:id 1 :t "a"} {:id 2 :t "b"}]
+            the-spin (spin (el/div {:class "shell"}
+                             ;; a sibling toggles; the list stays mounted
+                                   (when @(track flag) (el/span "x"))
+                                   (el/ul {:class "list"}
+                                          (ifor-each :id items (fn [i] (el/li (:t i)))))))]
+        (render/render-spin! nil the-spin discharge)
+        @the-spin
+        (reset! flag false)
+        (await-drain rt)
+        (is (pos? (state-size :dom/keyed-cache))
+            "a still-mounted ifor-each must keep its keyed cache")))))
+
+(deftest test-root-swap-calls-refs-on-unmount-and-evicts
+  (testing "a changed root re-mounts with full teardown: refs nil-called, caches evicted"
+    (with-ctx [rt]
+      (let [{:keys [discharge]} (disch/make-mock-discharge)
+            loading? (sig/signal true)
+            unmounts (atom 0)
+            mounts (atom 0)
+            ;; :ref fires with the element on mount and nil on unmount — this is
+            ;; what foreign nodes (TipTap) hang their teardown on.
+            ref-fn (fn [el] (if el (swap! mounts inc) (swap! unmounts inc)))
+            the-spin (spin (if @(track loading?)
+                             (el/div {:class "loading" :ref ref-fn} (el/p "LOADING"))
+                             (el/div {:class "loaded"} (el/p "CONTENT"))))]
+        (render/render-spin! nil the-spin discharge)
+        @the-spin
+        (is (= 1 @mounts) "ref called with the element on initial mount")
+        (is (= 0 @unmounts))
+        (let [slots-before (state-size :dom/cache)]
+
+          (reset! loading? false)
+          (await-drain rt)
+
+          (is (= 1 @unmounts)
+              "root swap must call the old tree's refs with nil (foreign-node teardown)")
+          (is (<= (state-size :dom/cache) slots-before)
+              "old root's caches must not accumulate across the swap"))))))
+
+(deftest test-root-swap-back-and-forth-is-bounded
+  (testing "A->B->A re-claims addresses; caches stay bounded across N flips"
+    (with-ctx [rt]
+      (let [{:keys [discharge]} (disch/make-mock-discharge)
+            loading? (sig/signal true)
+            the-spin (spin (if @(track loading?)
+                             (el/div {:class "loading"} (el/p "LOADING"))
+                             (el/div {:class "loaded"} (el/p "CONTENT"))))]
+        (render/render-spin! nil the-spin discharge)
+        @the-spin
+        (let [after-first (do (reset! loading? false) (await-drain rt)
+                              (state-size :dom/cache))]
+          (dotimes [_ 5]
+            (reset! loading? true) (await-drain rt)
+            (reset! loading? false) (await-drain rt))
+          (is (<= (state-size :dom/cache) (* 2 after-first))
+              "repeated root swaps must not grow the cache without bound"))))))

--- a/test/org/replikativ/spindel/engine/await_supersession_test.cljc
+++ b/test/org/replikativ/spindel/engine/await_supersession_test.cljc
@@ -1,0 +1,93 @@
+(ns org.replikativ.spindel.engine.await-supersession-test
+  "Regression: the await slow path must run the full body re-entry
+  prologue (mark-running! / clear-created-spins! / clear-prior-body-conts!
+  / seed-body-chain-head!) — parity with `Spin`'s `-invoke` Case 2.
+
+  Before the fix it only seeded the chain-head. Because track conts have
+  no deterministic id (they gensym), every slow-path re-run APPENDED a new
+  generation of track conts on top of the prior body's. Dispatch resumes
+  the earliest cont by :order — always the STALE one — which then
+  truncates the live body's conts and re-runs with its frozen lexical
+  bindings ('zombie repaint'). Discovered in simmis: opening a tab (parent
+  re-run with changed captures → child re-run via await slow path) and
+  then firing ANY signal the column tracked reverted the column DOM to its
+  pre-tab-open state while the layout signal held the new state.
+
+  Scenario: parent tracks P and awaits a child whose body captures P's
+  value lexically BEFORE tracking T. Changing P supersedes the child body
+  (changed captures → dirty → await slow path). Firing T afterwards must
+  resume the NEW body (fresh capture), and the child must hold exactly ONE
+  track cont for T — no accumulation."
+  (:refer-clojure :exclude [await])
+  (:require #?(:clj [clojure.test :refer [deftest is testing]])
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.engine.impl.simple :as simple]
+            [org.replikativ.spindel.signal :as sig]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.effects.track :refer [track]]))
+
+#?(:clj
+   (defn- track-conts-for
+     "All track conts registered on spin `tid` for `signal-ref`."
+     [tid signal-ref]
+     (->> (vals (ec/get-state [:track-subscriptions tid]))
+          (filterv #(= (:signal-id %) (:id signal-ref))))))
+
+#?(:clj
+   (deftest superseded-await-child-does-not-zombie
+     (testing "after a parent re-run supersedes an awaited child (changed
+              captures → await slow path), firing the child's tracked
+              signal resumes the NEW body, not the stale one"
+       (let [ctx-root (ctx/create-execution-context)
+             hold (atom nil)]
+         (try
+           (binding [ec/*execution-context* ctx-root]
+             (let [s-p (sig/signal :old)      ; parent-owned capture source
+                   s-t (sig/signal 0)         ; child-tracked signal
+                   runs (atom [])             ; [label t] per child body slice
+                   child-id (atom nil)
+                   parent (spin
+                           (let [{p :new} (track s-p)
+                                 c (spin
+                                    (let [{t :new} (track s-t)]
+                                      ;; `p` is captured lexically BEFORE the
+                                      ;; track point — the zombie's frozen value
+                                      (swap! runs conj [p t])
+                                      [p t]))]
+                             (reset! child-id (spin-core/spin-id c))
+                             (await c)))
+                   _ (reset! hold parent)]
+               (is (= [:old 0] @parent) "initial value")
+               (simple/await-drain-complete! ctx-root :timeout-ms 2000)
+
+               ;; Supersede: P changes → parent re-runs → child re-created
+               ;; with changed captures → re-run via the await SLOW path.
+               (reset! s-p :new)
+               (simple/await-drain-complete! ctx-root :timeout-ms 2000)
+               (is (= [:new 0] @parent) "supersession delivered")
+
+               ;; The child must hold exactly ONE track cont for T. Before
+               ;; the fix the stale body's cont survived alongside the new
+               ;; one (2 conts), and being earlier by :order it won dispatch.
+               (is (= 1 (count (track-conts-for @child-id s-t)))
+                   "no track-cont accumulation across slow-path re-runs")
+
+               ;; Fire the child's tracked signal: the NEW body must resume.
+               (reset! s-t 1)
+               (simple/await-drain-complete! ctx-root :timeout-ms 2000)
+               (is (= [:new 1] @parent)
+                   "post-supersession T change resumes the NEW body")
+               (is (not-any? #(= % [:old 1]) @runs)
+                   "the stale body (frozen :old capture) never re-ran")
+
+               ;; And the lineage keeps working.
+               (reset! s-t 2)
+               (simple/await-drain-complete! ctx-root :timeout-ms 2000)
+               (is (= [:new 2] @parent) "subsequent T changes keep working")
+               (is (some? @hold))))
+           (finally
+             (reset! hold nil)
+             (ctx/close-context! ctx-root)))))))

--- a/test/org/replikativ/spindel/pubsub/fork_ctx_reentrancy_test.cljc
+++ b/test/org/replikativ/spindel/pubsub/fork_ctx_reentrancy_test.cljc
@@ -108,7 +108,7 @@
                    [reply _] (await (anext asker-sub))]
                (log-trace :outer-got-reply reply)
                (deliver done {:reply (:content reply)})))))
-         (let [result (deref done 3000 :TIMEOUT)]
+         (let [result (deref done 30000 :TIMEOUT)]
            (ctx/stop-context! parent-ctx)
            (println "TRACE:" (pr-str @*trace*))
            (is (= {:reply "reply"} result)
@@ -135,7 +135,7 @@
              (bus-post! bus {:to worker-id :from asker-id :content "go"})
              (let [[reply _] (await (anext asker-sub))]
                (deliver done {:reply (:content reply)})))))
-         (let [result (deref done 3000 :TIMEOUT)]
+         (let [result (deref done 30000 :TIMEOUT)]
            (ctx/stop-context! parent-ctx)
            (is (= {:reply "reply"} result)))))))
 
@@ -158,7 +158,7 @@
                                              :content "go"})
                    [reply _] (await (anext asker-sub))]
                (deliver done {:reply (:content reply)})))))
-         (let [result (deref done 3000 :TIMEOUT)]
+         (let [result (deref done 30000 :TIMEOUT)]
            (ctx/stop-context! parent-ctx)
            (is (= {:reply "reply"} result)))))))
 
@@ -208,7 +208,7 @@
                            (await (anext result-tap)))]
                (log-trace :outer-got-final r)
                (deliver done r)))))
-         (let [result (deref done 3000 :TIMEOUT)
+         (let [result (deref done 30000 :TIMEOUT)
             ;; Reach into the TapSeq's internal state to see what's in result-tap's buffer
                inspect-tap (fn [tap label]
                              (try
@@ -248,7 +248,7 @@
                 (spin
                  (let [[reply _] (await (anext asker-sub))]
                    (deliver done {:reply (:content reply)})))))))
-         (let [result (deref done 3000 :TIMEOUT)]
+         (let [result (deref done 30000 :TIMEOUT)]
            (ctx/stop-context! parent-ctx)
            (is (= {:reply "reply"} result)
                "Should work since the setup happened outside the spin."))))))

--- a/test/org/replikativ/spindel/pubsub/mult_test.cljc
+++ b/test/org/replikativ/spindel/pubsub/mult_test.cljc
@@ -331,3 +331,37 @@
            ;; Pump should have delivered all items successfully
            ;; (verifying event-based execution works correctly)
            (is (= [1 2 3] result) "Pump should deliver all items via event-based execution"))))))
+
+;; =============================================================================
+;; Regression: consumer-fault isolation in deliver! (bug-bus-source-pump-lost-waiter)
+;; =============================================================================
+
+(def ^:private make-promise* @#'mult/make-promise)
+
+(deftest deliver-isolates-watcher-faults
+  ;; A promise watcher resumes a consumer spin and runs ON THE PRODUCER (pump)
+  ;; STACK. An unguarded throw there unwinds into the pump, cancels its await
+  ;; cont, and wedges the whole room bus deaf. deliver! must isolate each watcher
+  ;; fault: report it, keep notifying the remaining watchers, never propagate.
+  (let [orig-reporter @@#'mult/fault-reporter
+        faults (atom [])]
+    (mult/set-fault-reporter! (fn [ev data] (swap! faults conj [ev data])))
+    (try
+      (let [p (make-promise*)
+            called (atom [])]
+        ;; watcher order: a throwing one FIRST, a recording one after it
+        (swap! (:state p) update :watchers conj
+               (fn [_v] (throw (ex-info "consumer boom" {}))))
+        (swap! (:state p) update :watchers conj
+               (fn [v] (swap! called conj v)))
+        (testing "deliver! returns normally — the fault does not reach the producer"
+          (is (= :val ((:deliver! p) :val))))
+        (testing "a later watcher still runs despite the earlier fault (isolation)"
+          (is (= [:val] @called)))
+        (testing "the fault is reported, not silently swallowed"
+          (is (= 1 (count @faults)))
+          (is (= ::mult/watcher-fault (ffirst @faults)))
+          (is (instance? #?(:clj Throwable :cljs js/Error)
+                         (:error (second (first @faults)))))))
+      (finally
+        (mult/set-fault-reporter! orig-reporter)))))

--- a/test/org/replikativ/spindel/spin/mailbox_cancel_waiter_test.clj
+++ b/test/org/replikativ/spindel/spin/mailbox_cancel_waiter_test.clj
@@ -1,0 +1,168 @@
+(ns org.replikativ.spindel.spin.mailbox-cancel-waiter-test
+  "Regression: a cancelled external-await cont must never SILENTLY ABSORB a
+  producer's post.
+
+  `post-inline!` can skip a cancelled waiter *without consuming the message*
+  only if it can recognise the waiter as cancelled. It recognises it by the
+  `:cancel-token` stored on the waiter struct, which the Mailbox 2-arity
+  reads from `ec/*external-await-cancel-token*`.
+
+  That var is bound only by `await-handler`'s **Mailbox** dispatch branch.
+  But `(aseq/anext mbx)` returns a plain CPS *closure*, not the Mailbox, so
+  awaiting a mailbox through the PAsyncSeq protocol — which is what
+  `pubsub.mult`'s source pump does — lands in the generic `ifn?` branch,
+  where the cancel-token is discarded and the var is never bound.
+
+  Consequence: the waiter carries `:cancel-token nil`. When the cont is later
+  cancelled (e.g. `spin/core`'s `:external-await` reject path arms the gate
+  and drops the cont), `post-inline!` cannot tell the waiter is dead. It pops
+  the waiter, hands the message to the gated resolve, and the gate no-ops.
+  The message is gone, the waiter is gone, the consumer never re-arms.
+
+  Observed in production as a permanently deaf dvergr room bus:
+  `{:queue N :waiters 0}` with a live `:external-await` cont on the pump.
+  See ../dvergr/doc/bug-bus-source-pump-lost-waiter.md.
+
+  The tests drive the drain synchronously (`enqueue-event!` + `drain-events!`
+  rather than `post!`, which triggers an async drain) so there is no timing
+  dependence."
+  (:refer-clojure :exclude [await])
+  (:require [clojure.test :refer [deftest is testing]]
+            [is.simm.partial-cps.sequence :as aseq]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.impl.simple :as simple]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.spin.sync :as sync]))
+
+(defn- mbox-state
+  "Mailbox state is ctx-backed — read it under the owning context."
+  [context mbx]
+  (binding [ec/*execution-context* context]
+    @(.-state-atom mbx)))
+
+(defn- external-await-conts [context spin-id]
+  (binding [ec/*execution-context* context]
+    (->> (ec/get-state [:await-conts spin-id])
+         (filter (fn [[_id c]] (= :external-await (:kind c))))
+         (into {}))))
+
+(defn- cancel-all-external-awaits!
+  "Simulate any engine truncation site that arms the cancellation gate:
+  `spin/core`'s :external-await reject path, `truncate-stale-conts!`, or
+  `add-continuation!` displacing a cont at the same deterministic cont-id."
+  [context spin-id]
+  (doseq [[_id c] (external-await-conts context spin-id)]
+    ((:cancel! c) context)))
+
+(defn- post-synchronously!
+  "Post + drain on the calling thread. `sync/post!` enqueues and fires an
+  async drain on the executor; here we want the drain to have happened by the
+  time we assert."
+  [context mbx msg]
+  (simple/enqueue-event! context {:type :mailbox-post :mailbox mbx :msg msg})
+  (binding [ec/*execution-context* context]
+    (simple/drain-events! context (:executor context))))
+
+(defn- start-consumer!
+  "Invoke `spin` inline so it runs to its first suspend point, registering the
+  mailbox waiter synchronously. Returns the spin-id."
+  [context s]
+  (binding [ec/*execution-context* context]
+    (s (fn [_] nil) (fn [_] nil))
+    (spin-core/spin-id s)))
+
+(deftest test-anext-await-registers-untokened-waiter
+  (testing "awaiting a Mailbox through anext loses the cancel-token, awaiting it directly keeps it"
+    (let [context (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* context]
+          (let [via-anext (sync/create-mailbox context)
+                direct    (sync/create-mailbox context)
+                _ (start-consumer! context (spin (await (aseq/anext via-anext))))
+                _ (start-consumer! context (spin (await direct)))
+                anext-waiter  (first (:waiters (mbox-state context via-anext)))
+                direct-waiter (first (:waiters (mbox-state context direct)))]
+
+            (is (some? anext-waiter) "anext consumer should be parked on the mailbox")
+            (is (some? direct-waiter) "direct consumer should be parked on the mailbox")
+
+            (is (some? (:cancel-token direct-waiter))
+                "direct Mailbox await threads its cancel-token onto the waiter")
+
+          ;; This is the defect. Both consumers end up in the SAME mailbox
+          ;; waiter list, but only one of them is identifiable as cancellable.
+            (is (some? (:cancel-token anext-waiter))
+                "anext-await must ALSO thread its cancel-token onto the waiter")))
+        (finally (ctx/stop-context! context))))))
+
+(deftest test-cancelled-anext-waiter-absorbs-and-loses-message
+  (testing "a cancelled anext-await waiter swallows a post: message lost, consumer never resumes"
+    (let [context (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* context]
+          (let [mbx      (sync/create-mailbox context)
+                received (atom ::none)
+                sid      (start-consumer!
+                          context
+                          (spin (let [[msg _] (await (aseq/anext mbx))]
+                                  (reset! received msg))))]
+
+            (is (= 1 (count (:waiters (mbox-state context mbx)))) "consumer parked")
+            (is (seq (external-await-conts context sid)) "external-await cont registered")
+
+            (cancel-all-external-awaits! context sid)
+            (post-synchronously! context mbx :m1)
+
+            (let [{:keys [queue waiters]} (mbox-state context mbx)]
+              (is (= ::none @received) "gated resolve no-ops — consumer does not resume")
+              (is (empty? waiters) "the dead waiter was popped")
+
+            ;; THE BUG: the message was consumed by a waiter that could not act
+            ;; on it. It is neither delivered nor queued — it is gone.
+              (is (= [:m1] (vec queue))
+                  "a cancelled waiter must NOT consume the message; it must stay queued"))))
+        (finally (ctx/stop-context! context))))))
+
+(deftest test-cancelled-direct-waiter-preserves-message
+  (testing "control: the Mailbox dispatch branch protects the message (post-inline! skips)"
+    (let [context (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* context]
+          (let [mbx      (sync/create-mailbox context)
+                received (atom ::none)
+                sid      (start-consumer!
+                          context
+                          (spin (reset! received (await mbx))))]
+
+            (cancel-all-external-awaits! context sid)
+            (post-synchronously! context mbx :m1)
+
+            (let [{:keys [queue]} (mbox-state context mbx)]
+              (is (= ::none @received) "cancelled consumer does not resume")
+              (is (= [:m1] (vec queue))
+                  "post-inline! skips the tokened waiter WITHOUT consuming the message"))))
+        (finally (ctx/stop-context! context))))))
+
+(deftest test-wedge-shape-matches-production
+  (testing "after the absorbed post, further posts queue behind a pump that never re-arms"
+    (let [context (ctx/create-execution-context)]
+      (try
+        (binding [ec/*execution-context* context]
+          (let [mbx (sync/create-mailbox context)
+                sid (start-consumer! context (spin (await (aseq/anext mbx))))]
+            (cancel-all-external-awaits! context sid)
+            (post-synchronously! context mbx :lost)
+            (post-synchronously! context mbx :q1)
+            (post-synchronously! context mbx :q2)
+            (post-synchronously! context mbx :q3)
+
+            (let [{:keys [queue waiters]} (mbox-state context mbx)]
+            ;; The production signature: {:queue N :waiters 0}, N messages
+            ;; stuck, one silently dropped.
+              (is (zero? (count waiters)) "no waiter — the bus is deaf")
+              (is (= [:lost :q1 :q2 :q3] (vec queue))
+                  "no message may be dropped; :lost is absorbed by the dead waiter"))))
+        (finally (ctx/stop-context! context))))))

--- a/test/org/replikativ/spindel/spin_test.cljc
+++ b/test/org/replikativ/spindel/spin_test.cljc
@@ -102,12 +102,13 @@
              (is (= 1 @exec-count))
              (is (>= time1 10) "Should take at least 10ms"))
 
-           (let [start (System/currentTimeMillis)
-                 result2 @expensive-spin
-                 time2 (- (System/currentTimeMillis) start)]
+           ;; `exec-count` is the assertion that the cache worked; a wall-clock
+           ;; bound on the second deref only measures the machine (a GC pause
+           ;; under full-suite load makes it flake). The body sleeps 10ms per
+           ;; execution, so "did not re-execute" is already pinned exactly.
+           (let [result2 @expensive-spin]
              (is (= 499500 result2))
-             (is (= 1 @exec-count) "Should not re-execute")
-             (is (< time2 5) "Should be instant from cache")))))))
+             (is (= 1 @exec-count) "Should not re-execute (cache hit)")))))))
 
 ;; =============================================================================
 ;; Signal Consumption and Dependency Tracking (cross-platform)


### PR DESCRIPTION
Engine correctness fixes surfaced while hardening simmis, plus DOM/instrumentation fixes. All landed on this branch during co-development; releasing them so downstream (simmis) can consume them from a Maven pin instead of a local checkout.

## Engine
- **`fix(await)`** thread the cancel-token through the `ifn?` branch (`abcff43`) — the root cause of the dvergr room-bus wedge: a cancelled await on the anext/ifn path bypassed the cancel token and lost its mailbox waiter.
- **`fix(engine)`** the await slow path now runs the full body re-entry prologue (`71d5801`) — fixes zombie continuations re-firing.
- **`fix(incremental)`** the typed-interval probe must exclude records (`45661bb`) — `as-interval` record probe correctness.
- **`refactor(engine)`** shared `enter-body!` prologue + dev loud-reject + documented invariants.
- **`fix(mult)`** isolate consumer faults from the producer pump; loud pump reject.

## DOM
- **`fix(dom)`** render `:style` maps — they were falling through to `setAttribute` as EDN.
- **`fix(dom)`** identity is the address; complete the unmount protocol.

## Docs
- `docs(foreach)` document `ifor-each`'s memoization contract; `ifor-each` item-equality note.

## Tests
Green locally: JVM 897 tests / 3080 assertions, CLJS 398 / 1481, 0 failures. New tests include `mailbox_cancel_waiter_test` (the cancel-token path) and `pubsub/mult_test` (fault isolation).

## Relation to #27 (lost wakeup)

**Mitigates #27** — resolves the production incidents, but not the root-cause redesign, so #27 stays open.

Addressed:
- Trigger — cancel-agent-turn `future-cancel`/interrupt losing a mailbox waiter: `await.cljc` threads the cancel-token through the `ifn?` branch (`abcff43`) + `mailbox_cancel_waiter_test`. Covers mult pumps and mailbox consumers from the consumer side.
- Amplification — a dying consumer taking down the pump / other consumers: `mult.cljc` wraps each watcher in try/catch → `::watcher-fault` (fault isolation).
- Silent failure → loud: the pump `:reject-fn` now reports `::pump-rejected`.

Not addressed (remains in #27):
- Root cause: continuations still run inline on the producer thread (not enqueued through the event system).
- Transactional re-registration: watchers are CAS'd out before running; the catch isolates but does not re-deliver, so an interrupted consumer's own wakeup is still lost.
- `spin/sync.cljc`'s mailbox `deliver!` is not given the general try/catch — only the cancel path is covered (via `await.cljc`).
