### PR TITLE
test: de-race the multi-sub pub tests; trace-instrument the fork-ctx CONTROL test (spindel#34)

### DIFF
--- a/test/org/replikativ/spindel/pubsub/fork_ctx_reentrancy_test.cljc
+++ b/test/org/replikativ/spindel/pubsub/fork_ctx_reentrancy_test.cljc
@@ -119,24 +119,38 @@
      (testing "CONTROL: same flow but bus + worker built OUTSIDE the outer
             spin. Should pass — confirms the bug is specific to the
             inline pattern, not the topology."
+       ;; Traced like its siblings: this test timed out ONCE on CI (30s,
+       ;; main build 552) with zero diagnostics — the worker helper logs
+       ;; into *trace* but nothing reset/printed it here. If it stalls
+       ;; again, the trace shows WHERE (worker never started / worker got
+       ;; the msg but the reply never reached the asker / …).
+       (reset! *trace* [])
        (let [parent-ctx (ctx/create-execution-context)
              worker-id  :worker
              fork-ctx   (binding [ec/*execution-context* parent-ctx]
                           (ctx/fork-context parent-ctx))
+             _ (log-trace :forked)
              bus        (make-bus fork-ctx)
+             _ (log-trace :bus-made)
              _worker    (spawn-echo-worker! bus worker-id)
              asker-id   (keyword (str "ask-" (rand-int 1000000)))
              asker-sub  (binding [ec/*execution-context* fork-ctx]
                           (bus-subscribe! bus asker-id (buf/fixed-buffer 1)))
+             _ (log-trace :asker-subscribed)
              done       (promise)]
          (binding [ec/*execution-context* fork-ctx]
            (sp/spawn!
             (spin
+             (log-trace :outer-spin-start)
              (bus-post! bus {:to worker-id :from asker-id :content "go"})
+             (log-trace :posted-go)
              (let [[reply _] (await (anext asker-sub))]
+               (log-trace :outer-got-reply reply)
                (deliver done {:reply (:content reply)})))))
          (let [result (deref done 30000 :TIMEOUT)]
            (ctx/stop-context! parent-ctx)
+           (when (= result :TIMEOUT)
+             (println "CONTROL-TIMEOUT TRACE:" (pr-str @*trace*)))
            (is (= {:reply "reply"} result)))))))
 
 #?(:clj


### PR DESCRIPTION
CI test-reliability PR — root-causes two of spindel#34's three manifestations and instruments the third.

**De-raced (root cause: test-level, not engine).** `test-pub-multiple-topics` and `test-pub-multiple-subscribers-per-topic` raced their *own* subscriptions: the pump starts lazily on the FIRST `sub`, items for topics without a subscriber are dropped (by design — pinned by `test-pub-unsubscribed-topics-dropped`), and a mult tap only receives items delivered after it registered. With an eager pre-filled vector source, the pump could consume early items before the second sub/tap existed — `[2 4]` became `[4]` or `[]` at ~13% per cycle under CPU load (reproduced 4/30, and repeatedly blocked CI/release runs). `gated-aseq` holds the source's head behind a Deferred; the tests open the gate once every sub is in place. The drop semantics keep their own dedicated test, unchanged.

**Instrumented.** `fork-ctx-pubsub-bus-built-outside` (manifestation 2 — subs strictly precede any post, so the sub-race explanation does NOT apply) has timed out 3× with zero diagnostics; it now uses the trace machinery its siblings have and prints the trace on timeout. Deliberately no timeout bump.

Verification: de-raced tests stress-tested 30 cycles under n-2-core CPU load (previous rate 4/30) — result posted below when complete.