### PR TITLE
fix(fork): deliver events in one world only; undo in-flight mailbox claims in forks

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -123,19 +123,33 @@ drain its own events without contending with the parent's drain.
 >   external caller callbacks that must fire exactly once — in the
 >   parent's world.
 >
-> - **Data-bearing handoff events** (`:mailbox-post`,
->   `:deferred-delivery`, `:cont-resume`) are *inherited* — copied into
->   the fork's initial queue (and the fork's drain is triggered).
->   Unlike notifications, these CARRY a payload that exists nowhere
->   else: the message/value in flight. Dropping them would lose the
->   message in the fork's world — and a `:cont-resume`'s waiter has
->   already been popped from the (CoW-shared) primitive state, so the
->   fork's consumer copy would hang un-armed. Each world drains its own
->   copy against its own ctx (continuation closures resolve
->   `*execution-context*` dynamically, and the fork copied
->   `[:await-conts]`), so both worlds' body copies receive the value —
->   the same both-worlds semantics as a message sitting in the mailbox
->   `:queue` at fork time.
+> - **Delivery events** (`:mailbox-post`, `:deferred-delivery`) are
+>   also *dropped* — an event is delivered in exactly ONE world, the
+>   parent's. A message is single-consumer; delivering it in two worlds
+>   is a double-claim, and forks are routinely taken from *inside spin
+>   bodies* — mid-drain, where a just-posted message pending in the
+>   queue is the norm (`post!` then fork in one body slice). A consumer
+>   whose effect targets state outside the ctx (a durable log; the
+>   pubsub layer's plain-atom tap buffers and coordination promises)
+>   would otherwise process the same message in both worlds. CoW
+>   isolates ctx state, not external effects. If a fork must see a
+>   particular message, deliver it before forking or post it to the
+>   fork explicitly.
+>
+> - **`:cont-resume` events** (a popped waiter's pending resume) are
+>   dropped like the rest — the transactional handoff already ASSIGNED
+>   that message to a consumer instance in the parent's world — but the
+>   POP is *undone in the fork's world*: `fork-context` re-registers the
+>   waiter into the fork's CoW mailbox copy (pure state surgery, nothing
+>   executes), so the fork's consumer copy is armed for the fork's own
+>   traffic instead of being permanently wedged by a half-done handoff
+>   it can't observe. Deferred readers need no repair (the value is
+>   committed into the deferred's state atomically with the pop — the
+>   fork's copy is already assigned). Pubsub promise watchers and
+>   semaphore acquirers are not re-armed: their coordination state is
+>   plain-atom / permit-accounted; fork copies of those pipelines stay
+>   dormant — re-create live pipelines in the fork (participant/bus
+>   factories) rather than relying on inherited in-flight machinery.
 
 `:engine/cancelled-tokens` is the one shared path with subtle
 fork behavior; see [§8](#8-overlay-backend).

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -415,30 +415,48 @@
         parent-track-subscriptions (rtp/get-state parent-ctx [:track-subscriptions])
         parent-await-conts (rtp/get-state parent-ctx [:await-conts])
 
-        ;; Inherit the parent's in-flight DATA-BEARING events.
-        ;; :engine/pending is fork-local, and a fork deliberately DROPS
-        ;; the parent's un-drained NOTIFICATION events (:signal-change,
-        ;; :spin-completion, :spin-execution, :gc-cleanup): their truth
-        ;; already lives in state the fork sees (committed signal
-        ;; values, cached results), so re-delivering them in the fork
-        ;; would double-fire, and :spin-execution carries external
-        ;; caller callbacks that must fire once. Handoff events are
-        ;; different — they CARRY DATA that exists nowhere else: a
-        ;; :mailbox-post's / :cont-resume's message, a
-        ;; :deferred-delivery's value. Dropping those loses the message
-        ;; in the fork's world — and under the transactional handoff
-        ;; (#27 Phase C) a :cont-resume's waiter was already popped
-        ;; from the CoW-shared mailbox state, so the fork's consumer
-        ;; copy would hang un-armed with the message gone. Copy them:
-        ;; each world drains its own copy against its own ctx (the
-        ;; continuation closures resolve *execution-context*
-        ;; dynamically, and the fork copied [:await-conts], so the
-        ;; fork's processing advances the fork's body copies) — the
-        ;; same both-worlds semantics as a message sitting in the
-        ;; mailbox :queue at fork time.
-        parent-inflight-data-events
-        (vec (filter #(contains? #{:cont-resume :mailbox-post :deferred-delivery}
-                                 (:type %))
+        ;; The fork inherits NONE of the parent's un-drained events —
+        ;; an event is delivered in exactly one world (the parent's).
+        ;;
+        ;; - NOTIFICATION events (:signal-change, :spin-completion,
+        ;;   :spin-execution, :gc-cleanup): their truth already lives in
+        ;;   state the fork sees (committed signal values, cached
+        ;;   results, dirty flags + generation guard); re-delivering
+        ;;   would double-fire, and :spin-execution carries external
+        ;;   caller callbacks that must fire once.
+        ;;
+        ;; - DELIVERY events (:mailbox-post, :deferred-delivery): a
+        ;;   message is single-consumer; delivering it in two worlds is
+        ;;   a double-claim. Forks are routinely taken from INSIDE spin
+        ;;   bodies — mid-drain, where a just-posted message pending in
+        ;;   the queue is the NORM (post! then fork in one body slice) —
+        ;;   and a consumer whose effect targets state OUTSIDE the ctx
+        ;;   (a durable room log; the pubsub layer's plain-atom tap
+        ;;   buffers and coordination promises) would process the same
+        ;;   message in both worlds: duplicate external writes, corrupted
+        ;;   mult/pub coordination. CoW isolates ctx state, not external
+        ;;   effects.
+        ;;
+        ;; - :cont-resume events (a popped waiter's pending resume): the
+        ;;   transactional handoff (#27 Phase C) already ASSIGNED the
+        ;;   in-flight message to a consumer instance in the parent's
+        ;;   world when it popped the waiter. The event is dropped like
+        ;;   the rest — but the POP is undone in the fork's world by
+        ;;   re-registering the waiter into the fork's CoW mailbox copy
+        ;;   (below): pure state surgery, no execution, so the fork's
+        ;;   consumer copy is not left permanently un-armed and wakes on
+        ;;   the fork's OWN next post. Deferred readers need no repair —
+        ;;   deliver-inline! commits the value into the deferred's state
+        ;;   atomically with popping its readers, so the fork's copy is
+        ;;   already assigned and any re-run/await reads it. Pubsub
+        ;;   promise watchers and semaphore acquirers are NOT re-armed:
+        ;;   their coordination state is plain-atom (shared across
+        ;;   worlds) / permit-accounted — fork copies of those consumers
+        ;;   stay dormant, which is the pre-#27 semantics; embedders
+        ;;   re-create live pipelines in the fork (dvergr's participant
+        ;;   factories + fresh per-fork bus).
+        parent-inflight-mailbox-claims
+        (vec (filter #(and (= :cont-resume (:type %)) (:mailbox %))
                      (rtp/get-state parent-ctx [:engine/pending])))
 
         ;; Fork the forkable signals — those whose value is external mutable
@@ -475,7 +493,7 @@
         fork-local-state (cond-> (merge
                                   {:track-subscriptions (or parent-track-subscriptions {}) ; ← Copy parent's track conts!
                                    :await-conts (or parent-await-conts {})                 ; ← Copy parent's await conts!
-                                   :engine/pending parent-inflight-data-events ; ← data-bearing events only, see above
+                                   :engine/pending [] ; ← NO inherited events; see the claim-undo below
                                    :engine/draining? false
                                    :engine/delayed-spins (sorted-map)
                                    :engine/timer-handles {}}
@@ -535,11 +553,28 @@
                 (:running parent-ctx)        ; Share parent's lifecycle flag
                 (:drain-active parent-ctx)   ; Share parent's drain-active counter
                 )]
-      ;; A fork seeded with inherited in-flight data events (or explicit
-      ;; :engine/pending via state-updates) has work waiting but nothing
-      ;; has poked its drain yet — the parent's drain never touches a
-      ;; fork's fork-local queue. Trigger once so the inherited events
-      ;; don't sit until the fork's first own enqueue.
+      ;; Undo the parent's in-flight mailbox CLAIMS in the fork's world:
+      ;; each pending :cont-resume popped its waiter from the (CoW-shared)
+      ;; mailbox state before the fork — re-register the waiter into the
+      ;; fork's copy so the fork's consumer copy is armed for the fork's
+      ;; OWN traffic. State surgery only: nothing is delivered or
+      ;; executed here, and the in-flight message itself stays with the
+      ;; parent's world (single-consumer semantics). Restored at the
+      ;; FRONT — it was the front waiter when popped.
+      (doseq [{:keys [mailbox spin-id cancel-token resolve]} parent-inflight-mailbox-claims]
+        (let [state-atom #?(:clj  (.-state-atom mailbox)
+                            :cljs (.-state-atom ^js mailbox))
+              aid        #?(:clj  (.-id state-atom)
+                            :cljs (.-id ^js state-atom))]
+          (rtp/swap-state! fork [:atoms aid :value :waiters]
+                           (fn [ws]
+                             (into [{:spin-id spin-id
+                                     :cancel-token cancel-token
+                                     :resolve resolve}]
+                                   ws)))))
+      ;; A fork given explicit :engine/pending via state-updates has work
+      ;; waiting but nothing has poked its drain yet — the parent's drain
+      ;; never touches a fork's fork-local queue. Trigger once.
       (when (seq (rtp/get-state fork [:engine/pending]))
         (simple/trigger-drain! fork (:executor fork)))
       fork)))

--- a/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
+++ b/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
@@ -283,12 +283,14 @@
 ;; -----------------------------------------------------------------------------
 
 #?(:clj
-   (deftest fork-inherits-in-flight-handoff-events
+   (deftest fork-undoes-in-flight-mailbox-claims
      (testing "a fork taken between the transactional handoff commit and its
-             :cont-resume processing inherits the event — the fork's consumer
-             copy receives the message instead of hanging un-armed (the
-             message exists in BOTH worlds, like a queued mailbox message
-             at fork time). Notification events stay dropped."
+             :cont-resume processing inherits NO events (an event is
+             delivered in exactly one world — the parent's; the popped
+             message was CLAIMED by a parent-world consumer), but the pop
+             is UNDONE in the fork's world: the waiter is re-registered
+             into the fork's CoW mailbox copy, so the fork's consumer
+             copy is armed for the fork's own traffic."
        (th/with-ctx [ctx]
          (let [mbx (sync/create-mailbox ctx)
                hits (atom []) ;; PLAIN atom — shared across worlds, one hit per world
@@ -332,30 +334,40 @@
                                      :cancel-token (:cancel-token @w)
                                      :resolve (:resolve @w)
                                      :value :the-msg
-                                     :mailbox mbx}]))
+                                     :mailbox mbx}])
+             ;; ...plus a pending DELIVERY event, which the fork must NOT
+             ;; inherit: forks happen mid-drain routinely (post!-then-fork
+             ;; in one body slice), and inheriting posts double-runs
+             ;; consumers with external effects (e.g. a durable room
+             ;; log). The fork's consumer for this one stays armed and
+             ;; simply never sees this particular message.
+             (rtp/swap-state-args! ctx [:engine/pending] conj
+                                   [{:type :mailbox-post
+                                     :mailbox mbx
+                                     :msg :dropped-in-fork}]))
            (let [fork (ectx/fork-context ctx)]
-             ;; fork-context both seeds the fork's pending with the
-             ;; in-flight data event AND triggers the fork's drain, so by
-             ;; the time we look the event may be pending or already
-             ;; processed — either way it was INHERITED, which the
-             ;; both-worlds outcome below pins. (The parent's copy can't
-             ;; move: we hold the parent's drain lock.)
-             (is (or (= 1 (count (filter #(= :cont-resume (:type %))
-                                         (rtp/get-state fork [:engine/pending]))))
-                     (= [:the-msg] @hits))
-                 "the fork inherited the in-flight data event")
+             (is (empty? (rtp/get-state fork [:engine/pending]))
+                 "the fork inherited NO events — neither the :cont-resume
+                nor the pending :mailbox-post")
+             (is (= 1 (count (:waiters (binding [ec/*execution-context* fork]
+                                         @(.-state-atom mbx)))))
+                 "the popped waiter was re-registered in the fork's copy
+                (the in-flight claim is undone, the consumer copy armed)")
              ;; Release the parent's drain lock and trigger it — in
              ;; reality post-inline! runs inside an active drain session,
              ;; which picks the event up itself.
              (rtp/swap-state! ctx [:engine/draining?] (constantly false))
              (simple/trigger-drain! ctx (:executor ctx))
-             ;; Each world drains its own copy of the event against its own
-             ;; ctx — the shared plain atom records one hit per world.
-             (is (poll-until #(= [:the-msg :the-msg] @hits) 4000)
-                 "both worlds' consumer copies received the message")
-             ;; Silence the unused-binding lint without dropping the fork
-             ;; reference before the drain we care about has run.
-             fork))))))
+             (is (poll-until #(= [:the-msg] @hits) 4000)
+                 "the in-flight message was delivered ONCE, in the parent's
+                world only")
+             ;; The fork's re-armed consumer copy wakes on the fork's OWN
+             ;; traffic.
+             (binding [ec/*execution-context* fork]
+               (sync/post! mbx :fork-msg))
+             (is (poll-until #(= [:the-msg :fork-msg] @hits) 4000)
+                 "the fork's consumer copy received the fork's own post —
+                re-armed, not wedged")))))))
 
 ;; -----------------------------------------------------------------------------
 ;; 5. CLJS: non-Error throw values must not slip past the catches


### PR DESCRIPTION
Fixes a fork-semantics regression that 0.1.31 (#29) shipped, caught by dvergr's suite against the release and confirmed unsound in review.

## The regression

#29's last commit made forks inherit the parent's in-flight data-bearing events (`:mailbox-post` / `:deferred-delivery` / `:cont-resume`). dvergr's `agent.subagent-test/hire-tracks-lifecycle` failed 3/3 deterministically against 0.1.31 — a duplicated durable `:dvergr/subagent :running` event in the room log — and bisects exactly to that commit.

Two reasons it was unsound:

1. **Forks are routinely taken from inside spin bodies — mid-drain.** A just-posted message pending in the queue is the *norm* (`hire!` does `post!`-then-`fork-room` in one body slice), not a rare race. A body also cannot quiesce its own queue before forking — it would wait on itself. So inheriting delivery events runs consumers in both worlds as a matter of course.
2. **Consumers reach state CoW cannot isolate.** The durable room log (datahike) — duplicate writes — and the pubsub layer's own coordination: tap buffers, rendezvous slots, and availability promises are plain JVM atoms shared across worlds; waking a fork's pump/consumer copy against them corrupts mult/pub. A message is also single-consumer: delivery in two worlds is a double-claim.

## The fix

**An event is delivered in exactly one world — the parent's.** Forks start with an empty queue for every event kind (the pre-0.1.31 semantics). The one genuine hole the #27 redesign had opened — a fork taken between the transactional handoff commit and its `:cont-resume` processing sees the waiter already popped from the CoW-shared mailbox state and would be permanently un-armed — is closed by **claim-undo** instead of delivery: `fork-context` re-registers the popped waiter into the fork's CoW mailbox copy. Pure state surgery, nothing executes; the in-flight message stays with the parent-world consumer that claimed it, and the fork's consumer copy wakes on the fork's *own* next post.

- Deferred readers need no repair: `deliver-inline!` commits the value into the deferred's state atomically with popping its readers, so the fork's copy is already assigned.
- Pubsub promise watchers and semaphore acquirers are deliberately **not** re-armed: their coordination is plain-atom / permit-accounted; fork copies of those pipelines stay dormant (pre-#27 semantics) — embedders re-create live pipelines in forks (dvergr's participant factories + fresh per-fork bus).

`engine.md`'s forking note is rewritten accordingly; `fork-undoes-in-flight-mailbox-claims` pins all four properties (no inherited events; waiter re-armed; in-flight message delivered once, parent only; fork consumer receives the fork's own post).

## Verification — full vertical against this exact head

- spindel JVM: **908 / 3123 / 0**; CLJS (node): **399 / 1483 / 0**
- dvergr full suite via `:local` overlay: **358 / 1403 / 0** — including the previously failing lifecycle test
- simmis Maven baseline with spindel overridden to this branch: **20 / 135 / 0**
