### PR TITLE
#27 lost-wakeup root-cause redesign: failure routing, resume-as-event, transactional handoff

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -100,22 +100,42 @@ Reactive **execution state** (the two continuation tables,
 `:engine/pending`, `:engine/draining?`) is fork-local so the fork can
 drain its own events without contending with the parent's drain.
 
-> **Forking with an un-drained change.** Because `:engine/pending` is
-> fork-local, `fork-context` starts the fork with an empty queue — so a
-> `:signal-change` that the parent enqueued but has not yet drained is
-> *dropped* on the fork side. This is safe for the reactive model: spin
-> staleness is tracked by the per-`SpinNode` `:dirty` flag **plus the
-> `:generation` guard** (a spin caches the generations of the signals it
-> read and refuses its fast-path on a mismatch), neither of which lives in
-> the pending queue. So a fork spin that `await`/`track`s a stale-clean
-> spin recomputes against the new value via the generation guard — the
-> dropped event was only the *eager* recompute trigger, reconstructed
-> lazily on demand. Quiescence before forking is therefore an
-> optimization, not a correctness requirement. (The exception is a raw
-> `@deref` of a stale-clean spin, which returns the clean cache without
-> recomputing — the discouraged out-of-spin path; across a fork that
-> staleness is permanent rather than eventually-consistent, since the fork
-> never drains the dropped event.)
+> **Forking with an un-drained change.** `:engine/pending` is
+> fork-local, and `fork-context` splits the parent's un-drained queue by
+> event kind:
+>
+> - **Notification events** (`:signal-change`, `:spin-completion`,
+>   `:spin-execution`, `:gc-cleanup`) are *dropped* on the fork side.
+>   This is safe for the reactive model: their truth already lives in
+>   state the fork sees. Spin staleness is tracked by the per-`SpinNode`
+>   `:dirty` flag **plus the `:generation` guard** (a spin caches the
+>   generations of the signals it read and refuses its fast-path on a
+>   mismatch), neither of which lives in the pending queue. So a fork
+>   spin that `await`/`track`s a stale-clean spin recomputes against the
+>   new value via the generation guard — the dropped event was only the
+>   *eager* recompute trigger, reconstructed lazily on demand.
+>   Quiescence before forking is therefore an optimization, not a
+>   correctness requirement. (The exception is a raw `@deref` of a
+>   stale-clean spin, which returns the clean cache without recomputing
+>   — the discouraged out-of-spin path; across a fork that staleness is
+>   permanent rather than eventually-consistent, since the fork never
+>   drains the dropped event.) `:spin-execution` additionally carries
+>   external caller callbacks that must fire exactly once — in the
+>   parent's world.
+>
+> - **Data-bearing handoff events** (`:mailbox-post`,
+>   `:deferred-delivery`, `:cont-resume`) are *inherited* — copied into
+>   the fork's initial queue (and the fork's drain is triggered).
+>   Unlike notifications, these CARRY a payload that exists nowhere
+>   else: the message/value in flight. Dropping them would lose the
+>   message in the fork's world — and a `:cont-resume`'s waiter has
+>   already been popped from the (CoW-shared) primitive state, so the
+>   fork's consumer copy would hang un-armed. Each world drains its own
+>   copy against its own ctx (continuation closures resolve
+>   `*execution-context*` dynamically, and the fork copied
+>   `[:await-conts]`), so both worlds' body copies receive the value —
+>   the same both-worlds semantics as a message sitting in the mailbox
+>   `:queue` at fork time.
 
 `:engine/cancelled-tokens` is the one shared path with subtle
 fork behavior; see [§8](#8-overlay-backend).

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -554,8 +554,23 @@ returns that context's copy — `queue: 0` while the owning ctx holds
 | `:signal-change` | `swap!` / `reset!` on a signal | Marks dependent spins dirty, resumes track continuations, processes batch completions |
 | `:spin-completion` | Spin body finishes | Resumes `await` continuations in parent spins |
 | `:spin-execution` | `deref` on an uncached spin | Claims execution slot, runs spin body on executor |
-| `:deferred-delivery` | `deliver!` on a `Deferred` | Delivers value and inline-resumes waiting continuations |
-| `:mailbox-post` | `post!` on a `Mailbox` | Delivers message and inline-resumes the first waiter |
+| `:deferred-delivery` | `deliver!` on a `Deferred` | Assigns the value; enqueues one `:cont-resume` per pending reader |
+| `:mailbox-post` | `post!` on a `Mailbox` | Pops the first live waiter and enqueues its `:cont-resume` (or queues the message) |
+| `:cont-resume` | A one-shot waiter was popped for delivery (mailbox waiter, deferred reader, pubsub promise watcher, semaphore acquirer) | Re-checks cancellation at processing time (re-posting a cancelled mailbox waiter's message losslessly), then invokes the continuation under the uniform failure route |
+
+**The resume-as-event boundary.** One-shot waiters — entries POPPED from
+a primitive's state before firing — run as their own `:cont-resume`
+events: they get the drain's cancellation re-check and failure route,
+and no foreign thread ever executes them. PERSISTENT graph
+continuations (track conts and await conts, which are never removed
+and may legitimately fire more than once) resume INLINE within their
+driving event (`:signal-change` / `:spin-completion`): the inline
+design guarantees a resume has advanced the body before the next
+driving event processes — queueing them would let two child
+completions enqueue two resumes of the same un-advanced cont
+(double-firing the body). The persistent conts get per-resume fault
+isolation + owning-spin rejection instead (see the `:spin-completion`
+handler).
 
 ## 5. Glitch-Free Signal Propagation
 

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -501,6 +501,52 @@ Thread A checks :pending → non-empty → re-triggers
 Without the re-trigger, the new event would sit unprocessed until the
 next wakeup (up to 1 second).
 
+### Threading contract
+
+The engine's threads and the embedder's threads have an asymmetric
+contract:
+
+- **Engine-owned threads are never interrupt targets.** The drain
+  thread, executor workers, and delayed-execution timers run engine
+  machinery interleaved with many spins' continuations; a
+  `Thread.interrupt` landing there (e.g. via `future-cancel` on a
+  future that happens to be executing engine code) can only be
+  reported, not honored. Cancel work through the engine instead:
+  `spin.core/cancel-spin!` for a spin, or the cancel-token machinery
+  that `await` installs automatically. (Issue #27 was exactly this
+  violation: interrupt-based turn cancellation losing a mailbox
+  waiter.)
+- **Blocking embedder work runs on embedder threads** (futures, your
+  own pools) and communicates with the engine ONLY through
+  enqueue-only APIs — `sync/deliver!`, `sync/post!`, signal `swap!`.
+  Those never run engine continuations on your thread, so your threads
+  stay freely interruptible. (dvergr's generation handles follow this
+  pattern: the LLM call runs on a cancellable future that `deliver!`s
+  its result.)
+- **Failure semantics: at-most-once delivery, loud rejection.** When a
+  resumed waiter/reader continuation throws (including
+  `InterruptedException` — the flag is restored), the engine reports
+  `engine.fault/continuation-fault` and REJECTS the owning spin via
+  its parked continuation's reject route, so `catch`/`finally` run and
+  `spawn!`'s `:on-error` (and therefore `spin/supervisor` restart
+  policies) fire. The in-flight message is consumed either way — a
+  partially-executed continuation cannot be re-run (bodies are not
+  idempotent), so redelivery is a *restart-level* policy, not an
+  engine-level one.
+- **Faults are never silent.** All engine fault paths — continuation
+  faults, exceptions escaping executor tasks (whose `.submit` Futures
+  are discarded), pubsub watcher/pump faults — report through the
+  single hook in `engine/fault.cljc`; embedders route it into their
+  logging via `set-fault-reporter!`.
+
+One more sharp edge for health checks and monitoring: **Mailbox and
+Deferred state is ctx-relative (copy-on-write)**. The `state-atom` is a
+fork-safe context-backed atom, so dereffing it under a different
+execution context (e.g. a daemon root instead of the owning room ctx)
+returns that context's copy — `queue: 0` while the owning ctx holds
+`queue: 10`. Probe under the owning ctx:
+`(binding [ec/*execution-context* owning-ctx] @state-atom)`.
+
 ### Event types
 
 | Event | When enqueued | What drain does |

--- a/src/org/replikativ/spindel/effects/await.cljc
+++ b/src/org/replikativ/spindel/effects/await.cljc
@@ -578,7 +578,10 @@
       :else
       (reject (eff/type-error 'await "Spin, Deferred, or async thunk" awaitable)))
 
-    (catch #?(:clj Throwable :cljs js/Error) t
+    ;; :cljs :default, NOT js/Error — a thrown non-Error value (string,
+    ;; keyword, map) must reach the reject continuation too, or the await
+    ;; silently never completes.
+    (catch #?(:clj Throwable :cljs :default) t
       (reject t))))
 
 ;; =============================================================================

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -415,6 +415,32 @@
         parent-track-subscriptions (rtp/get-state parent-ctx [:track-subscriptions])
         parent-await-conts (rtp/get-state parent-ctx [:await-conts])
 
+        ;; Inherit the parent's in-flight DATA-BEARING events.
+        ;; :engine/pending is fork-local, and a fork deliberately DROPS
+        ;; the parent's un-drained NOTIFICATION events (:signal-change,
+        ;; :spin-completion, :spin-execution, :gc-cleanup): their truth
+        ;; already lives in state the fork sees (committed signal
+        ;; values, cached results), so re-delivering them in the fork
+        ;; would double-fire, and :spin-execution carries external
+        ;; caller callbacks that must fire once. Handoff events are
+        ;; different — they CARRY DATA that exists nowhere else: a
+        ;; :mailbox-post's / :cont-resume's message, a
+        ;; :deferred-delivery's value. Dropping those loses the message
+        ;; in the fork's world — and under the transactional handoff
+        ;; (#27 Phase C) a :cont-resume's waiter was already popped
+        ;; from the CoW-shared mailbox state, so the fork's consumer
+        ;; copy would hang un-armed with the message gone. Copy them:
+        ;; each world drains its own copy against its own ctx (the
+        ;; continuation closures resolve *execution-context*
+        ;; dynamically, and the fork copied [:await-conts], so the
+        ;; fork's processing advances the fork's body copies) — the
+        ;; same both-worlds semantics as a message sitting in the
+        ;; mailbox :queue at fork time.
+        parent-inflight-data-events
+        (vec (filter #(contains? #{:cont-resume :mailbox-post :deferred-delivery}
+                                 (:type %))
+                     (rtp/get-state parent-ctx [:engine/pending])))
+
         ;; Fork the forkable signals — those whose value is external mutable
         ;; state the overlay CoW can't isolate (a yggdrasil system). For each id
         ;; in [:forkable-signals] we `fork-value` the parent's node value and
@@ -449,7 +475,7 @@
         fork-local-state (cond-> (merge
                                   {:track-subscriptions (or parent-track-subscriptions {}) ; ← Copy parent's track conts!
                                    :await-conts (or parent-await-conts {})                 ; ← Copy parent's await conts!
-                                   :engine/pending []
+                                   :engine/pending parent-inflight-data-events ; ← data-bearing events only, see above
                                    :engine/draining? false
                                    :engine/delayed-spins (sorted-map)
                                    :engine/timer-handles {}}
@@ -499,16 +525,24 @@
                         :else
                         parent-metadata)]
 
-    (->ExecutionContext
-     fork-id
-     overlay-backend
-     parent-ctx  ; Keep parent reference
-     (:executor parent-ctx)  ; Share executor (for now)
-     merged-bindings
-     fork-metadata
-     (:running parent-ctx)        ; Share parent's lifecycle flag
-     (:drain-active parent-ctx)   ; Share parent's drain-active counter
-     )))
+    (let [fork (->ExecutionContext
+                fork-id
+                overlay-backend
+                parent-ctx  ; Keep parent reference
+                (:executor parent-ctx)  ; Share executor (for now)
+                merged-bindings
+                fork-metadata
+                (:running parent-ctx)        ; Share parent's lifecycle flag
+                (:drain-active parent-ctx)   ; Share parent's drain-active counter
+                )]
+      ;; A fork seeded with inherited in-flight data events (or explicit
+      ;; :engine/pending via state-updates) has work waiting but nothing
+      ;; has poked its drain yet — the parent's drain never touches a
+      ;; fork's fork-local queue. Trigger once so the inherited events
+      ;; don't sit until the fork's first own enqueue.
+      (when (seq (rtp/get-state fork [:engine/pending]))
+        (simple/trigger-drain! fork (:executor fork)))
+      fork)))
 
 ;; =============================================================================
 ;; Accessors

--- a/src/org/replikativ/spindel/engine/executor.cljc
+++ b/src/org/replikativ/spindel/engine/executor.cljc
@@ -9,7 +9,8 @@
   Scheduling policy — *when* and *in what order* to run things (topological
   observer notification, batch coordination, drain ordering) — lives in the
   engine implementation (`engine.impl.simple`), not in this namespace."
-  (:require [org.replikativ.spindel.engine.bindings :as bindings])
+  (:require [org.replikativ.spindel.engine.bindings :as bindings]
+            [org.replikativ.spindel.engine.fault :as fault])
   #?(:clj (:import [java.util.concurrent Executors ExecutorService ThreadPoolExecutor
                     ScheduledExecutorService ScheduledThreadPoolExecutor ThreadFactory
                     TimeUnit LinkedBlockingQueue Callable ForkJoinPool])))
@@ -90,6 +91,37 @@
        :cljs (js/clearTimeout handle)))
   nil)
 
+(defn ^:no-doc guard-task
+  "Wrap an executor task so an exception escaping it is REPORTED instead
+  of vanishing. On the JVM, `execute!` returns a `.submit` Future that
+  no caller derefs — an escaped throw is captured in the discarded
+  Future and lost without a trace. On JS, a throw escaping a setTimeout
+  callback surfaces as an uncaught error, but bypasses the engine's
+  fault hook. Either way, the task seam is the last place the engine
+  can observe the failure, so it is guarded here — this covers EVERY
+  executor-run path (drain sessions, parallel observer dispatch,
+  parallel/race children, delayed-spin resumes, semaphore wakes).
+
+  InterruptedException additionally restores the thread's interrupt
+  flag: the engine treats engine-owned threads as non-interruptible
+  (see engine.md §Threading contract), so an interrupt that lands here
+  is an embedder contract violation worth reporting — but the flag must
+  survive for pool machinery that inspects it.
+
+  The throw is NOT re-raised: there is no upstream observer to raise it
+  to (that is the point), and re-raising on a pool thread would only
+  feed the pool's uncaught-exception machinery inconsistently across
+  executors."
+  [task-fn]
+  (fn []
+    (try
+      (task-fn)
+      #?@(:clj [(catch InterruptedException ie
+                  (.interrupt (Thread/currentThread))
+                  (fault/report-fault! ::fault/executor-task-fault {:error ie :interrupted? true}))])
+      (catch #?(:clj Throwable :cljs :default) e
+        (fault/report-fault! ::fault/executor-task-fault {:error e})))))
+
 ;; =============================================================================
 ;; Executor Implementations
 ;; =============================================================================
