### PR TITLE
fix(engine): enforce the node-record invariant at field-write sites (#31)

### DIFF
--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -6,6 +6,7 @@
   (:require [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.impl.simple :as simple]
             [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.engine.nodes :as nodes]
             [org.replikativ.spindel.engine.protocols :as rtp]
             [org.replikativ.spindel.engine.addressing :as addressing]
             [org.replikativ.spindel.engine.bindings :as bindings]
@@ -460,8 +461,20 @@
        (let [spin-scope (select-keys (:bindings ctx)
                                      (bindings/spin-scope-keys))]
          (when (seq spin-scope)
-           (rtp/swap-state! ctx [:nodes spin-id :spin-scope]
-                            (constantly spin-scope)))))
+           ;; NODE-RECORD INVARIANT (#31): swap the WHOLE node, never a
+           ;; field path. A field-path write (`[:nodes id :spin-scope]`)
+           ;; on an ABSENT node — possible when a reap raced between
+           ;; register-spin! above and here — materializes a plain map
+           ;; `{:spin-scope …}` where a SpinNode record belongs; every
+           ;; downstream `(or node (->spin-node …))` guard then keeps the
+           ;; truthy map forever, and the first protocol call on it
+           ;; (`get-observers` in cache-result!) throws — silently
+           ;; stranding that spin's completion.
+           (rtp/swap-state! ctx [:nodes spin-id]
+                            (fn [node]
+                              (let [node (or node (nodes/->spin-node
+                                                   nil :clean false false #{} {} nil #{}))]
+                                (assoc node :spin-scope spin-scope)))))))
 
      ;; Register automatic cleanup when spin is GC'd
      ;; Both platforms: capture a WeakRef to the ExecutionContext so cleanup
@@ -602,8 +615,17 @@
    covers)."
   [sid spins]
   (when-let [ctx (ec/current-execution-context)]
-    (rtp/swap-state! ctx [:nodes sid :owned-spins]
-                     (constantly (when (seq spins) (vec spins))))))
+    ;; NODE-RECORD INVARIANT (#31): swap the WHOLE node, never a field
+    ;; path. The clear-on-done call can race a GC / generation-boundary
+    ;; reap of the combinator's node; a field-path write would then
+    ;; materialize a plain map `{:owned-spins nil}` where a SpinNode
+    ;; record belongs (see the :spin-scope write in make-spin for the
+    ;; full failure chain). A reaped node needs no owned-spins edge —
+    ;; skip, preserving absence.
+    (rtp/swap-state! ctx [:nodes sid]
+                     (fn [node]
+                       (when node
+                         (assoc node :owned-spins (when (seq spins) (vec spins))))))))
 
 (defn cancel-spin!
   "Cancel a spin and all its observers (cooperative cancellation).

--- a/test/org/replikativ/spindel/engine/node_record_invariant_test.cljc
+++ b/test/org/replikativ/spindel/engine/node_record_invariant_test.cljc
@@ -1,0 +1,56 @@
+(ns org.replikativ.spindel.engine.node-record-invariant-test
+  "Regression for spindel#31: every `[:nodes id]` entry must be a
+  SpinNode/SignalNode RECORD (or absent). A field-path write
+  (`[:nodes id :field]`) on an absent node materializes a plain map,
+  which every downstream `(or node (->spin-node …))` guard keeps
+  forever; the first protocol call on it (`get-observers` in
+  cache-result!) then throws and the spin's completion silently never
+  notifies its observers. Seen in CI as an executor-task-fault during
+  parallel-test (a sleep-timer resume caching into a poisoned node).
+
+  The two culprit sites — make-spin's `:spin-scope` snapshot and the
+  combinators' `set-owned-spins!` (whose clear-on-done can race a GC /
+  generation-boundary reap of the node) — now swap the WHOLE node."
+  (:require #?(:clj [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer [deftest is testing] :include-macros true])
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.bindings :as bindings]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.test-helpers :as th]))
+
+(deftest set-owned-spins-preserves-record-invariant
+  (testing "set-owned-spins! on an ABSENT (reaped) node must not
+          materialize a plain map — absence is preserved"
+    (th/with-ctx [ctx]
+      (spin-core/set-owned-spins! ::reaped-spin [::child-a])
+      (let [n (rtp/get-state ctx [:nodes ::reaped-spin])]
+        (is (or (nil? n) (record? n))
+            "no plain-map node was created for the reaped spin"))))
+  (testing "set-owned-spins! on an existing node keeps the record"
+    (th/with-ctx [ctx]
+      (let [s (spin-core/make-spin (fn [resolve _reject] (resolve 1)))
+            sid (spin-core/spin-id s)]
+        (spin-core/set-owned-spins! sid [::child-b])
+        (let [n (rtp/get-state ctx [:nodes sid])]
+          (is (record? n))
+          (is (= [::child-b] (:owned-spins n))))
+        ;; clearing (done? flip) keeps the record too
+        (spin-core/set-owned-spins! sid nil)
+        (is (record? (rtp/get-state ctx [:nodes sid])))))))
+
+(deftest spin-scope-write-preserves-record-invariant
+  (testing "make-spin's :spin-scope snapshot lands on a RECORD node even
+          when scope keys are captured"
+    ;; Register a (namespaced, test-only) scope key; registration is
+    ;; additive and only affects spins whose ctx carries the key.
+    (bindings/register-spin-scope-key! ::probe-scope)
+    (th/with-ctx [ctx]
+      (binding [ec/*execution-context* (assoc ctx :bindings
+                                              (assoc (:bindings ctx) ::probe-scope :v))]
+        (let [s (spin-core/make-spin (fn [resolve _reject] (resolve 1)))
+              sid (spin-core/spin-id s)
+              n (rtp/get-state ctx [:nodes sid])]
+          (is (record? n) "the node is a record, not a plain map")
+          (is (= {::probe-scope :v} (:spin-scope n))
+              "the scope snapshot landed on the record"))))))


### PR DESCRIPTION
Root-causes #31 (the executor-task-fault the #27 fault guard surfaced on its first CI run): `get-observers` on a plain `PersistentArrayMap` where a `SpinNode` record belongs.

**Mechanism.** Two sites wrote node *fields* at depth-3 paths — `[:nodes id :spin-scope]` (make-spin's scope snapshot) and `[:nodes id :owned-spins]` (race/parallel's owned-spins edge). `update-in` on an **absent** node materializes a plain map; every downstream `(or node (->spin-node …))` guard keeps the truthy map forever, and the first protocol call on it (inside `cache-result!`'s swap) throws — silently stranding that spin's completion. Pre-#27 the exception died in a discarded Future, so this is a latent bug made visible, not a regression. The absent-node window is real: `set-owned-spins!`'s clear-on-done can race a GC / generation-boundary reap.

**Fix.** Both sites swap the whole node (create-record-if-absent for the scope write; skip-if-reaped for owned-spins). A sweep confirms no other depth-3 node writes remain. Regression tests in `node_record_invariant_test.cljc`.

(The fork-ctx CONTROL-test trace instrumentation was split into #33 per review.)

**Verified against this head** (whole vertical): spindel JVM 910/3125/0 + CLJS 399/1483/0, dvergr `:local` 358/1403/0, simmis Maven + this branch 20/135/0.