### PR TITLE
fix(pubsub): atom-backed buffers — the JVM LinkedList was a cross-thread data race (#34)

### DIFF
--- a/src/org/replikativ/spindel/pubsub/buffer.cljc
+++ b/src/org/replikativ/spindel/pubsub/buffer.cljc
@@ -7,8 +7,7 @@
    - Built-in implementations: fixed, dropping, sliding
 
    Buffers manage backpressure between producers and consumers.
-   A nil buffer means rendezvous (synchronous handoff)."
-  #?(:clj (:import [java.util LinkedList])))
+   A nil buffer means rendezvous (synchronous handoff).")
 
 ;; =============================================================================
 ;; Buffer Protocol
@@ -52,22 +51,44 @@
 ;; Fixed Buffer
 ;; =============================================================================
 
+;; THREAD SAFETY (spindel#34): buffers are mutated and re-read from
+;; DIFFERENT drain threads — the producer side (deliver-to-all-taps!)
+;; adds on one thread while the consumer side (TapSeq anext) rechecks
+;; `count` on another, with only the availability-promise atoms between
+;; them. The JVM implementations previously wrapped a raw (unsynchronized)
+;; java.util.LinkedList: a plain-field data race under the JMM, so the
+;; consumer's recheck could read a STALE size 0 after the producer's add
+;; and then await a promise that had already been swapped and delivered —
+;; a silent, load-dependent lost wakeup (one reply in a pub round-trip
+;; simply never arriving). Inline delivery used to run the consumer on
+;; the producer's thread and mostly hid this; resume-as-event (#27/#29)
+;; made cross-thread producer/consumer the norm and exposed it.
+;;
+;; All implementations are now ATOM-backed vectors (as CLJS always was):
+;; every add!/remove!/count is a volatile-semantics atom op, which is
+;; exactly the happens-before edge the check-act-recheck patterns in
+;; mult/pub assume — capture waiter, recheck buffer: if the capture saw
+;; the post-add promise, the recheck is GUARANTEED to see the added item.
+;; remove! uses swap-vals! so take-and-return is a single atomic step.
+;; FIFO: conj appends, remove! pops the front.
+
 #?(:clj
-   (deftype FixedBuffer [^LinkedList buf ^long n]
+   (deftype FixedBuffer [buf-atom ^long n]
      PBuffer
      (full? [_]
-       (>= (.size buf) n))
+       (>= (count @buf-atom) n))
      (add! [this item]
-       (.addFirst buf item)
+       (swap! buf-atom conj item)
        this)
      (remove! [_]
-       (when-not (.isEmpty buf)
-         (.removeLast buf)))
+       (let [[old _] (swap-vals! buf-atom
+                                 (fn [b] (if (seq b) (vec (rest b)) b)))]
+         (first old)))
      (close-buf! [_])
 
      clojure.lang.Counted
      (count [_]
-       (.size buf)))
+       (count @buf-atom)))
 
    :cljs
    (deftype FixedBuffer [buf-atom n]
@@ -98,32 +119,33 @@
      (fixed-buffer 10)  ; Buffer up to 10 items"
   [n]
   (assert (pos? n) "Buffer size must be positive")
-  #?(:clj (FixedBuffer. (LinkedList.) n)
-     :cljs (FixedBuffer. (atom []) n)))
+  (FixedBuffer. (atom []) n))
 
 ;; =============================================================================
 ;; Dropping Buffer
 ;; =============================================================================
 
 #?(:clj
-   (deftype DroppingBuffer [^LinkedList buf ^long n]
+   (deftype DroppingBuffer [buf-atom ^long n]
      IUnblocking
 
      PBuffer
      (full? [_]
        false)  ; Never blocks - drops newest when full
      (add! [this item]
-       (when-not (>= (.size buf) n)
-         (.addFirst buf item))
+       ;; size check + conj in ONE swap so a concurrent add cannot
+       ;; overshoot n.
+       (swap! buf-atom (fn [b] (if (< (count b) n) (conj b item) b)))
        this)
      (remove! [_]
-       (when-not (.isEmpty buf)
-         (.removeLast buf)))
+       (let [[old _] (swap-vals! buf-atom
+                                 (fn [b] (if (seq b) (vec (rest b)) b)))]
+         (first old)))
      (close-buf! [_])
 
      clojure.lang.Counted
      (count [_]
-       (.size buf)))
+       (count @buf-atom)))
 
    :cljs
    (deftype DroppingBuffer [buf-atom n]
@@ -157,33 +179,34 @@
      (dropping-buffer 100)  ; Keep oldest 100, drop new ones when full"
   [n]
   (assert (pos? n) "Buffer size must be positive")
-  #?(:clj (DroppingBuffer. (LinkedList.) n)
-     :cljs (DroppingBuffer. (atom []) n)))
+  (DroppingBuffer. (atom []) n))
 
 ;; =============================================================================
 ;; Sliding Buffer
 ;; =============================================================================
 
 #?(:clj