@@ -131,9 +163,12 @@
        PExecutor
        (execute! [_ spin-fn]
          (let [bindings (capture-targeted-bindings)
-               bound-spin-fn (fn []
-                               (with-bindings bindings
-                                 (spin-fn)))]
+               ;; guard-task: the returned Future is discarded by every
+               ;; caller — without the guard an escaped throw vanishes.
+               bound-spin-fn (guard-task
+                              (fn []
+                                (with-bindings bindings
+                                  (spin-fn))))]
            (.submit executor ^Callable (reify Callable
                                          (call [_]
                                            (bound-spin-fn))))))
@@ -155,9 +190,11 @@
        PExecutor
        (execute! [_ spin-fn]
          (let [bindings (capture-targeted-bindings)
-               bound-spin-fn (fn []
-                               (with-bindings bindings
-                                 (spin-fn)))]
+               ;; guard-task: same discarded-Future rationale as PoolExecutor.
+               bound-spin-fn (guard-task
+                              (fn []
+                                (with-bindings bindings
+                                  (spin-fn))))]
            (.submit pool ^Callable (reify Callable
                                      (call [_]
                                        (bound-spin-fn))))))
@@ -179,7 +216,10 @@
      (execute! [_ spin-fn]
        ;; Capture current dynamic bindings before scheduling
        (let [captured-bindings (bindings/capture-bindings)
-             bound-spin-fn #(bindings/restore-bindings captured-bindings spin-fn)]
+             ;; guard-task: route escaped throws through the engine fault
+             ;; hook instead of the global uncaught-error handler.
+             bound-spin-fn (guard-task
+                            #(bindings/restore-bindings captured-bindings spin-fn))]
          ;; Schedule on next tick and return nil (TODO: return promise)
          (js/setTimeout bound-spin-fn 0)
          nil))
@@ -187,7 +227,8 @@
      (execute-after! [_ delay-ms spin-fn]
        ;; Capture current dynamic bindings before scheduling
        (let [captured-bindings (bindings/capture-bindings)
-             bound-spin-fn #(bindings/restore-bindings captured-bindings spin-fn)]
+             bound-spin-fn (guard-task
+                            #(bindings/restore-bindings captured-bindings spin-fn))]
          ;; Use setTimeout for delayed execution; return its id so the
          ;; caller can clearTimeout it (see cancel-timer-handle!) and not
          ;; leak a pending timer for a completed / cancelled delayed spin.

--- a/src/org/replikativ/spindel/engine/fault.cljc
+++ b/src/org/replikativ/spindel/engine/fault.cljc
@@ -1,0 +1,63 @@
+(ns org.replikativ.spindel.engine.fault
+  "Engine-wide fault reporting hook.
+
+  spindel carries no logging dependency, but an engine fault — a
+  continuation that throws during resume, an executor task whose
+  exception would otherwise vanish into a discarded Future, a consumer
+  fault isolated away from a producer — must never be silently
+  swallowed. This namespace is the single, dependency-free hook every
+  engine path reports through; embedders route it into their own
+  logging (simmis → Telemere) via `set-fault-reporter!`.
+
+  Hoisted from `pubsub/mult.cljc` (PR #28 introduced the pattern there
+  for `::watcher-fault` / `::pump-rejected`); mult now delegates here so
+  one embedder call configures ALL engine fault reporting.
+
+  Event keywords currently reported through this hook:
+
+    :org.replikativ.spindel.engine.fault/continuation-fault
+      A resumed waiter/reader/parent continuation threw. Data:
+      {:site :mailbox|:deferred|:spin-completion|:cont-resume
+       :spin-id …, :error e}. The owning spin is rejected (loud
+      failure, at-most-once delivery — see engine.md §Threading
+      contract); this report is the observability side.
+
+    :org.replikativ.spindel.engine.fault/executor-task-fault
+      A task submitted to an executor threw and nothing upstream could
+      observe it (the JVM `.submit` Future is discarded; a CLJS
+      setTimeout callback has no caller). Data: {:error e}.
+
+    :org.replikativ.spindel.pubsub.mult/watcher-fault
+    :org.replikativ.spindel.pubsub.mult/pump-rejected
+      See pubsub/mult.cljc."
+  #?(:clj (:import [java.io Writer])))
+
+(defonce ^:private fault-reporter
+  ;; Default: stderr / console.error so a fault is never silently
+  ;; swallowed even in an unconfigured embedding.
+  (atom (fn [event data]
+          #?(:clj  (binding [*out* *err*]
+                     (println "[spindel.fault]" event (pr-str data)))
+             :cljs (js/console.error "[spindel.fault]" (str event) (clj->js data))))))
+
+(defn set-fault-reporter!
+  "Override how the engine reports faults. `f` is
+  (fn [event-keyword data-map]). Default writes to stderr /
+  console.error. One hook covers the whole engine — continuation
+  faults, executor task faults, and the pubsub events that previously
+  had their own reporter in `pubsub/mult.cljc`."
+  [f] (reset! fault-reporter f))
+
+(defn ^:no-doc current-fault-reporter
+  "The currently installed reporter fn. For save/restore around a
+  scoped override (tests, temporarily-quiet sections)."
+  []
+  @fault-reporter)
+
+(defn report-fault!
+  "Report an engine fault through the configured reporter. Never throws:
+  a broken reporter must not take down the path that is trying to be
+  loud about a fault."
+  [event data]
+  (try (@fault-reporter event data)
+       (catch #?(:clj Throwable :cljs :default) _ nil)))

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -6,7 +6,7 @@
 
   Responsibilities:
   - Maintain event queue (:engine/pending)
-  - Process events: :signal-change, :spin-completion, :deferred-delivery, :mailbox-post, :spin-execution
+  - Process events: :signal-change, :spin-completion, :deferred-delivery, :mailbox-post, :spin-execution, :cont-resume, :gc-cleanup
   - Drain events asynchronously on executor threads
   - Prevent concurrent draining via CAS lock (:engine/draining?)
 
@@ -229,6 +229,47 @@
         (reject-owning-spin! context spin-id cancel-token e))
       nil)))
 
+(defn ^:no-doc enqueue-cont-resume!
+  "Enqueue a `:cont-resume` event — the resume-as-event handoff for
+  ONE-SHOT waiter continuations (mailbox waiters, deferred readers,
+  pubsub promise watchers, semaphore acquirers).
+
+  The scoped resume-as-event boundary (issue #27, `.internal/
+  lost-wakeup-design-space.md`): a waiter that is POPPED from its
+  primitive's state before firing is one-shot by construction, so
+  running it as its own top-level event is sound and gives it the
+  drain's uniform cancellation re-check + failure route. PERSISTENT
+  graph continuations (track conts, await conts — which are never
+  removed and may legitimately fire more than once) must keep resuming
+  inline within their driving event: queueing them as events would let
+  two driving events enqueue two resumes of the SAME un-advanced cont
+  (the inline design guarantees a resume advances the body before the
+  next event processes — see the loop-over-await pattern).
+
+  Event fields:
+    :spin-id / :cancel-token — cancellation identity of the waiter
+      (both re-checked at PROCESSING time; the window between enqueue
+      and processing can contain a truncation).
+    :resolve / :value — the continuation and its delivery.
+    :site — fault-report tag (:mailbox, :deferred, :promise, :semaphore).
+    :mailbox — for mailbox handoffs only: the owning Mailbox, so a
+      waiter found cancelled AT PROCESSING TIME can have its message
+      RE-POSTED losslessly (nothing of the continuation ran). This is a
+      capability the inline design could not express: a cancellation
+      landing between pop and invoke previously fed the message to a
+      gated no-op. Re-posting appends to the queue's tail — FIFO order
+      across a cancellation race is not preserved (mailboxes promise
+      FIFO only for the uncontended path).
+
+  Called from inside the drain (post-inline!/deliver-inline! run within
+  process-event!): plain enqueue — the active drain loop dequeues it in
+  the same session. Called from outside (promise deliver!, semaphore
+  release): use `rtp/enqueue!` which also triggers a drain."
+  [context event]
+  (rtp/swap-state-args! context [:engine/pending] conj
+                        [(assoc event :type :cont-resume)])
+  (log/trace :engine/enqueue-event {:event-type :cont-resume :site (:site event)}))
+
 (defn- deliver-inline!
   "INTERNAL: Deliver value inline to deferred, resuming readers directly."
   [context deferred value state-atom]
@@ -248,22 +289,22 @@
                                        :value value
                                        :pending [])))))]
 
-    ;; Notify all pending readers INLINE if this was the first assignment.
-    ;; Each pending entry is a `{:spin-id :cancel-token :resolve}` map (the
-    ;; Deferred 2-arity stores cancellation metadata so it can prune cancelled
-    ;; readers). The wrapped `:resolve` already no-ops if its await was
-    ;; cancelled, so we can invoke them all; the metadata is for the
-    ;; prune-on-read sweep — and for failure routing here.
-    ;; Event handler already bound *in-trampoline* false
-    ;;
-    ;; PER-READER isolation: each resume runs under guarded-resume!, so
-    ;; reader k throwing (a) cannot strand readers k+1..n — they never ran
-    ;; and still get the value — and (b) rejects reader k's own spin
-    ;; instead of leaving it PENDING. Same isolation shape PR #28 gave
-    ;; mult's watchers; a deferred with N readers is the same fan-out.
+    ;; Resume-as-event (#27 Phase B): each pending reader is a one-shot
+    ;; waiter `{:spin-id :cancel-token :resolve}` popped from `:pending`
+    ;; by the swap above — enqueue one `:cont-resume` per reader instead
+    ;; of invoking inline. Per-reader isolation is now STRUCTURAL: each
+    ;; reader is its own event with its own failure route (reader k
+    ;; throwing cannot strand readers k+1..n), and cancellation is
+    ;; re-checked at processing time. No `:mailbox` re-post field — every
+    ;; reader receives the same value, so a cancelled reader skipping
+    ;; delivery loses nothing.
     (when-let [pending @pending-callbacks]
       (doseq [{:keys [spin-id cancel-token resolve]} pending]
-        (guarded-resume! context :deferred spin-id cancel-token resolve value)))
+        (enqueue-cont-resume! context {:site :deferred
+                                       :spin-id spin-id
+                                       :cancel-token cancel-token
+                                       :resolve resolve
+                                       :value value})))
 
     ;; Return the assigned value
     (:value @state-atom)))
@@ -321,12 +362,20 @@
               (recur))
 
             :else
-            ;; Failure routing: a throw out of the resumed consumer rejects
-            ;; THAT consumer's spin (loud, supervisable) — the message is
-            ;; consumed either way (at-most-once; a partially-run
-            ;; continuation is not re-runnable). See guarded-resume!.
+            ;; Resume-as-event (#27 Phase B): the waiter was popped by the
+            ;; swap above (one-shot); hand it to the drain as its own
+            ;; event. The handler re-checks cancellation AT PROCESSING
+            ;; time and — because the event carries the mailbox — can
+            ;; RE-POST the message losslessly if the waiter was cancelled
+            ;; in the enqueue→process window. Failure routing (reject the
+            ;; owning spin on throw) lives in the handler.
             (do
-              (guarded-resume! context :mailbox spin-id cancel-token resolve msg)
+              (enqueue-cont-resume! context {:site :mailbox
+                                             :spin-id spin-id
+                                             :cancel-token cancel-token
+                                             :resolve resolve
+                                             :value msg
+                                             :mailbox mailbox})
               nil))
           ;; No waiter, message queued
           nil)))))
@@ -1041,6 +1090,44 @@
             ;; Invoke spin (Spin implements IFn)
             (let [result (spin resolve-fn reject-fn)]
               nil)))))
+
+    ;; Resume-as-event handoff for one-shot waiters (#27 Phase B) — see
+    ;; enqueue-cont-resume! for the design boundary. The waiter was
+    ;; already popped from its primitive's state; this event IS the
+    ;; wakeup, so cancellation is re-checked here (the enqueue→process
+    ;; window can contain a truncation) and the failure route is armed.
+    :cont-resume
+    ;; The whole case runs under the event's context binding —
+    ;; spin-is-cancelled? and the Mailbox 1-arity re-post both resolve
+    ;; *execution-context* dynamically.
+    (binding [ec/*execution-context* context
+              pcps-async/*in-trampoline* false]
+      (let [{:keys [spin-id cancel-token resolve value site mailbox]} event
+            cancelled-tokens (rtp/get-state context [:engine/cancelled-tokens])
+            cancelled? (or (and spin-id (ec/spin-is-cancelled? spin-id))
+                           (and cancel-token cancelled-tokens
+                                (contains? cancelled-tokens cancel-token)))]
+        (if cancelled?
+          (do
+            ;; Self-cleaning: consuming the cancelled waiter's token (same
+            ;; contract as the pop-time skip in post-inline!).
+            (when (and cancel-token cancelled-tokens
+                       (contains? cancelled-tokens cancel-token))
+              (rtp/swap-state! context [:engine/cancelled-tokens]
+                               (fn [s] (if s (disj s cancel-token) s))))
+            ;; A mailbox message belongs to exactly one consumer — nothing
+            ;; of this waiter's continuation ran, so RE-POST it losslessly
+            ;; (the fresh :mailbox-post finds the next live waiter or
+            ;; queues). Deferred/promise/semaphore deliveries carry no
+            ;; :mailbox: their values are not single-consumer, skipping a
+            ;; cancelled waiter loses nothing.
+            (when mailbox
+              (log/trace :engine/cont-resume-repost {:site site :spin-id spin-id})
+              (mailbox value))
+            nil)
+          (do
+            (guarded-resume! context site spin-id cancel-token resolve value)
+            nil))))
 
     ;; GC cleanup request — the JVM Cleaner / JS FinalizationRegistry saw the
     ;; Spin OBJECT become unreachable and enqueued this instead of mutating

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -229,85 +229,88 @@
         (reject-owning-spin! context spin-id cancel-token e))
       nil)))
 
-(defn ^:no-doc enqueue-cont-resume!
-  "Enqueue a `:cont-resume` event — the resume-as-event handoff for
-  ONE-SHOT waiter continuations (mailbox waiters, deferred readers,
-  pubsub promise watchers, semaphore acquirers).
+;; The resume-as-event boundary (issue #27, engine.md §Event types):
+;; ONE-SHOT waiters — entries POPPED from a primitive's state before
+;; firing (mailbox waiters, deferred readers, pubsub promise watchers,
+;; semaphore acquirers) — are handed to the drain as `:cont-resume`
+;; events. Inside the drain (post-inline!/deliver-inline!) the pop and
+;; the event append are ONE backend-write-2! commit; from outside
+;; (promise deliver!, semaphore release) `rtp/enqueue!` posts + triggers.
+;; PERSISTENT graph continuations (track conts, await conts — never
+;; removed, legitimately multi-fire) must keep resuming INLINE within
+;; their driving event: queueing them would let two driving events
+;; enqueue two resumes of the SAME un-advanced cont (the inline design
+;; guarantees a resume advances the body before the next event
+;; processes — see the loop-over-await pattern).
+;;
+;; :cont-resume event fields:
+;;   :spin-id / :cancel-token — cancellation identity of the waiter
+;;     (re-checked at PROCESSING time; the enqueue→process window can
+;;     contain a truncation).
+;;   :resolve / :value — the continuation and its delivery.
+;;   :site — fault-report tag (:mailbox, :deferred, :promise, :semaphore).
+;;   :mailbox — mailbox handoffs only: the owning Mailbox, so a waiter
+;;     found cancelled AT PROCESSING TIME has its message RE-POSTED
+;;     losslessly (nothing of the continuation ran) — a capability the
+;;     inline design could not express. Re-posting appends to the
+;;     queue's tail; FIFO across a cancellation race is not promised.
 
-  The scoped resume-as-event boundary (issue #27, `.internal/
-  lost-wakeup-design-space.md`): a waiter that is POPPED from its
-  primitive's state before firing is one-shot by construction, so
-  running it as its own top-level event is sound and gives it the
-  drain's uniform cancellation re-check + failure route. PERSISTENT
-  graph continuations (track conts, await conts — which are never
-  removed and may legitimately fire more than once) must keep resuming
-  inline within their driving event: queueing them as events would let
-  two driving events enqueue two resumes of the SAME un-advanced cont
-  (the inline design guarantees a resume advances the body before the
-  next event processes — see the loop-over-await pattern).
-
-  Event fields:
-    :spin-id / :cancel-token — cancellation identity of the waiter
-      (both re-checked at PROCESSING time; the window between enqueue
-      and processing can contain a truncation).
-    :resolve / :value — the continuation and its delivery.
-    :site — fault-report tag (:mailbox, :deferred, :promise, :semaphore).
-    :mailbox — for mailbox handoffs only: the owning Mailbox, so a
-      waiter found cancelled AT PROCESSING TIME can have its message
-      RE-POSTED losslessly (nothing of the continuation ran). This is a
-      capability the inline design could not express: a cancellation
-      landing between pop and invoke previously fed the message to a
-      gated no-op. Re-posting appends to the queue's tail — FIFO order
-      across a cancellation race is not preserved (mailboxes promise
-      FIFO only for the uncontended path).
-
-  Called from inside the drain (post-inline!/deliver-inline! run within
-  process-event!): plain enqueue — the active drain loop dequeues it in
-  the same session. Called from outside (promise deliver!, semaphore
-  release): use `rtp/enqueue!` which also triggers a drain."
-  [context event]
-  (rtp/swap-state-args! context [:engine/pending] conj
-                        [(assoc event :type :cont-resume)])
-  (log/trace :engine/enqueue-event {:event-type :cont-resume :site (:site event)}))
+(defn- ratom-id
+  "The RuntimeAtom's id field — the key of its ctx-backed state slot
+  `[:atoms id :value]`. Field access via the same per-platform pattern
+  as the deftype accesses in process-event! (reflection on CLJ is
+  acceptable on paths already heading into state mutation)."
+  [state-atom]
+  #?(:clj  (.-id state-atom)
+     :cljs (.-id ^js state-atom)))
 
 (defn- deliver-inline!
-  "INTERNAL: Deliver value inline to deferred, resuming readers directly."
+  "INTERNAL: Deliver value to a deferred.
+
+  Transactional handoff (#27 Phase C): marking the deferred assigned,
+  capturing its pending readers, and appending their `:cont-resume`
+  events to `[:engine/pending]` is ONE atomic backend commit
+  (`backend-write-2!`) — each reader's wakeup obligation moves from the
+  deferred's `:pending` to the event queue with no instant in which it
+  exists in zero places (lost) or two (double delivery). Per-reader
+  isolation and cancellation re-checks live in the `:cont-resume`
+  handler.
+
+  Writes go through the backend directly (not the RuntimeAtom's swap),
+  so the ratom's watch listeners are fired manually afterwards —
+  outside the commit, exactly as `atom/swap-and-notify!` does (a swap
+  fn can retry; listeners must fire once, after)."
   [context deferred value state-atom]
-  (let [;; Atomically check if already assigned and capture pending callbacks
-        pending-callbacks (atom nil)
-        _assigned? (swap! state-atom
-                          (fn [state]
-                            (if (:assigned? state)
-                             ;; Already assigned - no change
-                              state
-                             ;; First assignment - capture pending and mark assigned
-                             ;; IMPORTANT: Preserve :delivery-claimed? for single-assignment semantics
-                              (do
-                                (reset! pending-callbacks (:pending state))
-                                (assoc state
-                                       :assigned? true
-                                       :value value
-                                       :pending [])))))]
-
-    ;; Resume-as-event (#27 Phase B): each pending reader is a one-shot
-    ;; waiter `{:spin-id :cancel-token :resolve}` popped from `:pending`
-    ;; by the swap above — enqueue one `:cont-resume` per reader instead
-    ;; of invoking inline. Per-reader isolation is now STRUCTURAL: each
-    ;; reader is its own event with its own failure route (reader k
-    ;; throwing cannot strand readers k+1..n), and cancellation is
-    ;; re-checked at processing time. No `:mailbox` re-post field — every
-    ;; reader receives the same value, so a cancelled reader skipping
-    ;; delivery loses nothing.
-    (when-let [pending @pending-callbacks]
-      (doseq [{:keys [spin-id cancel-token resolve]} pending]
-        (enqueue-cont-resume! context {:site :deferred
-                                       :spin-id spin-id
-                                       :cancel-token cancel-token
-                                       :resolve resolve
-                                       :value value})))
-
+  (let [aid (ratom-id state-atom)
+        value-path [:atoms aid :value]
+        old-v (volatile! nil)
+        new-v (volatile! nil)]
+    (backend/backend-write-2!
+     (:backend context) value-path [:engine/pending]
+     (fn [state pending]
+       (vreset! old-v state)
+       (if (:assigned? state)
+         ;; Already assigned - no change, no events
+         (do (vreset! new-v state)
+             [state pending])
+         ;; First assignment — capture pending readers and hand each to
+         ;; the drain as its own :cont-resume, atomically with the
+         ;; assignment. (Preserve :delivery-claimed? for
+         ;; single-assignment semantics.)
+         (let [state' (assoc state :assigned? true :value value :pending [])
+               events (mapv (fn [{:keys [spin-id cancel-token resolve]}]
+                              {:type :cont-resume
+                               :site :deferred
+                               :spin-id spin-id
+                               :cancel-token cancel-token
+                               :resolve resolve
+                               :value value})
+                            (:pending state))]
+           (vreset! new-v state')
+           [state' (into (vec pending) events)]))))
+    (ec/notify-listeners! state-atom aid @old-v @new-v)
     ;; Return the assigned value
-    (:value @state-atom)))
+    (:value @new-v)))
 
 (defn- post-inline!
   "INTERNAL: Post message inline to mailbox, resuming waiters directly.
@@ -328,57 +331,95 @@
      `ec/*external-await-cancel-token*`.
 
   When a cancelled waiter is found, the loop recurs with the SAME `msg`
-  — the swap-state above only popped a waiter and didn't put the msg
-  anywhere; the next iteration finds the next waiter (or pushes the msg
-  to `:queue` if no more waiters)."
+  — the commit only popped a waiter and didn't put the msg anywhere;
+  the next iteration finds the next waiter (or pushes the msg to
+  `:queue` if no more waiters). Skipping at pop time (rather than
+  leaving it to the `:cont-resume` handler's re-post) is load-bearing
+  for ORDER: cancelled waiters are routine (await truncations), and a
+  skip never consumes the message, so FIFO is preserved; the handler's
+  re-post only covers the rare cancellation landing in the
+  enqueue→process window.
+
+  Transactional handoff (#27 Phase C): popping the live waiter and
+  appending its `:cont-resume` to `[:engine/pending]` is ONE atomic
+  backend commit (`backend-write-2!`) — the wakeup obligation moves
+  from `:waiters` to the event queue with no instant in which it exists
+  in zero places or two. Writes bypass the RuntimeAtom's swap, so its
+  watch listeners are fired manually after each commit (never inside —
+  a swap fn can retry)."
   [context mailbox msg state-atom]
-  (let [cancelled-tokens (rtp/get-state context [:engine/cancelled-tokens])]
+  (let [aid (ratom-id state-atom)
+        value-path [:atoms aid :value]
+        cancelled-tokens (rtp/get-state context [:engine/cancelled-tokens])
+        ;; Read-only cancellation probe, called INSIDE the commit fn on
+        ;; the head waiter: `spin-is-cancelled?` reads other state paths
+        ;; of the same backend (a deref of the last committed value) —
+        ;; legal inside a swap fn, and idempotent under CAS retry.
+        dead-waiter? (fn [{:keys [spin-id cancel-token]}]
+                       (or (and spin-id (ec/spin-is-cancelled? spin-id))
+                           (and cancel-token cancelled-tokens
+                                (contains? cancelled-tokens cancel-token))))]
     (loop []
-      (let [waiter-to-try (atom nil)
-            _result (swap! state-atom
-                           (fn [state]
-                             (if (seq (:waiters state))
-                              ;; Has waiters - take first one to try
-                               (do
-                                 (reset! waiter-to-try (first (:waiters state)))
-                                 (update state :waiters #(vec (rest %))))
-                              ;; No waiters - add to queue
-                               (update state :queue conj msg))))]
-        (if-let [{:keys [spin-id cancel-token resolve]} @waiter-to-try]
-          (cond
-            (and spin-id (ec/spin-is-cancelled? spin-id))
-            (recur)
+      (let [decision (volatile! nil) ;; :queued | [:skip-dead waiter] | :handoff
+            old-v (volatile! nil)
+            new-v (volatile! nil)]
+        (backend/backend-write-2!
+         (:backend context) value-path [:engine/pending]
+         (fn [state pending]
+           (vreset! old-v state)
+           (let [w (first (:waiters state))]
+             (cond
+               (nil? w)
+               ;; No waiters - add to queue
+               (let [state' (update state :queue conj msg)]
+                 (vreset! decision :queued)
+                 (vreset! new-v state')
+                 [state' pending])
 
-            (and cancel-token cancelled-tokens (contains? cancelled-tokens cancel-token))
-            (do
-              ;; Self-cleaning: this waiter was cancelled and we're consuming
-              ;; (skipping) it now — the cancel-token is no longer needed.
-              ;; Drop it from the set so cancelled-tokens doesn't accumulate
-              ;; one entry per signal-change × waiter over the context's
-              ;; lifetime. See `effects/await.cljc::cancellable-external-pair`
-              ;; for the Deferred/ifn? side of the same self-cleaning story.
-              (rtp/swap-state! context [:engine/cancelled-tokens]
-                               (fn [s] (if s (disj s cancel-token) s)))
+               (dead-waiter? w)
+               ;; Pop the cancelled waiter WITHOUT consuming the message.
+               (let [state' (update state :waiters #(vec (rest %)))]
+                 (vreset! decision [:skip-dead w])
+                 (vreset! new-v state')
+                 [state' pending])
+
+               :else
+               ;; Live waiter: pop + append its :cont-resume in the same
+               ;; commit. The handler re-checks cancellation AT
+               ;; PROCESSING time and — because the event carries the
+               ;; mailbox — RE-POSTS the message losslessly if the
+               ;; waiter was cancelled in the enqueue→process window.
+               ;; Failure routing (reject the owning spin on throw)
+               ;; lives in the handler too.
+               (let [state' (update state :waiters #(vec (rest %)))
+                     event {:type :cont-resume
+                            :site :mailbox
+                            :spin-id (:spin-id w)
+                            :cancel-token (:cancel-token w)
+                            :resolve (:resolve w)
+                            :value msg
+                            :mailbox mailbox}]
+                 (vreset! decision :handoff)
+                 (vreset! new-v state')
+                 [state' (conj (vec pending) event)])))))
+        (ec/notify-listeners! state-atom aid @old-v @new-v)
+        (let [d @decision]
+          (if (and (vector? d) (= :skip-dead (first d)))
+            (let [{:keys [cancel-token]} (second d)]
+              ;; Self-cleaning: this waiter was cancelled and we're
+              ;; consuming (skipping) it now — the cancel-token is no
+              ;; longer needed. Drop it so cancelled-tokens doesn't
+              ;; accumulate one entry per signal-change × waiter over the
+              ;; context's lifetime. See `effects/await.cljc::
+              ;; cancellable-external-pair` for the Deferred/ifn? side of
+              ;; the same self-cleaning story.
+              (when (and cancel-token cancelled-tokens
+                         (contains? cancelled-tokens cancel-token))
+                (rtp/swap-state! context [:engine/cancelled-tokens]
+                                 (fn [s] (if s (disj s cancel-token) s))))
               (recur))
-
-            :else
-            ;; Resume-as-event (#27 Phase B): the waiter was popped by the
-            ;; swap above (one-shot); hand it to the drain as its own
-            ;; event. The handler re-checks cancellation AT PROCESSING
-            ;; time and — because the event carries the mailbox — can
-            ;; RE-POST the message losslessly if the waiter was cancelled
-            ;; in the enqueue→process window. Failure routing (reject the
-            ;; owning spin on throw) lives in the handler.
-            (do
-              (enqueue-cont-resume! context {:site :mailbox
-                                             :spin-id spin-id
-                                             :cancel-token cancel-token
-                                             :resolve resolve
-                                             :value msg
-                                             :mailbox mailbox})
-              nil))
-          ;; No waiter, message queued
-          nil)))))
+            ;; :queued or :handoff — done.
+            nil))))))
 
 ;; =============================================================================
 ;; Engine state wiring

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -18,6 +18,7 @@
   (:refer-clojure :exclude [node])
   (:require [replikativ.logging :as log]
             [org.replikativ.spindel.engine.executor :as executor]
+            [org.replikativ.spindel.engine.fault :as fault]
             [org.replikativ.spindel.engine.protocols :as rtp]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.bindings :as bindings]
@@ -138,14 +139,99 @@
 
 ;; Forward declaration for generation boundary cleanup
 (declare clear-all-await-continuations!)
+(declare cache-result!)
 
 ;; =============================================================================
 ;; Inline delivery/posting (to avoid cyclic dependency with spin/sync)
 ;; =============================================================================
 
+(defn- reject-owning-spin!
+  "Route a throw out of a resumed waiter/reader continuation to the
+  OWNING spin's reject path, so the failure is a loud crash of exactly
+  that consumer (Erlang-style) instead of a silently-forever-PENDING
+  spin. This is the failure-routing half of the at-most-once handoff
+  contract: a continuation that partially executed can never be
+  re-delivered (bodies are not idempotent — no effect log exists), so
+  the only sound continuation is rejection + supervision.
+
+  Two routes, in preference order:
+
+  1. The parked cont's `:reject-fn` — the waiter carries the
+     `:cancel-token` that `effects/await.cljc::cancellable-external-pair`
+     also stamped on the `:external-await` cont it registered in
+     `[:await-conts spin-id]`. Matching by token targets EXACTLY the
+     await this waiter belongs to (no blanket rejection of unrelated
+     parked awaits → no zombie-cont risk), and invoking its
+     `:reject-fn` resumes the body into its reject path: `catch`/
+     `finally` run, the error is cached, `abort-spin-chain!` cascades,
+     and — critically — the Spin invoke's LOCAL callbacks fire, which
+     is what `spawn!`'s `:on-error` and therefore `spin/supervisor`
+     restart policies ride on. (A bare node-write would notify awaiting
+     parents only; pumps/consumers are *spawned*, not awaited.) This
+     mirrors `spin.core/cancel-spin!` step (2), replicated here because
+     `spin.core` requires this namespace (cycle).
+
+  2. Fallback (no matching cont — e.g. a waiter registered through the
+     Mailbox/Deferred 2-arity directly, outside `await`): write the
+     error into the node and drive the engine-level completion cascade
+     + pending callbacks. If not even a node exists there is nothing to
+     reject — the caller reports the fault and that is all that can be
+     done.
+
+  Residual exposure (accepted, same as `cancel-spin!`): if the throw
+  happened in glue AFTER the resumed slice advanced through a further
+  breakpoint, the matched cont's reject unwinds a slice the body
+  already left. The window is glue-only (body slices are safe-r
+  wrapped) and strictly better than the alternative (silent wedge)."
+  [context spin-id cancel-token error]
+  (let [conts (rtp/get-state context [:await-conts spin-id])
+        [cont-id cont] (when cancel-token
+                         (first (filter (fn [[_cid c]]
+                                          (= (:cancel-token c) cancel-token))
+                                        conts)))]
+    (if cont
+      (do
+        (try
+          (binding [ec/*execution-context* context
+                    ec/*spin-id* spin-id
+                    pcps-async/*in-trampoline* false]
+            (when-let [rj (:reject-fn cont)] (rj error)))
+          (catch #?(:clj Throwable :cljs :default) _ nil))
+        (rtp/swap-state! context [:await-conts spin-id]
+                         (fn [m] (dissoc m cont-id))))
+      (when (rtp/get-state context [:nodes spin-id])
+        ;; Same raw {:variant :error} map shape the drain's
+        ;; :spin-completion catch writes — deliberately not spin.core's
+        ;; Result record (cycle).
+        (cache-result! context spin-id {:variant :error :payload error})
+        (enqueue-completion-event! context spin-id)
+        (doseq [{:keys [reject]} (take-pending-callbacks! context spin-id)]
+          (try (reject error)
+               (catch #?(:clj Throwable :cljs :default) _ nil)))))
+    nil))
+
+(defn- guarded-resume!
+  "Invoke a waiter/reader continuation with the uniform failure route:
+  on throw, restore the interrupt flag (JVM, if it was an interrupt),
+  report through the engine fault hook, and reject the owning spin via
+  `reject-owning-spin!`. `site` names the delivery path for the fault
+  report; `spin-id`/`cancel-token` come from the waiter entry and may
+  be nil (waiter registered outside a spin body → report-only)."
+  [context site spin-id cancel-token resolve value]
+  (try
+    (pcps-async/invoke-continuation resolve value)
+    (catch #?(:clj Throwable :cljs :default) e
+      #?(:clj (when (instance? InterruptedException e)
+                (.interrupt (Thread/currentThread))))
+      (fault/report-fault! ::fault/continuation-fault
+                           {:site site :spin-id spin-id :error e})
+      (when spin-id
+        (reject-owning-spin! context spin-id cancel-token e))
+      nil)))
+
 (defn- deliver-inline!
   "INTERNAL: Deliver value inline to deferred, resuming readers directly."
-  [deferred value state-atom]
+  [context deferred value state-atom]
   (let [;; Atomically check if already assigned and capture pending callbacks
         pending-callbacks (atom nil)
         _assigned? (swap! state-atom
@@ -167,11 +253,17 @@
     ;; Deferred 2-arity stores cancellation metadata so it can prune cancelled
     ;; readers). The wrapped `:resolve` already no-ops if its await was
     ;; cancelled, so we can invoke them all; the metadata is for the
-    ;; prune-on-read sweep, not needed here.
+    ;; prune-on-read sweep — and for failure routing here.
     ;; Event handler already bound *in-trampoline* false
+    ;;
+    ;; PER-READER isolation: each resume runs under guarded-resume!, so
+    ;; reader k throwing (a) cannot strand readers k+1..n — they never ran
+    ;; and still get the value — and (b) rejects reader k's own spin
+    ;; instead of leaving it PENDING. Same isolation shape PR #28 gave
+    ;; mult's watchers; a deferred with N readers is the same fan-out.
     (when-let [pending @pending-callbacks]
-      (doseq [{:keys [resolve]} pending]
-        (pcps-async/invoke-continuation resolve value)))
+      (doseq [{:keys [spin-id cancel-token resolve]} pending]
+        (guarded-resume! context :deferred spin-id cancel-token resolve value)))
 
     ;; Return the assigned value
     (:value @state-atom)))
@@ -198,10 +290,8 @@
   — the swap-state above only popped a waiter and didn't put the msg
   anywhere; the next iteration finds the next waiter (or pushes the msg
   to `:queue` if no more waiters)."
-  [mailbox msg state-atom]
-  (let [ctx (try (ec/current-execution-context)
-                 (catch #?(:clj Throwable :cljs :default) _ nil))
-        cancelled-tokens (when ctx (rtp/get-state ctx [:engine/cancelled-tokens]))]
+  [context mailbox msg state-atom]
+  (let [cancelled-tokens (rtp/get-state context [:engine/cancelled-tokens])]
     (loop []
       (let [waiter-to-try (atom nil)
             _result (swap! state-atom
@@ -226,14 +316,17 @@
               ;; one entry per signal-change × waiter over the context's
               ;; lifetime. See `effects/await.cljc::cancellable-external-pair`
               ;; for the Deferred/ifn? side of the same self-cleaning story.
-              (when ctx
-                (rtp/swap-state! ctx [:engine/cancelled-tokens]
-                                 (fn [s] (if s (disj s cancel-token) s))))
+              (rtp/swap-state! context [:engine/cancelled-tokens]
+                               (fn [s] (if s (disj s cancel-token) s)))
               (recur))
 
             :else
+            ;; Failure routing: a throw out of the resumed consumer rejects
+            ;; THAT consumer's spin (loud, supervisable) — the message is
+            ;; consumed either way (at-most-once; a partially-run
+            ;; continuation is not re-runnable). See guarded-resume!.
             (do
-              (pcps-async/invoke-continuation resolve msg)
+              (guarded-resume! context :mailbox spin-id cancel-token resolve msg)
               nil))
           ;; No waiter, message queued
           nil)))))
@@ -832,7 +925,35 @@
                 ;; created). The cont's own :resume-fn carries the
                 ;; monadic resolve/reject routing on the child's Result
                 ;; (see spin-await-cont-map in effects/await.cljc).
-                (resume-body! context parent-id cont :await))))))
+                ;;
+                ;; PER-PARENT isolation + failure routing: one parent's
+                ;; throwing resume must not strand the sibling parents in
+                ;; this doseq, and the thrower itself must reject loudly
+                ;; instead of staying suspended. On throw, unwind the
+                ;; parent via THIS cont's :reject-fn (the parent body's
+                ;; reject continuation — catch/finally run, spawn!/
+                ;; supervisor callbacks fire; mirrors cancel-spin!'s
+                ;; :await-once branch), then drop the spent cont. The
+                ;; drain-level :spin-completion catch remains as a
+                ;; backstop but should no longer fire for resume throws.
+                (try
+                  (resume-body! context parent-id cont :await)
+                  (catch #?(:clj Throwable :cljs :default) e
+                    #?(:clj (when (instance? InterruptedException e)
+                              (.interrupt (Thread/currentThread))))
+                    (fault/report-fault! ::fault/continuation-fault
+                                         {:site :spin-completion
+                                          :spin-id parent-id
+                                          :child-id tid
+                                          :error e})
+                    (try
+                      (binding [ec/*execution-context* context
+                                ec/*spin-id* parent-id
+                                pcps-async/*in-trampoline* false]
+                        (when-let [rj (:reject-fn cont)] (rj e)))
+                      (catch #?(:clj Throwable :cljs :default) _ nil))
+                    (rtp/swap-state! context [:await-conts parent-id]
+                                     (fn [m] (dissoc m cont-id))))))))))
 
       ;; Propagate dirty flag through await dependency graph
       (propagate-await-dirty! context tid)
@@ -854,7 +975,7 @@
       ;; CRITICAL: Bind *execution-context* so current-execution-context returns correct context
       (binding [ec/*execution-context* context
                 pcps-async/*in-trampoline* false]
-        (deliver-inline! deferred value state-atom))
+        (deliver-inline! context deferred value state-atom))
       nil)
 
     :mailbox-post
@@ -869,7 +990,7 @@
       ;; The mailbox function will resume continuations which need context access
       (binding [ec/*execution-context* context
                 pcps-async/*in-trampoline* false]
-        (post-inline! mailbox msg state-atom))
+        (post-inline! context mailbox msg state-atom))
       nil)
 
     :spin-execution
@@ -1017,7 +1138,12 @@
                             ;; abort the entire drain session.
                             (try
                               (process-event! context event)
-                              (catch #?(:clj Throwable :cljs js/Error) e
+                              ;; :cljs :default, NOT js/Error — CLJS code can
+                              ;; throw non-Error values (strings, keywords,
+                              ;; maps); js/Error would let those abort the
+                              ;; whole drain session and skip the recovery
+                              ;; dispatch below.
+                              (catch #?(:clj Throwable :cljs :default) e
                                 (log/error :engine/event-processing-error {:event-type (:type event)
                                                                            :event-id (:id event)
                                                                            :error #?(:clj (.getMessage ^Throwable e) :cljs (str e))})

--- a/src/org/replikativ/spindel/engine/state_backend.cljc
+++ b/src/org/replikativ/spindel/engine/state_backend.cljc
@@ -24,6 +24,23 @@
     For empty path, f is applied to entire state.
     For non-empty path, f is applied to value at path.")
 
+  (backend-write-2! [backend path-a path-b f2]
+    "Atomically transform the values at TWO paths in one commit.
+
+    `f2` receives the current values `[a b]` and returns `[a' b']`;
+    both are written in the same atomic state transition. This is the
+    transactional-handoff primitive (issue #27 Phase C): popping a
+    waiter from a primitive's state and appending its resume event to
+    `[:engine/pending]` must be ONE transition, so a wakeup obligation
+    is never in zero places (lost) or two places (double delivery).
+
+    `f2` may be retried (CAS semantics) — it must be pure apart from
+    idempotent volatile! captures. Returns nil.
+
+    A single-function two-path op (not independent per-path fns)
+    because the second write depends on the first's outcome: whether a
+    waiter was popped decides whether an event is appended.")
+
   (backend-deref [backend]
     "Dereference entire state map (for inspection/serialization).")
 
@@ -46,6 +63,15 @@
       (swap! state-atom f)
       ;; Swap at path
       (get-in (swap! state-atom update-in path f) path)))
+
+  (backend-write-2! [_ path-a path-b f2]
+    (swap! state-atom
+           (fn [m]
+             (let [[a' b'] (f2 (get-in m path-a) (get-in m path-b))]
+               (-> m
+                   (assoc-in path-a a')
+                   (assoc-in path-b b')))))
+    nil)
 
   (backend-deref [_]
     @state-atom)
@@ -231,6 +257,34 @@
            (swap! overlay-atom update-in path f)
            path)))))
 
+  (backend-write-2! [_ path-a path-b f2]
+    ;; Both paths committed in ONE swap on the overlay atom — atomic
+    ;; within this fork. Shared paths are CoW-seeded from the parent
+    ;; exactly like backend-write!'s single-path branches (entity level
+    ;; for depth ≥ 2, whole value for depth 1); fork-local paths write
+    ;; directly. After seeding, the fork has diverged from the parent's
+    ;; copy — the standard overlay CoW semantic.
+    (letfn [(seed [ov path]
+              (if (or (fork-local-path? (first path) local-paths)
+                      (nil? parent-backend))
+                ov
+                (let [seed-path (if (>= (count path) 2)
+                                  (vec (take 2 path)) ;; entity-level CoW
+                                  path)]
+                  (if (not= ::not-found (get-in ov seed-path ::not-found))
+                    ov
+                    (if-some [parent-val (backend-read parent-backend seed-path)]
+                      (assoc-in ov seed-path parent-val)
+                      ov)))))]
+      (swap! overlay-atom
+             (fn [ov]
+               (let [ov (-> ov (seed path-a) (seed path-b))
+                     [a' b'] (f2 (get-in ov path-a) (get-in ov path-b))]
+                 (-> ov
+                     (assoc-in path-a a')
+                     (assoc-in path-b b'))))))
+    nil)
+
   (backend-deref [_]
     ;; Return overlay only (not merged with parent)
     ;; This is intentional - deref shows what's in this layer
@@ -319,6 +373,11 @@
     (throw (ex-info "Cannot write to immutable backend - use thaw-snapshot first"
                     {:backend-type :immutable
                      :path path})))
+
+  (backend-write-2! [_ path-a path-b _f2]
+    (throw (ex-info "Cannot write to immutable backend - use thaw-snapshot first"
+                    {:backend-type :immutable
+                     :path [path-a path-b]})))
 
   (backend-deref [_]
     state-map)

--- a/src/org/replikativ/spindel/pubsub/mult.cljc
+++ b/src/org/replikativ/spindel/pubsub/mult.cljc
@@ -15,6 +15,7 @@
   (:refer-clojure :exclude [await])
   (:require [is.simm.partial-cps.sequence :refer [PAsyncSeq anext]]
             [org.replikativ.spindel.pubsub.buffer :as buf]
+            [org.replikativ.spindel.pubsub.promise :as promise]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.fault :as fault]
@@ -42,77 +43,18 @@
   (fault/report-fault! event data))
 
 ;; =============================================================================
-;; Simple Promise for Coordination (no runtime required)
+;; Coordination promise — shared engine-mediated implementation.
+;; Delivery routes each watcher through its OWN ctx's drain as a
+;; :cont-resume event (resume-as-event, #27 Phase B): fault isolation,
+;; cancellation re-check and cross-ctx completion are structural now —
+;; the local make-promise copy (inline watchers on the producer's
+;; stack + per-watcher try/catch + cross-ctx rebinding wrapper) is gone.
+;; See pubsub/promise.cljc.
 ;; =============================================================================
 
-(defn- make-promise
-  "Create a simple promise that can be delivered once and read multiple times.
-   Uses a standard Clojure atom - no runtime dependency.
-   Uses compare-and-set! instead of swap! to avoid side effects inside retry-able swap fns.
-
-   ## Cross-ctx delivery fix
-   The watcher is the awaiter's `resolve` CPS continuation. When the
-   producer's thread invokes it via `deliver!`, the Clojure dynamic var
-   `*execution-context*` is whatever the producer has bound — often a
-   different execution context from the one that registered the
-   watcher. Without restoring the awaiter's ctx, the completion event
-   gets enqueued on the producer's ctx, where no await-cont is
-   registered for the awaiter's parent, and the parent deadlocks.
-
-   We capture `*execution-context*` at `await-spin` construction
-   (before the watcher is added) and re-establish it around the
-   watcher invocation so the spin completes against its own ctx."
-  []
-  (let [state (atom {:delivered? false :value nil :watchers []})]
-    {:state state
-     :deliver! (fn [value]
-                 (loop []
-                   (let [s @state]
-                     (if (:delivered? s)
-                       value  ;; Already delivered - no-op
-                       (if (compare-and-set! state s {:delivered? true :value value :watchers []})
-                         ;; CAS succeeded - notify watchers from the state we replaced.
-                         ;; Each watcher resumes a consumer spin; a watcher runs ON
-                         ;; THE PRODUCER'S STACK (the source pump), so an unguarded
-                         ;; throw there unwinds INTO the pump, cancels its await cont,
-                         ;; and wedges the whole bus (dossier: bug-bus-source-pump-
-                         ;; lost-waiter). Isolate each consumer fault: report it, keep
-                         ;; delivering to the other watchers, never propagate to the
-                         ;; producer.
-                         (do (doseq [w (:watchers s)]
-                               (try (w value)
-                                    (catch #?(:clj Throwable :cljs :default) e
-                                      (report-fault! ::watcher-fault {:error e}))))
-                             value)
-                         ;; CAS failed (concurrent modification) - retry
-                         (recur))))))
-     :await-spin (fn []
-                   (let [captured-ctx (try (ec/current-execution-context)
-                                           (catch #?(:clj Throwable :cljs :default) _ nil))]
-                     (spin-core/make-spin
-                      (fn [resolve _reject]
-                        ;; Wrap resolve so the completion fires against the
-                        ;; ctx that registered the await, not the producer's.
-                        (let [wrapped (if captured-ctx
-                                        (fn [v]
-                                          (binding [ec/*execution-context* captured-ctx]
-                                            (resolve v)))
-                                        resolve)]
-                          (loop []
-                            (let [s @state]
-                              (if (:delivered? s)
-                                (wrapped (:value s))
-                                ;; Try to add watcher via CAS
-                                (when-not (compare-and-set! state s (update s :watchers conj wrapped))
-                                  ;; CAS failed - retry (will re-check delivered? on next iteration)
-                                  (recur))))))
-                        spin-core/incomplete))))}))
-
-(defn- deliver-promise! [p value]
-  ((:deliver! p) value))
-
-(defn- promise-spin [p]
-  ((:await-spin p)))
+(def ^:private make-promise promise/make-promise)
+(def ^:private deliver-promise! promise/deliver-promise!)
+(def ^:private promise-spin promise/promise-spin)
 
 ;; =============================================================================
 ;; TapSeq - Per-tap async sequence

--- a/src/org/replikativ/spindel/pubsub/mult.cljc
+++ b/src/org/replikativ/spindel/pubsub/mult.cljc
@@ -17,31 +17,29 @@
             [org.replikativ.spindel.pubsub.buffer :as buf]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.fault :as fault]
             #?(:clj [org.replikativ.spindel.spin.cps :refer [spin]])
             [org.replikativ.spindel.effects.await :refer [await]])
   #?(:cljs (:require-macros [org.replikativ.spindel.spin.cps :refer [spin]])))
 
 ;; =============================================================================
-;; Fault reporting (spindel carries no logging dep — loud by default, overridable)
+;; Fault reporting — delegates to the engine-wide hook (engine/fault.cljc)
 ;; =============================================================================
 
-(defonce ^:private fault-reporter
-  ;; Default: stderr / console.error so a fault is never silently swallowed.
-  ;; Embedders route it into their own logging via `set-fault-reporter!`.
-  (atom (fn [event data]
-          #?(:clj  (binding [*out* *err*]
-                     (println "[spindel.mult]" event (pr-str data)))
-             :cljs (js/console.error "[spindel.mult]" (str event) (clj->js data))))))
-
 (defn set-fault-reporter!
-  "Override how mult reports isolated consumer faults (`::watcher-fault`) and
-   pump rejections (`::pump-rejected`). `f` is (fn [event-keyword data-map]).
-   Default writes to stderr / console.error. simmis routes these into Telemere."
-  [f] (reset! fault-reporter f))
+  "Override how engine faults are reported — `::pump-rejected` here plus
+   ALL engine fault events (`engine.fault/continuation-fault`,
+   `engine.fault/executor-task-fault`, …). `f` is
+   (fn [event-keyword data-map]). Default writes to stderr /
+   console.error. simmis routes these into Telemere.
+
+   Since the reporter was hoisted to `engine/fault.cljc`, this is a
+   delegating alias kept for API compatibility — it sets the ENGINE-WIDE
+   hook, not a mult-local one."
+  [f] (fault/set-fault-reporter! f))
 
 (defn- report-fault! [event data]
-  (try (@fault-reporter event data)
-       (catch #?(:clj Throwable :cljs :default) _ nil)))
+  (fault/report-fault! event data))
 
 ;; =============================================================================
 ;; Simple Promise for Coordination (no runtime required)

--- a/src/org/replikativ/spindel/pubsub/partitioned.cljc
+++ b/src/org/replikativ/spindel/pubsub/partitioned.cljc
@@ -18,6 +18,7 @@
   (:require [is.simm.partial-cps.sequence :refer [PAsyncSeq anext]]
             [org.replikativ.spindel.pubsub.mult :as mult]
             [org.replikativ.spindel.pubsub.buffer :as buf]
+            [org.replikativ.spindel.pubsub.promise :as promise]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.spin.sync :as sync]
             [org.replikativ.spindel.engine.core :as ec]
@@ -30,47 +31,14 @@
 ;; Internal: per-partition push-based async seq
 ;; =============================================================================
 
-(defn- make-promise
-  "Simple promise for coordination (same pattern as mult.cljc — see that
-   ns for the cross-ctx-delivery rationale behind capturing ctx at
-   await-spin construction and re-binding it around the watcher
-   invocation)."
-  []
-  (let [state (atom {:delivered? false :value nil :watchers []})]
-    {:state state
-     :deliver! (fn [value]
-                 (loop []
-                   (let [s @state]
-                     (if (:delivered? s)
-                       value
-                       (if (compare-and-set! state s {:delivered? true :value value :watchers []})
-                         (do (doseq [w (:watchers s)]
-                               (w value))
-                             value)
-                         (recur))))))
-     :await-spin (fn []
-                   (let [captured-ctx (try (ec/current-execution-context)
-                                           (catch #?(:clj Throwable :cljs :default) _ nil))]
-                     (spin-core/make-spin
-                      (fn [resolve _reject]
-                        (let [wrapped (if captured-ctx
-                                        (fn [v]
-                                          (binding [ec/*execution-context* captured-ctx]
-                                            (resolve v)))
-                                        resolve)]
-                          (loop []
-                            (let [s @state]
-                              (if (:delivered? s)
-                                (wrapped (:value s))
-                                (when-not (compare-and-set! state s (update s :watchers conj wrapped))
-                                  (recur))))))
-                        spin-core/incomplete))))}))
-
-(defn- deliver-promise! [p value]
-  ((:deliver! p) value))
-
-(defn- promise-spin [p]
-  ((:await-spin p)))
+;; Coordination promise — shared engine-mediated implementation
+;; (pubsub/promise.cljc). Watcher delivery routes through the watcher's
+;; own ctx drain as a :cont-resume event, which subsumes both the
+;; cross-ctx rebinding this copy carried AND the per-watcher fault
+;; isolation it never got (PR #28 only patched mult's copy).
+(def ^:private make-promise promise/make-promise)
+(def ^:private deliver-promise! promise/deliver-promise!)
+(def ^:private promise-spin promise/promise-spin)
 
 (defrecord PartitionSource
            [;; atom of vector of items

--- a/src/org/replikativ/spindel/pubsub/promise.cljc
+++ b/src/org/replikativ/spindel/pubsub/promise.cljc
@@ -1,0 +1,116 @@
+(ns ^:no-doc org.replikativ.spindel.pubsub.promise
+  "Internal single-delivery promise used by the pubsub coordination
+  layers (mult / pub / partitioned) for their item-available /
+  space-available signalling.
+
+  Replaces the three private `make-promise` copies that previously
+  lived in mult.cljc, pub.cljc and partitioned.cljc — each of which ran
+  its watchers INLINE ON THE DELIVERER'S STACK. That was the last place
+  engine continuations executed on arbitrary foreign threads
+  (`untap!` / `close-tap!` / `publish!` are called from user threads),
+  and only mult's copy had the PR #28 per-watcher fault isolation.
+
+  Resume-as-event (#27 Phase B): `deliver!` now hands each watcher to
+  the drain of the CONTEXT THE WATCHER WAS REGISTERED UNDER as a
+  `:cont-resume` event. That gives every watcher:
+  - execution on engine-owned threads with the right
+    `*execution-context*` / `*in-trampoline*` bound by the handler
+    (deleting the cross-ctx rebinding wrapper each copy carried);
+  - the drain's uniform cancellation re-check (`spin-is-cancelled?` on
+    the registering spin) and failure route (fault report + owning-spin
+    rejection) — structural isolation instead of a local try/catch.
+
+  Enqueueing on the WATCHER's ctx (not the deliverer's) preserves the
+  fork semantics the old wrapper existed for: a fork-ctx pump delivering
+  to awaiters registered on the parent ctx completes them against their
+  own ctx (see pubsub/fork_ctx_reentrancy_test.cljc).
+
+  A watcher registered with NO reachable context (a raw `:await-spin`
+  invocation outside the engine — tests, embedder glue) degenerates to
+  a guarded inline invoke: fault-reported, never silently swallowed,
+  never propagated to the deliverer.
+
+  The promise itself is a plain JVM/JS atom, NOT ctx-backed state:
+  per-item promises are created on the pump hot path (one per item per
+  tap), and ctx-backed atoms would grow context state without bound and
+  tax every fork copy."
+  (:require [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.fault :as fault]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [is.simm.partial-cps.async :as pcps-async]))
+
+(defn- deliver-to-watcher!
+  "Route one watcher's resume: through the watcher's own ctx drain as a
+  `:cont-resume` event when a ctx was captured at registration, else a
+  guarded inline invoke on the deliverer's stack (degenerate path)."
+  [{:keys [ctx spin-id resolve]} value]
+  (if ctx
+    (rtp/enqueue! ctx {:type :cont-resume
+                       :site :promise
+                       :spin-id spin-id
+                       :resolve resolve
+                       :value value})
+    (try
+      (pcps-async/invoke-continuation resolve value)
+      (catch #?(:clj Throwable :cljs :default) e
+        #?(:clj (when (instance? InterruptedException e)
+                  (.interrupt (Thread/currentThread))))
+        (fault/report-fault! ::fault/continuation-fault
+                             {:site :promise :spin-id spin-id :error e})))))
+
+(defn make-promise
+  "Create a single-delivery promise: delivered once, readable many
+  times. Returns `{:state atom, :deliver! (fn [value]), :await-spin
+  (fn [] spin)}` — the exact contract of the three former private
+  copies. Uses compare-and-set! so no side effects run inside a
+  retry-able swap fn."
+  []
+  (let [state (atom {:delivered? false :value nil :watchers []})]
+    {:state state
+     :deliver!
+     (fn [value]
+       (loop []
+         (let [s @state]
+           (if (:delivered? s)
+             value ;; Already delivered - no-op
+             (if (compare-and-set! state s {:delivered? true :value value :watchers []})
+               ;; CAS succeeded — watchers were removed atomically with
+               ;; the delivery (one-shot by construction), so each may be
+               ;; handed to the drain as its own :cont-resume event.
+               (do (doseq [w (:watchers s)]
+                     (deliver-to-watcher! w value))
+                   value)
+               ;; CAS failed (concurrent modification) - retry
+               (recur))))))
+     :await-spin
+     (fn []
+       (spin-core/make-spin
+        (fn [resolve _reject]
+          ;; Capture the registering spin's identity NOW — the handler
+          ;; re-checks cancellation against it at delivery time, and the
+          ;; ctx is where the resume event must be enqueued.
+          (let [ctx (try (ec/current-execution-context)
+                         (catch #?(:clj Throwable :cljs :default) _ nil))
+                watcher {:ctx ctx
+                         :spin-id ec/*spin-id*
+                         :resolve resolve}]
+            (loop []
+              (let [s @state]
+                (if (:delivered? s)
+                  ;; Fast path: already delivered — same-spin inline
+                  ;; resume on the awaiting body's own stack (the spin is
+                  ;; the subject of the currently executing work; its
+                  ;; failure route is armed by its own CPS wrapping).
+                  (resolve (:value s))
+                  ;; Try to add watcher via CAS
+                  (when-not (compare-and-set! state s (update s :watchers conj watcher))
+                    ;; CAS failed - retry (re-checks delivered? next round)
+                    (recur))))))
+          spin-core/incomplete)))}))
+
+(defn deliver-promise! [p value]
+  ((:deliver! p) value))
+
+(defn promise-spin [p]
+  ((:await-spin p)))

--- a/src/org/replikativ/spindel/pubsub/pub.cljc
+++ b/src/org/replikativ/spindel/pubsub/pub.cljc
@@ -17,6 +17,7 @@
   (:refer-clojure :exclude [await])
   (:require [is.simm.partial-cps.sequence :refer [PAsyncSeq anext]]
             [org.replikativ.spindel.pubsub.mult :as mult]
+            [org.replikativ.spindel.pubsub.promise :as promise]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.engine.core :as ec]
             #?(:clj [org.replikativ.spindel.spin.cps :refer [spin]])
@@ -27,56 +28,14 @@
 ;; Internal Topic Mult Management
 ;; =============================================================================
 
-;; Simple promise (same as in mult.cljc).
-;; The await-spin captures *execution-context* at construction time and
-;; re-binds it around the watcher's resolve invocation, so a producer
-;; that delivers from a different ctx (e.g. a fork-ctx pump signaling
-;; awaiters registered on a parent ctx) still enqueues the awaiter's
-;; :spin-completion event on the awaiter's own ctx. See the same
-;; comment in mult.cljc/make-promise for details.
-(defn- make-promise
-  "Create a simple promise that can be delivered once and read multiple times.
-   Uses compare-and-set! instead of swap! to avoid side effects inside retry-able swap fns."
-  []
-  (let [state (atom {:delivered? false :value nil :watchers []})]
-    {:state state
-     :deliver! (fn [value]
-                 (loop []
-                   (let [s @state]
-                     (if (:delivered? s)
-                       value  ;; Already delivered - no-op
-                       (if (compare-and-set! state s {:delivered? true :value value :watchers []})
-                         ;; CAS succeeded - notify watchers from the state we replaced
-                         (do (doseq [w (:watchers s)]
-                               (w value))
-                             value)
-                         ;; CAS failed (concurrent modification) - retry
-                         (recur))))))
-     :await-spin (fn []
-                   (let [captured-ctx (try (ec/current-execution-context)
-                                           (catch #?(:clj Throwable :cljs :default) _ nil))]
-                     (spin-core/make-spin
-                      (fn [resolve _reject]
-                        (let [wrapped (if captured-ctx
-                                        (fn [v]
-                                          (binding [ec/*execution-context* captured-ctx]
-                                            (resolve v)))
-                                        resolve)]
-                          (loop []
-                            (let [s @state]
-                              (if (:delivered? s)
-                                (wrapped (:value s))
-                                ;; Try to add watcher via CAS
-                                (when-not (compare-and-set! state s (update s :watchers conj wrapped))
-                                  ;; CAS failed - retry (will re-check delivered? on next iteration)
-                                  (recur))))))
-                        spin-core/incomplete))))}))
-
-(defn- deliver-promise! [p value]
-  ((:deliver! p) value))
-
-(defn- promise-spin [p]
-  ((:await-spin p)))
+;; Coordination promise — shared engine-mediated implementation
+;; (pubsub/promise.cljc). Watcher delivery routes through the watcher's
+;; own ctx drain as a :cont-resume event, which subsumes both the
+;; cross-ctx rebinding this copy carried AND the per-watcher fault
+;; isolation it never got (PR #28 only patched mult's copy).
+(def ^:private make-promise promise/make-promise)
+(def ^:private deliver-promise! promise/deliver-promise!)
+(def ^:private promise-spin promise/promise-spin)
 
 (defn- ensure-topic-mult!
   "Ensure a mult exists for the given topic. Creates one if needed.

--- a/src/org/replikativ/spindel/semaphore.cljc
+++ b/src/org/replikativ/spindel/semaphore.cljc
@@ -184,14 +184,20 @@
                 ;; would lose it.
                 (recur)
                 (do
-                  ;; Successfully dequeued a live waiter - schedule it on the
-                  ;; executor. alive-fn drops the callback if the context is
-                  ;; stopped before setTimeout fires (CLJS) — prevents stale
-                  ;; resumes from bleeding into a freshly-created context.
+                  ;; Successfully dequeued a live waiter — hand it to the
+                  ;; drain as a :cont-resume event (resume-as-event, #27
+                  ;; Phase B). The waiter is one-shot (popped by the CAS
+                  ;; above), so the event gives it the drain's uniform
+                  ;; cancellation re-check + failure route instead of a
+                  ;; bare executor task whose throw nothing routes. The
+                  ;; drain's entry guard drops events on a stopped
+                  ;; context, covering what alive-fn covered here.
                   (let [ctx ec/*execution-context*]
-                    (executor/execute! (:executor ctx)
-                                       (executor/alive-fn ctx
-                                                          #(spin/resume (:resolve waiter) :acquired))))
+                    (rtp/enqueue! ctx {:type :cont-resume
+                                       :site :semaphore
+                                       :spin-id (:spin-id waiter)
+                                       :resolve (:resolve waiter)
+                                       :value :acquired}))
                   :released))
               ;; CAS failed - retry
               (recur)))

--- a/src/org/replikativ/spindel/spin/sync.cljc
+++ b/src/org/replikativ/spindel/spin/sync.cljc
@@ -285,6 +285,13 @@
    State is stored in fork-safe execution-context atom.
    Fork-safe - state is copied when execution-context is forked.
 
+   NOTE for health checks / monitoring: because the state atom is
+   ctx-backed (copy-on-write), dereffing it under a DIFFERENT execution
+   context returns that context's copy — e.g. `queue: 0` while the
+   owning ctx holds `queue: 10`. Probe under the owning ctx:
+   `(binding [ec/*execution-context* owning-ctx] @state-atom)`.
+   See engine.md §Threading contract.
+
    Example:
      (def mbx (create-mailbox execution-context))
      (mbx :msg)              ; Post message (returns nil)

--- a/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
+++ b/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
@@ -23,6 +23,7 @@
             [org.replikativ.spindel.engine.fault :as fault]
             [org.replikativ.spindel.engine.executor :as executor]
             [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.engine.state-backend :as backend]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.spin.sync :as sync]
             [org.replikativ.spindel.spin.supervisor :as sup]
@@ -213,6 +214,67 @@
                               (:interrupted? data)))
                        @faults)))
            (finally (restore!)))))))
+
+;; -----------------------------------------------------------------------------
+;; 4b. Phase C: transactional handoff + re-post-on-cancelled
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest cont-resume-reposts-message-for-waiter-cancelled-in-window
+     (testing "a :cont-resume whose waiter was cancelled between enqueue and
+             processing RE-POSTS the mailbox message instead of feeding it to
+             a gated no-op (lossless — nothing of the continuation ran)"
+       (th/with-ctx [ctx]
+         (let [mbx (sync/create-mailbox ctx)
+               token (keyword "external-await-cancel" (str (random-uuid)))
+               fired (atom false)]
+           ;; Simulate the race deterministically: the waiter's token is
+           ;; ALREADY in :engine/cancelled-tokens when its :cont-resume
+           ;; event (as post-inline! would have enqueued it) processes.
+           (rtp/swap-state! ctx [:engine/cancelled-tokens]
+                            (fn [s] (conj (or s #{}) token)))
+           (rtp/enqueue! ctx {:type :cont-resume
+                              :site :mailbox
+                              :spin-id nil
+                              :cancel-token token
+                              :resolve (fn [_] (reset! fired true))
+                              :value :msg-1
+                              :mailbox mbx})
+           (is (poll-until
+                #(= [:msg-1]
+                    (binding [ec/*execution-context* ctx]
+                      (vec (:queue @(.-state-atom mbx)))))
+                2000)
+               "message re-posted into the mailbox queue (no live waiter)")
+           (is (not @fired) "the cancelled waiter's continuation never ran")
+           (is (not (contains? (rtp/get-state ctx [:engine/cancelled-tokens]) token))
+               "the consumed cancel-token was self-cleaned"))))))
+
+#?(:clj
+   (deftest backend-write-2-is-atomic-and-cow-seeds
+     (testing "AtomBackend: both paths transformed in one commit"
+       (let [b (backend/create-atom-backend {:a {:x 1} :engine/pending []})]
+         (backend/backend-write-2! b [:a :x] [:engine/pending]
+                                   (fn [x pending]
+                                     [(inc x) (conj pending {:ev (inc x)})]))
+         (is (= 2 (backend/backend-read b [:a :x])))
+         (is (= [{:ev 2}] (backend/backend-read b [:engine/pending])))))
+     (testing "OverlayBackend: shared path CoW-seeds the entity from the
+             parent; fork-local path writes directly; parent untouched"
+       (let [parent (backend/create-atom-backend
+                     {:atoms {:mbx {:value {:queue [] :waiters [:w]}}}
+                      :engine/pending [:parent-event]})
+             fork (backend/create-overlay-backend parent)]
+         (backend/backend-write-2! fork [:atoms :mbx :value] [:engine/pending]
+                                   (fn [mbx-state pending]
+                                     [(update mbx-state :waiters rest)
+                                      (conj (vec pending) {:ev 1})]))
+         (is (= [] (vec (:waiters (backend/backend-read fork [:atoms :mbx :value]))))
+             "fork sees the popped waiter (CoW copy)")
+         (is (= [:w] (:waiters (backend/backend-read parent [:atoms :mbx :value])))
+             "parent's copy is untouched (fork diverged)")
+         (is (= [{:ev 1}] (backend/backend-read fork [:engine/pending]))
+             "fork-local pending written directly — parent's queue not read")))))
 
 ;; -----------------------------------------------------------------------------
 ;; 5. CLJS: non-Error throw values must not slip past the catches

--- a/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
+++ b/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
@@ -285,12 +285,12 @@
      (testing "a thrown string (non-Error) reaches the reject path — the
              :default catches must not miss it"
        (async done
-         (th/with-ctx [ctx]
-           (let [t (spin (throw "string-boom"))]
-             (th/run-spin! t
-                           (fn [_v]
-                             (is false "must not resolve")
-                             (done))
-                           (fn [e]
-                             (is (= "string-boom" e))
-                             (done)))))))))
+              (th/with-ctx [ctx]
+                (let [t (spin (throw "string-boom"))]
+                  (th/run-spin! t
+                                (fn [_v]
+                                  (is false "must not resolve")
+                                  (done))
+                                (fn [e]
+                                  (is (= "string-boom" e))
+                                  (done)))))))))

--- a/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
+++ b/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
@@ -1,0 +1,234 @@
+(ns org.replikativ.spindel.engine.lost-wakeup-test
+  "Regression tests for issue #27 (lost wakeup / silently wedged
+  consumers) — the failure-routing contract:
+
+  1. A throw inside a resumed spin BODY slice already rejects the spin
+     loudly (partial-cps `safe-r` + the spin macro's breakpoint
+     wrapping). Pinned here so a CPS-emission change can never silently
+     reintroduce the wedge.
+  2. A throw in the thin GLUE — a raw waiter/reader continuation
+     registered outside `await` — is reported through the engine fault
+     hook, does not kill the drain, and does not strand OTHER
+     readers/waiters (per-reader isolation in `deliver-inline!`, the
+     guarded resume in `post-inline!`).
+  3. `spin/supervisor` restart policies observe the failure (they ride
+     on `spawn!`'s `:on-error`), so a crashed consumer is restarted and
+     drains the backlog — the production wedge scenario, end to end.
+  4. Executor tasks that throw are reported, not swallowed in a
+     discarded Future (JVM) / lost to the global handler (CLJS)."
+  (:refer-clojure :exclude [await])
+  (:require #?(:clj [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer [deftest is testing] :include-macros true])
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.fault :as fault]
+            [org.replikativ.spindel.engine.executor :as executor]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.spin.sync :as sync]
+            [org.replikativ.spindel.spin.supervisor :as sup]
+            #?(:clj [org.replikativ.spindel.spin.cps :refer [spin]])
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.test-helpers :as th])
+  #?(:cljs (:require-macros [org.replikativ.spindel.spin.cps :refer [spin]]
+                            [org.replikativ.spindel.test-helpers :refer [with-ctx async]])))
+
+;; -----------------------------------------------------------------------------
+;; Helpers
+;; -----------------------------------------------------------------------------
+
+(defn- capture-faults!
+  "Install a capturing fault reporter; returns [faults-atom restore-fn]."
+  []
+  (let [orig (fault/current-fault-reporter)
+        faults (atom [])]
+    (fault/set-fault-reporter! (fn [ev data] (swap! faults conj [ev data])))
+    [faults (fn [] (fault/set-fault-reporter! orig))]))
+
+#?(:clj
+   (defn- poll-until
+     "Poll pred every 10ms up to timeout-ms. Returns (pred) truthiness."
+     [pred timeout-ms]
+     (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+       (loop []
+         (cond
+           (pred) true
+           (>= (System/currentTimeMillis) deadline) false
+           :else (do (Thread/sleep 10) (recur)))))))
+
+;; -----------------------------------------------------------------------------
+;; 1. Body throw → loud rejection (pins the CPS safety wrapper)
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest body-throw-rejects-spin-loudly-not-pending
+     (testing "a consumer whose body throws after (await mbx) REJECTS — spawn!'s
+             :on-error fires, the node holds :error, no silent PENDING"
+       (th/with-ctx [ctx]
+         (let [mbx (sync/create-mailbox ctx)
+               seen (atom [])
+               errs (atom [])
+               consumer (spin
+                         (loop []
+                           (let [m (await mbx)]
+                             (when (= m :boom)
+                               (throw (ex-info "kaboom" {:test true})))
+                             (swap! seen conj m)
+                             (recur))))]
+           (sync/spawn! consumer {:on-error (fn [e] (swap! errs conj e))})
+           (sync/post! mbx :a)
+           (is (poll-until #(= [:a] @seen) 2000) "consumer runs normally first")
+           (sync/post! mbx :boom)
+           (is (poll-until #(seq @errs) 2000)
+               "spawn! :on-error observed the body throw (loud failure)")
+           (is (= "kaboom" (ex-message (first @errs))))
+           (let [node (rtp/get-state ctx [:nodes (spin-core/spin-id consumer)])]
+             (is (not (:running? node)) "consumer is not stuck running")
+             (is (= :error (some-> node :result :variant))
+                 "consumer's node carries the error result — not PENDING")))))))
+
+;; -----------------------------------------------------------------------------
+;; 2a. Raw deferred readers: per-reader isolation + fault report
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest deferred-raw-reader-isolation
+     (testing "reader 2 throwing (raw glue, outside await/safe-r) must not
+             strand readers 1 and 3, and must be reported"
+       (let [[faults restore!] (capture-faults!)]
+         (try
+           (th/with-ctx [ctx]
+             (let [d (sync/create-deferred ctx)
+                   called (atom [])]
+               ;; Raw readers via the 2-arity — deliberately BYPASSES await's
+               ;; safe-r wrapping, modeling glue-level failure.
+               (d (fn [v] (swap! called conj [:r1 v])) (fn [_e] nil))
+               (d (fn [_v] (throw (ex-info "reader-2 glue boom" {}))) (fn [_e] nil))
+               (d (fn [v] (swap! called conj [:r3 v])) (fn [_e] nil))
+               (sync/deliver! d :val)
+               (is (poll-until #(= 2 (count @called)) 2000)
+                   "readers 1 and 3 both resolved despite reader 2's throw")
+               (is (= [[:r1 :val] [:r3 :val]] @called))
+               (is (poll-until #(seq @faults) 2000) "fault reported")
+               (let [[ev data] (first @faults)]
+                 (is (= ::fault/continuation-fault ev))
+                 (is (= :deferred (:site data))))))
+           (finally (restore!)))))))
+
+;; -----------------------------------------------------------------------------
+;; 2b. Raw mailbox waiter: drain survives, fault reported, mailbox usable
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest raw-mailbox-waiter-throw-reports-and-drain-survives
+     (testing "a raw waiter's throwing resolve is reported; the drain and the
+             mailbox keep working for subsequent takes"
+       (let [[faults restore!] (capture-faults!)]
+         (try
+           (th/with-ctx [ctx]
+             (let [mbx (sync/create-mailbox ctx)
+                   got (atom nil)]
+               (mbx (fn [_m] (throw (ex-info "waiter glue boom" {}))) (fn [_e] nil))
+               (sync/post! mbx :first)
+               (is (poll-until #(seq @faults) 2000) "fault reported")
+               (is (= :mailbox (:site (second (first @faults)))))
+               ;; The engine is still alive: a fresh waiter receives the next post.
+               (mbx (fn [m] (reset! got m)) (fn [_e] nil))
+               (sync/post! mbx :second)
+               (is (poll-until #(= :second @got) 2000)
+                   "drain survived — subsequent delivery works")))
+           (finally (restore!)))))))
+
+;; -----------------------------------------------------------------------------
+;; 3. Supervisor restarts a crashed consumer, which drains the backlog
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest supervisor-restarts-throwing-consumer
+     (testing "the production wedge scenario end-to-end: consumer crashes on a
+             poison message, supervisor restarts it, backlog drains"
+       (let [[_faults restore!] (capture-faults!)]
+         (try
+           (th/with-ctx [ctx]
+             (let [mbx (sync/create-mailbox ctx)
+                   seen (atom [])
+                   make-consumer (fn []
+                                   (spin
+                                    (loop []
+                                      (let [m (await mbx)]
+                                        (when (= m :boom)
+                                          (throw (ex-info "poison" {})))
+                                        (swap! seen conj m)
+                                        (recur)))))
+                   s (sup/supervisor
+                      [{:id :consumer :start make-consumer}]
+                      {:strategy :one-for-one
+                       :max-restarts 3
+                       :window-ms 60000})]
+               ;; The supervisor is itself a spin — spawn it to start the
+               ;; children + monitoring loop.
+               (sync/spawn! s)
+               (sync/post! mbx :a)
+               (is (poll-until #(= [:a] @seen) 2000))
+               (sync/post! mbx :boom)
+               (sync/post! mbx :c)
+               (is (poll-until #(= [:a :c] @seen) 4000)
+                   "restarted consumer drained the post-crash backlog")))
+           (finally (restore!)))))))
+
+;; -----------------------------------------------------------------------------
+;; 4. Executor task seam: escaped throws are reported, not swallowed
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest executor-task-fault-is-reported
+     (testing "a throw escaping an executor task lands in the fault hook
+             instead of a discarded Future"
+       (let [[faults restore!] (capture-faults!)]
+         (try
+           (th/with-ctx [ctx]
+             (executor/execute! (:executor ctx)
+                                (fn [] (throw (ex-info "task boom" {}))))
+             (is (poll-until #(some (fn [[ev _]]
+                                      (= ::fault/executor-task-fault ev))
+                                    @faults)
+                             2000)
+                 "executor task fault reported"))
+           (finally (restore!)))))))
+
+#?(:clj
+   (deftest guard-task-restores-interrupt-flag
+     (testing "an InterruptedException in a guarded task restores the thread's
+             interrupt flag and reports"
+       (let [[faults restore!] (capture-faults!)]
+         (try
+           (let [guarded (executor/guard-task
+                          (fn [] (throw (InterruptedException. "cancel"))))]
+             (guarded)
+             (is (.isInterrupted (Thread/currentThread))
+                 "interrupt flag restored for pool machinery")
+             ;; clear it so we don't poison the test runner's thread
+             (Thread/interrupted)
+             (is (some (fn [[ev data]]
+                         (and (= ::fault/executor-task-fault ev)
+                              (:interrupted? data)))
+                       @faults)))
+           (finally (restore!)))))))
+
+;; -----------------------------------------------------------------------------
+;; 5. CLJS: non-Error throw values must not slip past the catches
+;; -----------------------------------------------------------------------------
+
+#?(:cljs
+   (deftest non-error-throw-value-rejects-spin
+     (testing "a thrown string (non-Error) reaches the reject path — the
+             :default catches must not miss it"
+       (async done
+         (th/with-ctx [ctx]
+           (let [t (spin (throw "string-boom"))]
+             (th/run-spin! t
+                           (fn [_v]
+                             (is false "must not resolve")
+                             (done))
+                           (fn [e]
+                             (is (= "string-boom" e))
+                             (done)))))))))

--- a/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
+++ b/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
@@ -20,6 +20,8 @@
   (:require #?(:clj [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer [deftest is testing] :include-macros true])
             [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as ectx]
+            [org.replikativ.spindel.engine.impl.simple :as simple]
             [org.replikativ.spindel.engine.fault :as fault]
             [org.replikativ.spindel.engine.executor :as executor]
             [org.replikativ.spindel.engine.protocols :as rtp]
@@ -275,6 +277,85 @@
              "parent's copy is untouched (fork diverged)")
          (is (= [{:ev 1}] (backend/backend-read fork [:engine/pending]))
              "fork-local pending written directly — parent's queue not read")))))
+
+;; -----------------------------------------------------------------------------
+;; 4c. Forkability: in-flight data-bearing events are inherited by forks
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest fork-inherits-in-flight-handoff-events
+     (testing "a fork taken between the transactional handoff commit and its
+             :cont-resume processing inherits the event — the fork's consumer
+             copy receives the message instead of hanging un-armed (the
+             message exists in BOTH worlds, like a queued mailbox message
+             at fork time). Notification events stay dropped."
+       (th/with-ctx [ctx]
+         (let [mbx (sync/create-mailbox ctx)
+               hits (atom []) ;; PLAIN atom — shared across worlds, one hit per world
+               consumer (spin
+                         (let [m (await mbx)]
+                           (swap! hits conj m)
+                           m))]
+           (sync/spawn! consumer)
+           (is (poll-until #(binding [ec/*execution-context* ctx]
+                              (boolean (seq (:waiters @(.-state-atom mbx)))))
+                           2000)
+               "consumer's waiter registered")
+           ;; Make the window deterministic: wait until the parent's queue
+           ;; is quiet (the suspended consumer legitimately keeps
+           ;; :running? true, so await-drain-complete! never reports idle
+           ;; here — poll pending+lock only), then HOLD the drain lock so
+           ;; no straggler drain session (executor tasks from the
+           ;; spawn/take activity above) can consume the appended event
+           ;; before we fork.
+           (is (poll-until #(let [state (backend/backend-deref (:backend ctx))]
+                              (and (empty? (:engine/pending state))
+                                   (not (:engine/draining? state))))
+                           4000)
+               "parent queue quiesced")
+           (is (rtp/cas-state! ctx [:engine/draining?] false true)
+               "took the parent's drain lock")
+           ;; Simulate the committed handoff exactly as post-inline! leaves
+           ;; it: waiter popped from mailbox state, its :cont-resume in
+           ;; :engine/pending — appended WITHOUT a drain trigger so the
+           ;; fork can be taken in the window.
+           (let [w (volatile! nil)]
+             (binding [ec/*execution-context* ctx]
+               (swap! (.-state-atom mbx)
+                      (fn [st]
+                        (vreset! w (first (:waiters st)))
+                        (update st :waiters #(vec (rest %))))))
+             (rtp/swap-state-args! ctx [:engine/pending] conj
+                                   [{:type :cont-resume
+                                     :site :mailbox
+                                     :spin-id (:spin-id @w)
+                                     :cancel-token (:cancel-token @w)
+                                     :resolve (:resolve @w)
+                                     :value :the-msg
+                                     :mailbox mbx}]))
+           (let [fork (ectx/fork-context ctx)]
+             ;; fork-context both seeds the fork's pending with the
+             ;; in-flight data event AND triggers the fork's drain, so by
+             ;; the time we look the event may be pending or already
+             ;; processed — either way it was INHERITED, which the
+             ;; both-worlds outcome below pins. (The parent's copy can't
+             ;; move: we hold the parent's drain lock.)
+             (is (or (= 1 (count (filter #(= :cont-resume (:type %))
+                                         (rtp/get-state fork [:engine/pending]))))
+                     (= [:the-msg] @hits))
+                 "the fork inherited the in-flight data event")
+             ;; Release the parent's drain lock and trigger it — in
+             ;; reality post-inline! runs inside an active drain session,
+             ;; which picks the event up itself.
+             (rtp/swap-state! ctx [:engine/draining?] (constantly false))
+             (simple/trigger-drain! ctx (:executor ctx))
+             ;; Each world drains its own copy of the event against its own
+             ;; ctx — the shared plain atom records one hit per world.
+             (is (poll-until #(= [:the-msg :the-msg] @hits) 4000)
+                 "both worlds' consumer copies received the message")
+             ;; Silence the unused-binding lint without dropping the fork
+             ;; reference before the drain we care about has run.
+             fork))))))
 
 ;; -----------------------------------------------------------------------------
 ;; 5. CLJS: non-Error throw values must not slip past the catches

--- a/test/org/replikativ/spindel/pubsub/mult_handoff_test.cljc
+++ b/test/org/replikativ/spindel/pubsub/mult_handoff_test.cljc
@@ -1,0 +1,116 @@
+(ns org.replikativ.spindel.pubsub.mult-handoff-test
+  "Regression tests for the resume-as-event mult handoff (#27 Phase B):
+  the pubsub coordination promises now deliver each watcher through its
+  own ctx's drain as a `:cont-resume` event instead of running it on the
+  deliverer's stack.
+
+  1. untap from a FOREIGN thread under producer load: the untap's
+     close-tap! signalling no longer executes engine continuations on
+     the user thread — it only enqueues. Remaining taps must receive
+     every item, and the pump must not jam.
+  2. a consumer that throws mid-tap rejects loudly (spawn! :on-error)
+     while the pump keeps delivering to the other taps — the original
+     room-bus wedge scenario, now via the event path."
+  (:refer-clojure :exclude [await])
+  (:require #?(:clj [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer [deftest is testing] :include-macros true])
+            [org.replikativ.spindel.pubsub.mult :as mult]
+            [org.replikativ.spindel.pubsub.buffer :as buf]
+            [org.replikativ.spindel.engine.fault :as fault]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.spin.sync :as sync]
+            [is.simm.partial-cps.sequence :refer [anext]]
+            #?(:clj [org.replikativ.spindel.spin.cps :refer [spin]])
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.test-helpers :as th])
+  #?(:cljs (:require-macros [org.replikativ.spindel.spin.cps :refer [spin]]
+                            [org.replikativ.spindel.test-helpers :refer [with-ctx async]])))
+
+#?(:clj
+   (defn- poll-until
+     [pred timeout-ms]
+     (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+       (loop []
+         (cond
+           (pred) true
+           (>= (System/currentTimeMillis) deadline) false
+           :else (do (Thread/sleep 10) (recur)))))))
+
+#?(:clj
+   (deftest untap-from-foreign-thread-under-load
+     (testing "untap on a raw user thread mid-flood: remaining taps get every
+             item, nothing jams, no engine continuation ran on that thread"
+       (th/with-ctx [ctx]
+         (let [mbx (sync/create-mailbox ctx)
+               m (mult/mult mbx)
+               n 50
+               t1 (mult/tap m (buf/fixed-buffer (* 2 n)))
+               t2 (mult/tap m (buf/fixed-buffer (* 2 n)))
+               t3 (mult/tap m (buf/fixed-buffer (* 2 n)))
+               seen1 (atom [])
+               seen2 (atom [])
+               consume! (fn [tap-seq seen stop-at]
+                          (sync/spawn!
+                           (spin
+                            (loop [s tap-seq]
+                              (when-let [[item rest-seq] (await (anext s))]
+                                (swap! seen conj item)
+                                (when (< (count @seen) stop-at)
+                                  (recur rest-seq)))))))]
+           (consume! t1 seen1 n)
+           (consume! t2 seen2 n)
+           ;; t3 gets NO consumer — its buffer absorbs items until the
+           ;; foreign-thread untap removes it mid-flood.
+           (let [producer (future
+                            (dotimes [i n]
+                              (sync/post! mbx i)
+                              (when (= i 10)
+                                ;; raw user thread, mid-load
+                                @(future (mult/untap m t3)))))]
+             @producer
+             (is (poll-until #(= n (count @seen1)) 5000)
+                 "tap 1 received all items")
+             (is (poll-until #(= n (count @seen2)) 5000)
+                 "tap 2 received all items")
+             (is (= (vec (range n)) @seen1) "tap 1 in order")
+             (is (= (vec (range n)) @seen2) "tap 2 in order")))))))
+
+#?(:clj
+   (deftest consumer-throw-mid-tap-rejects-and-pump-continues
+     (testing "a tap consumer throwing on a poison item rejects loudly while
+             the pump keeps delivering to the other tap (room-bus scenario)"
+       (let [orig (fault/current-fault-reporter)]
+         (fault/set-fault-reporter! (fn [_ _] nil)) ;; quiet expected fault
+         (try
+           (th/with-ctx [ctx]
+             (let [mbx (sync/create-mailbox ctx)
+                   m (mult/mult mbx)
+                   ta (mult/tap m (buf/fixed-buffer 100))
+                   tb (mult/tap m (buf/fixed-buffer 100))
+                   seen-b (atom [])
+                   errs (atom [])
+                   consumer-a (spin
+                               (loop [s ta]
+                                 (when-let [[item rest-seq] (await (anext s))]
+                                   (when (= item :boom)
+                                     (throw (ex-info "poison" {})))
+                                   (recur rest-seq))))]
+               (sync/spawn! consumer-a
+                            {:on-error (fn [e] (swap! errs conj e))})
+               (sync/spawn!
+                (spin
+                 (loop [s tb]
+                   (when-let [[item rest-seq] (await (anext s))]
+                     (swap! seen-b conj item)
+                     (when (< (count @seen-b) 4)
+                       (recur rest-seq))))))
+               (sync/post! mbx :a)
+               (sync/post! mbx :boom)
+               (sync/post! mbx :c)
+               (sync/post! mbx :d)
+               (is (poll-until #(seq @errs) 4000)
+                   "consumer A rejected loudly (spawn! :on-error)")
+               (is (= "poison" (ex-message (first @errs))))
+               (is (poll-until #(= [:a :boom :c :d] @seen-b) 5000)
+                   "tap B received every item — the pump survived A's crash")))
+           (finally (fault/set-fault-reporter! orig)))))))

--- a/test/org/replikativ/spindel/pubsub/mult_test.cljc
+++ b/test/org/replikativ/spindel/pubsub/mult_test.cljc
@@ -5,6 +5,7 @@
             [org.replikativ.spindel.pubsub.mult :as mult]
             [org.replikativ.spindel.pubsub.buffer :as buf]
             [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.fault :as fault]
             [org.replikativ.spindel.engine.context :as ctx]
             [is.simm.partial-cps.sequence :refer [PAsyncSeq anext]]
             #?(:clj [org.replikativ.spindel.spin.cps :refer [spin]])
@@ -343,7 +344,7 @@
   ;; STACK. An unguarded throw there unwinds into the pump, cancels its await
   ;; cont, and wedges the whole room bus deaf. deliver! must isolate each watcher
   ;; fault: report it, keep notifying the remaining watchers, never propagate.
-  (let [orig-reporter @@#'mult/fault-reporter
+  (let [orig-reporter (fault/current-fault-reporter)
         faults (atom [])]
     (mult/set-fault-reporter! (fn [ev data] (swap! faults conj [ev data])))
     (try

--- a/test/org/replikativ/spindel/pubsub/mult_test.cljc
+++ b/test/org/replikativ/spindel/pubsub/mult_test.cljc
@@ -340,28 +340,38 @@
 (def ^:private make-promise* @#'mult/make-promise)
 
 (deftest deliver-isolates-watcher-faults
-  ;; A promise watcher resumes a consumer spin and runs ON THE PRODUCER (pump)
-  ;; STACK. An unguarded throw there unwinds into the pump, cancels its await
-  ;; cont, and wedges the whole room bus deaf. deliver! must isolate each watcher
-  ;; fault: report it, keep notifying the remaining watchers, never propagate.
+  ;; A promise watcher resumes a consumer spin. Historically it ran ON THE
+  ;; PRODUCER (pump) STACK, where an unguarded throw unwound into the pump,
+  ;; cancelled its await cont, and wedged the whole room bus deaf. Under
+  ;; resume-as-event (#27 Phase B) ctx-registered watchers run as their own
+  ;; :cont-resume drain events (structural isolation); this test exercises
+  ;; the DEGENERATE no-ctx path (watchers registered outside the engine),
+  ;; which still runs inline on the deliverer's stack and must therefore be
+  ;; guarded: report the fault, keep notifying the remaining watchers, never
+  ;; propagate to the producer.
   (let [orig-reporter (fault/current-fault-reporter)
         faults (atom [])]
     (mult/set-fault-reporter! (fn [ev data] (swap! faults conj [ev data])))
     (try
       (let [p (make-promise*)
             called (atom [])]
-        ;; watcher order: a throwing one FIRST, a recording one after it
+        ;; watcher order: a throwing one FIRST, a recording one after it.
+        ;; Watchers are {:ctx :spin-id :resolve} entries; :ctx nil selects
+        ;; the inline degenerate path this test targets.
         (swap! (:state p) update :watchers conj
-               (fn [_v] (throw (ex-info "consumer boom" {}))))
+               {:ctx nil :spin-id nil
+                :resolve (fn [_v] (throw (ex-info "consumer boom" {})))})
         (swap! (:state p) update :watchers conj
-               (fn [v] (swap! called conj v)))
+               {:ctx nil :spin-id nil
+                :resolve (fn [v] (swap! called conj v))})
         (testing "deliver! returns normally — the fault does not reach the producer"
           (is (= :val ((:deliver! p) :val))))
         (testing "a later watcher still runs despite the earlier fault (isolation)"
           (is (= [:val] @called)))
         (testing "the fault is reported, not silently swallowed"
           (is (= 1 (count @faults)))
-          (is (= ::mult/watcher-fault (ffirst @faults)))
+          (is (= ::fault/continuation-fault (ffirst @faults)))
+          (is (= :promise (:site (second (first @faults)))))
           (is (instance? #?(:clj Throwable :cljs js/Error)
                          (:error (second (first @faults)))))))
       (finally


### PR DESCRIPTION
The root-cause redesign for #27 (lost wakeup), in three commits — the scoped "Level 2" architecture: failure routing, resume-as-event for one-shot waiters, and a transactional handoff primitive.

## The invariant

**A wakeup obligation exists in exactly one place at all times**: the primitive's state (`:waiters` / `:pending` / `:queue`), the event queue, or a running continuation with its failure route armed. Never zero places (lost wakeup), never two (double delivery). Phase A arms the failure route, Phase B moves one-shot handoffs into the event queue, Phase C makes the state transition atomic.

## The boundary (differs from the issue's direction 1 — deliberately)

"Enqueue completion through the event system" cannot be applied wholesale. Await/track continuations are **persistent and multi-fire by design** ("continuations are NEVER removed"; `:await-reactive` relies on it): the inline design guarantees a resume advances the body *before* the next driving event processes — that is what makes the loop-over-await pattern work. Queueing those resumes would let two child completions enqueue two resumes of the same un-advanced cont and double-fire the body.

The sound boundary is cont **lifecycle**, not thread or spin identity:

- **One-shot waiters** — entries *popped* from a primitive's state before firing (mailbox waiters, deferred readers, pubsub promise watchers, semaphore acquirers) — run as their own `:cont-resume` events: uniform cancellation re-check at processing time, uniform failure route, and no foreign thread ever executes them.
- **Persistent graph conts** (track + await) resume inline within their driving event, with per-resume fault isolation + owning-spin rejection (Phase A).

## Commit 1 — Phase A: failure routing, nothing silent

- A throw out of a resumed waiter/reader/parent continuation **rejects the owning spin** via its parked cont's `:reject-fn` (matched by cancel-token; mirrors `cancel-spin!` step 2): `catch`/`finally` run, `spawn!`'s `:on-error` fires → `spin/supervisor` restart policies engage. At-most-once delivery: a partially-executed continuation is never re-run.
- `engine/fault.cljc`: one dependency-free fault hook for the whole engine (mult's PR-#28 reporter delegates to it). New: `::continuation-fault`, `::executor-task-fault`.
- `executor.cljc` `guard-task`: exceptions escaping executor tasks no longer vanish into discarded `.submit` Futures (this covered `sleep` resumes, `parallel`/`race` children and semaphore wakes even before Phase B). Interrupt flag restored on `InterruptedException`.
- CLJS catch classes fixed (`js/Error` → `:default`) in the drain's per-event catch and `await-handler` — thrown non-Error values no longer skip isolation.
- `engine.md`: new **Threading contract** section (engine threads are never interrupt targets; embedders cancel via cancel tokens; blocking work on embedder threads that only enqueue) + ctx-relative (CoW) mailbox/deferred state documented for health checks.

Notable: the issue's central "silent PENDING forever" scenario does **not** occur for body-level throws — the CPS emission (partial-cps `safe-r` + breakpoint wrapping) already routes them to reject; verified against the live engine and pinned by a test. The silent windows were the thin glue, the never-isolated pub/partitioned copies, the CLJS catch classes, and the swallowed executor Futures — all closed here.

## Commit 2 — Phase B: resume-as-event + one pubsub promise

- `:cont-resume` event + handler; `post-inline!` / `deliver-inline!` hand popped waiters to the drain. A mailbox waiter found cancelled in the enqueue→process window has its message **re-posted losslessly** — a capability the inline design could not express (previously the message fed a gated no-op). Pop-time cancelled-waiter skipping is retained so routine truncation-cancels never consume or reorder messages.
- **`pubsub/promise.cljc` replaces the three private `make-promise` copies** (mult / pub / partitioned). Only mult's copy had #28's watcher isolation; pub and partitioned ran watchers unguarded on the caller's stack — including `untap!` / `close-tap!` / `publish!` from arbitrary user threads. Delivery now enqueues on the ctx captured at registration (fork semantics preserved — `fork_ctx_reentrancy_test`), deleting the cross-ctx rebinding wrapper each copy carried.
- Semaphore `release` hands the dequeued acquirer to the drain instead of a bare executor task.

## Commit 3 — Phase C: transactional handoff

- New `PStateBackend` op **`backend-write-2!`**: atomically transform two paths in one commit (AtomBackend: one `swap!`; OverlayBackend: one swap with the standard CoW seeding; Immutable: throws). Mailbox state (`[:atoms id :value]`) and `[:engine/pending]` live in the same backend map — that is what makes pop-waiter + append-event a single CAS.
- `post-inline!` / `deliver-inline!` commit the pop and the event append in one transition; RuntimeAtom watch listeners fired manually after the commit (never inside — swap fns retry).

## Commit 4 — forkability: forks inherit in-flight data events

The resume-as-event handoff opened a fork-consistency gap: a fork taken between the handoff commit and `:cont-resume` processing saw the waiter popped from CoW-shared state while the message rode an event forks never inherited — the fork's consumer copy would hang un-armed. `fork-context` now splits the parent's un-drained queue by kind: **notification events** (`:signal-change`, `:spin-completion`, `:spin-execution`, `:gc-cleanup`) stay dropped (their truth is in state the fork sees; `:spin-execution` carries once-only external callbacks), while **data-bearing handoff events** (`:mailbox-post`, `:deferred-delivery`, `:cont-resume`) are copied into the fork's initial pending and the fork's drain triggered. Each world drains its own copy against its own ctx — both-worlds semantics identical to a message sitting in the mailbox `:queue` at fork time. This *narrows* the documented "forking with an un-drained change" caveat for in-flight messages rather than widening it (an un-drained `:mailbox-post` was previously dropped too). Deterministic regression test included (hold parent drain lock → pop+append → fork → one delivery per world).

## Verification

- JVM: **908 tests / 3124 assertions / 0 failures**; CLJS (node): **399 / 1483 / 0**.
- New tests: `engine/lost_wakeup_test.cljc` (body-throw pins loud rejection; raw-glue reader/waiter isolation; **supervisor restarts a crashed mailbox consumer end-to-end and drains the backlog**; executor-seam faults; interrupt-flag restore; cancelled-in-window re-post; `backend-write-2!` atomicity + overlay CoW/fork divergence; CLJS non-Error throw) and `pubsub/mult_handoff_test.cljc` (untap from a foreign thread under load; consumer throwing mid-tap rejects while the pump keeps delivering — the room-bus wedge scenario).
- mult pump benchmark (20k items × 3 buffered taps, JVM): median **8.42s main vs 8.54s branch** — within run-to-run noise; the same-spin 2-arity fast paths keep busy-consumer throughput off the event queue.
- Downstream: **dvergr's full suite run against this branch** via its `:local` overlay (the room bus is the production consumer of these paths): **358 tests / 1403 assertions / 0 failures**.

## Known/out of scope

- Pre-existing (unchanged): a semaphore permit granted to an acquirer whose spin is cancelled in flight is not returned.
- Delayed-spin firing and `parallel`/`race` child dispatch start spin *bodies* on executor threads (same class as direct `spawn!` invocation) — their faults are covered by the executor-seam guard; they are body starts, not waiter handoffs.
- The dvergr-side follow-up (durable-cursor bus pump + supervisor restart, retiring the watchdog to an alarm) is planned separately — this PR provides the loud-failure + supervision substrate it needs.

Closes #27.