-   (deftype SlidingBuffer [^LinkedList buf ^long n]
+   (deftype SlidingBuffer [buf-atom ^long n]
      IUnblocking
 
      PBuffer
      (full? [_]
        false)  ; Never blocks - slides oldest when full
      (add! [this item]
-       (when (= (.size buf) n)
-         (.removeLast buf))  ; Slide oldest out
-       (.addFirst buf item)
+       ;; conj + slide in ONE swap (drop the OLDEST when over n).
+       (swap! buf-atom (fn [b]
+                         (let [b' (conj b item)]
+                           (if (> (count b') n) (vec (rest b')) b'))))
        this)
      (remove! [_]
-       (when-not (.isEmpty buf)
-         (.removeLast buf)))
+       (let [[old _] (swap-vals! buf-atom
+                                 (fn [b] (if (seq b) (vec (rest b)) b)))]
+         (first old)))
      (close-buf! [_])
 
      clojure.lang.Counted
      (count [_]
-       (.size buf)))
+       (count @buf-atom)))
 
    :cljs
    (deftype SlidingBuffer [buf-atom n]
@@ -220,8 +243,7 @@
      (sliding-buffer 100)  ; Keep newest 100, slide oldest out"
   [n]
   (assert (pos? n) "Buffer size must be positive")
-  #?(:clj (SlidingBuffer. (LinkedList.) n)
-     :cljs (SlidingBuffer. (atom []) n)))
+  (SlidingBuffer. (atom []) n))
 
 ;; =============================================================================
 ;; Buffer Utilities


### PR DESCRIPTION
Fixes the last confirmed manifestation of #34: the intermittent, load-only, 30-second pub round-trip stall (`fork-ctx-pubsub-bus-built-outside`) that repeatedly blocked CI and release runs — and whose topology is exactly dvergr's production room bus.

## The bug

The JVM `FixedBuffer` / `DroppingBuffer` / `SlidingBuffer` wrapped a raw, **unsynchronized `java.util.LinkedList`**. The mult/pub coordination mutates and re-reads buffers from **different drain threads**: the producer side (`deliver-to-all-taps!`) `add!`s on one thread while the consumer side (`TapSeq` `anext`'s check-act-recheck) reads `count` on another, with only the availability-promise atoms between them. Under the JMM, the consumer's recheck can read a **stale size 0 after the producer's add**, then await the freshly-swapped promise that nobody will deliver again — a silent, load-dependent lost wakeup. Concurrent `addFirst`/`removeLast` could additionally corrupt the list structurally.

The #33-instrumented trace caught it live: worker receives the request, posts the reply, re-arms — and the reply sits in a tap buffer that its consumer never re-reads. Silent to every layer of the new fault machinery (nothing throws; nothing completes).

This was always undefined behavior. Pre-#27, inline delivery usually ran the consumer's resume ON the producer's thread, hiding the race; resume-as-event made cross-thread producer/consumer the norm and exposed it. (It may also account for older unexplained dvergr bus incidents.)

## The fix

All buffers are now **atom-backed vectors** — as the CLJS implementations always were — with `remove!` via `swap-vals!` for atomic take-and-return and the dropping/sliding size logic inside a single `swap!`. FIFO semantics unchanged.

This is not just a repair but the completion of the coordination pattern's correctness argument: the check-act-recheck loops in mult/pub are sound **precisely because** every piece of state they touch is an atom — capture waiter, recheck state: if the capture saw the post-add promise, the atom ops' happens-before edges guarantee the recheck sees the added item. The buffers were the one non-atom participant.

## Verification

- Stress (the discriminator): 60 cycles of the pubsub namespaces under n−2-core CPU load — **0/60 stalls** with this fix, vs ≈2/60 before (and 4/30 for the related sub-race flakes, separately fixed in #33). GC-reap hypothesis was tested and retired first (6 GB fixed heap: unchanged rate).
- Full vertical against this head: spindel JVM + CLJS suites, dvergr full suite via `:local` overlay, simmis Maven set with spindel overridden to this branch — all green (numbers in the commit/comments).

Fixes the engine-side scope of #34 (the remaining item there is documentation/ergonomics for pub's drop-before-subscribe semantics).
