### PR TITLE
fix(dom): preserve node identity — moves, fragment offsets, foreign attrs

### DIFF
--- a/src/org/replikativ/spindel/dom/browser.cljs
+++ b/src/org/replikativ/spindel/dom/browser.cljs
@@ -142,16 +142,53 @@
         (.appendChild parent new-child))))
 
   (move-child! [_ parent from-idx to-idx]
+    ;; `moveBefore` MOVES a node; removeChild+insertBefore DESTROYS AND RECREATES
+    ;; it. For most elements the difference is invisible. For anything holding
+    ;; state OUTSIDE the element — an <iframe>'s browsing context, a <video>'s
+    ;; live srcObject, a WebGL context, an editor's selection — the difference is
+    ;; the whole ballgame: removal runs the DOM "removing steps", which discard
+    ;; that state. A Jitsi call died on a mere SIBLING REORDER, having survived
+    ;; nothing more than being renumbered.
+    ;;
+    ;; Measured in Chromium (a counter living inside the iframe's document):
+    ;;   removeChild + insertBefore → counter reset (context discarded)
+    ;;   moveBefore                 → counter preserved, across reorder AND
+    ;;                                across a change of parent
+    ;;
+    ;; moveBefore throws HierarchyRequestError if either node is DISCONNECTED,
+    ;; so the fallback is not decoration: it is the path for pre-2025 browsers
+    ;; (Chrome <133, Firefox/Safari until they ship it) and for any move
+    ;; involving a detached tree. There, state loss is unavoidable — the platform
+    ;; offers no other way — and we take the old behaviour rather than throw.
     (let [children (.-childNodes parent)
-          child (aget children from-idx)]
-      (when child
-        ;; Remove from current position and insert at new position
-        ;; Note: after removal, indices shift, so we need to account for that
-        (.removeChild parent child)
-        (let [ref-node (aget (.-childNodes parent) to-idx)]
-          (if ref-node
-            (.insertBefore parent child ref-node)
-            (.appendChild parent child))))))
+          child    (aget children from-idx)]
+      (when (and child (not= from-idx to-idx))
+        ;; INDEX SUBTLETY. Both APIs mean "put child before ref", and the final
+        ;; index of child is ref's index in the list WITHOUT child. The old code
+        ;; removed first, so it could just read the shortened list. moveBefore is
+        ;; ATOMIC — the child is still present when we pick ref — so we must
+        ;; account for the shift ourselves:
+        ;;   moving RIGHT (to > from): everything past `from` shifts left by one
+        ;;     when child leaves, so ref must be the node AFTER the target slot.
+        ;;   moving LEFT  (to < from): indices below `from` are unaffected.
+        ;; Getting this wrong is an off-by-one that silently misorders lists.
+        (let [ref (if (< from-idx to-idx)
+                    (aget children (inc to-idx))    ; may be undefined ⇒ to the end
+                    (aget children to-idx))
+              fallback! (fn []
+                          (.removeChild parent child)
+                          (let [r (aget (.-childNodes parent) to-idx)]
+                            (if r
+                              (.insertBefore parent child r)
+                              (.appendChild parent child))))]
+          (if (and (.-moveBefore parent) (.-isConnected child))
+            (try
+              (.moveBefore parent child (or ref nil))   ; null ⇒ append
+              (catch :default _
+                ;; disconnected / cross-document — the platform offers no
+                ;; state-preserving path here, so take the lossy one
+                (fallback!)))
+            (fallback!))))))
 
   (child-index-of [_ parent child]
     (let [children (.-childNodes parent)

--- a/src/org/replikativ/spindel/dom/cache.cljc
+++ b/src/org/replikativ/spindel/dom/cache.cljc
@@ -389,7 +389,7 @@
               ;; They are child-index deltas exactly like :add/:remove/:update,
               ;; so they need exactly the same slot→flattened conversion.
               (:add-fragment :remove-fragment
-               :replace-with-fragment :replace-fragment-with-single)
+                             :replace-with-fragment :replace-fragment-with-single)
               (assoc delta :path [base-idx])
 
               ;; Anything else: leave alone.

--- a/src/org/replikativ/spindel/dom/cache.cljc
+++ b/src/org/replikativ/spindel/dom/cache.cljc
@@ -376,7 +376,23 @@
                  :path [slot-idx]
                  :adjusted-deltas adjusted-internal})
 
-              ;; Fragment add/remove: need special handling at render time
+              ;; Fragment appears/disappears/replaces wholesale.
+              ;;
+              ;; These used to fall through UNADJUSTED — and `discharge` then
+              ;; used `(first path)` as a DOM child index. But an unadjusted path
+              ;; is a SLOT index, and slots do not correspond to children: a :nil
+              ;; slot flattens to zero nodes, a :keyed slot to many. So an
+              ;; ifor-each appearing after such a sibling inserted its items at
+              ;; the WRONG index — e.g. before a preceding element instead of
+              ;; after it. Silent, and only visible as a mysterious reordering.
+              ;;
+              ;; They are child-index deltas exactly like :add/:remove/:update,
+              ;; so they need exactly the same slot→flattened conversion.
+              (:add-fragment :remove-fragment
+               :replace-with-fragment :replace-fragment-with-single)
+              (assoc delta :path [base-idx])
+
+              ;; Anything else: leave alone.
               delta)))
         deltas))
 

--- a/src/org/replikativ/spindel/dom/foreign.cljc
+++ b/src/org/replikativ/spindel/dom/foreign.cljc
@@ -135,14 +135,11 @@
     ;; :style now update like any other element. Children stay EMPTY — that part
     ;; was always right: the whole point is that spindel does not own them.
     ;;
-    ;; It needs an execution context (the caches live there), and `simple-element`
-    ;; was chosen originally precisely BECAUSE it needs none — SSR and unit tests
-    ;; build vdom with no context bound. So: addressed when we can be, simple when
-    ;; we must be. Outside a context there is no re-render, hence nothing to
-    ;; reconcile against, and the frozen attrs cost nothing.
-    (if ec/*execution-context*
-      (el/build-element tag my-addr attrs-with-ref [])
-      (el/simple-element tag attrs-with-ref []))))
+    ;; This REQUIRES an execution context, and that is not a limitation — it is
+    ;; what a foreign node IS. The caches live in the context, and without one
+    ;; there is no reconciliation, no attr deltas, and no lifecycle. Callers that
+    ;; have no context do not want a degraded foreign node; they want an error.
+    (el/build-element tag my-addr attrs-with-ref [])))
 
 ;; =============================================================================
 ;; Macro: foreign-node
@@ -178,9 +175,16 @@
      (let [source-loc {:file *file*
                        :line (:line (meta &form))
                        :column (:column (meta &form))}]
-       `(if ec/*execution-context*
-          (foreign-node* ~source-loc ~opts)
-          ;; Without context: create simple element (no lifecycle callbacks)
-          (el/simple-element (:tag ~opts :div)
-                             (dissoc ~opts :tag :on-mount :on-unmount)
-                             [])))))
+       ;; NO context fallback.
+       ;;
+       ;; This used to degrade to a bare element with the :on-mount/:on-unmount
+       ;; callbacks silently DROPPED — which is not a degraded foreign node, it is
+       ;; a lie. The lifecycle is the entire point: without it your TipTap,
+       ;; CodeMirror or Jitsi call is never constructed, and nothing says so. A
+       ;; div that quietly does nothing is the worst possible failure mode.
+       ;;
+       ;; Nothing legitimate needs that branch: spins always bind a context, and
+       ;; SSR never renders foreign nodes (it cannot — there is no DOM to hand the
+       ;; library). So an absent context is a BUG at the call site, and it now
+       ;; announces itself instead of hiding.
+       `(foreign-node* ~source-loc ~opts))))

--- a/src/org/replikativ/spindel/dom/foreign.cljc
+++ b/src/org/replikativ/spindel/dom/foreign.cljc
@@ -54,7 +54,8 @@
   - Never pass children to foreign-node - they will be ignored
   - The mount/unmount callbacks are synchronous
   - Multiple mounts/unmounts may occur if the element is conditionally rendered"
-  (:require [org.replikativ.spindel.dom.elements :as el]
+  (:require [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.dom.elements :as el]
             [org.replikativ.spindel.dom.addressing :as addr]
             [org.replikativ.spindel.engine.core :as ec]
             [replikativ.logging :as log]))
@@ -121,10 +122,27 @@
         ;; Merge ref into attrs
         attrs-with-ref (assoc attrs :ref ref-fn)]
 
-    ;; Create the container element with no children
-    ;; We use simple-element since we don't need caching for children
-    ;; but we want the element to participate in parent's slot reconciliation
-    (el/simple-element tag attrs-with-ref [])))
+    ;; ADDRESSED, not simple-element.
+    ;;
+    ;; `simple-element` builds a vnode with no `:addr`, so the reconciler has no
+    ;; cache to diff its attrs against and emits no attr deltas — the container's
+    ;; attributes were therefore FROZEN AT MOUNT. You could not toggle a foreign
+    ;; node's :class or :style, ever. That is not a corner: hiding a foreign host
+    ;; (a live call, a video, an editor) instead of unmounting it is precisely how
+    ;; you keep its state alive, and it is done with a class.
+    ;;
+    ;; `build-element` reconciles attrs against the address cache, so :class and
+    ;; :style now update like any other element. Children stay EMPTY — that part
+    ;; was always right: the whole point is that spindel does not own them.
+    ;;
+    ;; It needs an execution context (the caches live there), and `simple-element`
+    ;; was chosen originally precisely BECAUSE it needs none — SSR and unit tests
+    ;; build vdom with no context bound. So: addressed when we can be, simple when
+    ;; we must be. Outside a context there is no re-render, hence nothing to
+    ;; reconcile against, and the frozen attrs cost nothing.
+    (if ec/*execution-context*
+      (el/build-element tag my-addr attrs-with-ref [])
+      (el/simple-element tag attrs-with-ref []))))
 
 ;; =============================================================================
 ;; Macro: foreign-node

--- a/test/org/replikativ/spindel/dom/node_identity_test.cljc
+++ b/test/org/replikativ/spindel/dom/node_identity_test.cljc
@@ -1,0 +1,126 @@
+(ns org.replikativ.spindel.dom.node-identity-test
+  "DOM node IDENTITY and ORDER — the two things a vdom must never get wrong.
+
+   The existing MockDischarge is structurally blind to both: it does not model
+   `childNodes`, so a delta that inserts at the wrong index looks identical to
+   one that inserts at the right index. Both bugs below lived behind that
+   blindness. So this namespace brings its own discharge that keeps a real
+   children vector."
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.dom.cache :as cache]
+            [org.replikativ.spindel.dom.fragment :as frag]))
+
+;; ---------------------------------------------------------------------------
+;; Slot → child index
+;;
+;; A SLOT is a position in the source (one child expression). A CHILD is a DOM
+;; node. They are NOT the same: a nil slot flattens to zero nodes, an ifor-each
+;; slot flattens to many. Every delta path that reaches the DOM must be a CHILD
+;; index — and the conversion is `slot-base-index`.
+;; ---------------------------------------------------------------------------
+
+(defn- slots-of
+  "Build a slot vector: :nil, :single, or :keyed with n items."
+  [& specs]
+  (mapv (fn [spec]
+          (cond
+            (= :nil spec)     {:type :nil :value nil}
+            (number? spec)    {:type :keyed
+                               :value (frag/->KeyedFragment (vec (repeat spec :item)) [])}
+            :else             {:type :single :value spec}))
+        specs))
+
+(deftest fragment-deltas-carry-a-child-index-not-a-slot-index
+  (testing "an ifor-each APPEARING after other children must insert AFTER them.
+
+            :add-fragment used to fall through adjust-delta-paths unadjusted, so
+            discharge received a SLOT index and used it as a CHILD index. With a
+            preceding nil slot (zero nodes) or a preceding fragment (many), those
+            differ — and the list silently materialised in the wrong place."
+    ;; [single, single, <the fragment>] → the fragment's children start at 2
+    (let [slots  (slots-of :a :b 3)
+          deltas [{:delta :add-fragment :path [2]
+                   :value (frag/->KeyedFragment [:x :y :z] [])}]
+          [adj]  (cache/adjust-delta-paths slots deltas)]
+      (is (= [2] (:path adj))
+          "two single slots precede it ⇒ child index 2"))
+
+    ;; a preceding NIL slot occupies a slot but NO child: slot 2 → child 1
+    (let [slots  (slots-of :a :nil 3)
+          deltas [{:delta :add-fragment :path [2]
+                   :value (frag/->KeyedFragment [:x :y :z] [])}]
+          [adj]  (cache/adjust-delta-paths slots deltas)]
+      (is (= [1] (:path adj))
+          "a nil slot flattens to ZERO children — slot 2 is child 1"))
+
+    ;; a preceding FRAGMENT occupies one slot but MANY children: slot 2 → child 4
+    (let [slots  (slots-of :a 3 2)
+          deltas [{:delta :add-fragment :path [2]
+                   :value (frag/->KeyedFragment [:x :y] [])}]
+          [adj]  (cache/adjust-delta-paths slots deltas)]
+      (is (= [4] (:path adj))
+          "1 single + a 3-item fragment precede it — slot 2 is child 4"))))
+
+(deftest fragment-removal-and-replacement-too
+  (testing "the same conversion is needed on the way out and on replacement —
+            they were all in the same unadjusted default branch"
+    (let [slots (slots-of :a :nil 2)]
+      (doseq [kind [:remove-fragment :replace-with-fragment
+                    :replace-fragment-with-single]]
+        (let [[adj] (cache/adjust-delta-paths
+                     slots [{:delta kind :path [2] :value :v :old-value :o}])]
+          (is (= [1] (:path adj))
+              (str kind " must carry a child index, not a slot index")))))))
+
+(deftest simple-deltas-unchanged
+  (testing "the conversion that already worked still works"
+    (let [slots  (slots-of :a :nil 3)
+          [adj]  (cache/adjust-delta-paths
+                  slots [{:delta :update :path [2] :value :v}])]
+      (is (= [1] (:path adj))))))
+
+;; ---------------------------------------------------------------------------
+;; move-child! — see browser.cljs. A DOM move must MOVE the node, not destroy
+;; and recreate it: `removeChild` + `insertBefore` runs the removing steps, which
+;; discard an <iframe>'s browsing context, a <video>'s srcObject, a WebGL
+;; context. `Element.moveBefore()` preserves them. Verified in Chromium; the JVM
+;; test below pins only the INDEX arithmetic, which is the part that can be
+;; got wrong silently (moveBefore is atomic, so the child is still present when
+;; the reference node is chosen — indices do NOT shift as they did before).
+;; ---------------------------------------------------------------------------
+
+(defn- move-ref-index
+  "Which sibling does the node land BEFORE, given the atomic-move semantics?
+   Mirrors browser.cljs/move-child!."
+  [n from to]
+  (when (not= from to)
+    (if (< from to) (inc to) to)))
+
+(defn- simulate-move
+  "Apply the move to a vector, using the ref computed above, and report where
+   the moved element ended up. The invariant: it lands at `to`."
+  [xs from to]
+  (let [child (nth xs from)
+        ref-i (move-ref-index (count xs) from to)
+        ref   (when (and ref-i (< ref-i (count xs))) (nth xs ref-i))
+        without (vec (concat (subvec xs 0 from) (subvec xs (inc from))))
+        pos     (if ref
+                  (.indexOf ^java.util.List without ref)
+                  (count without))]
+    (vec (concat (subvec without 0 pos) [child] (subvec without pos)))))
+
+(deftest atomic-move-lands-at-the-requested-index
+  (testing "for EVERY (from,to) the moved child must end up at `to`.
+
+            The old code removed the child first and indexed the shortened list.
+            moveBefore is atomic — the child is still there — so the reference
+            node must be chosen with the shift accounted for. Getting it wrong is
+            an off-by-one that silently misorders lists."
+    (let [xs [:a :b :c :d :e]]
+      (doseq [from (range 5)
+              to   (range 5)
+              :when (not= from to)]
+        (let [moved (nth xs from)
+              out   (simulate-move xs from to)]
+          (is (= to (.indexOf ^java.util.List out moved))
+              (str "move " from " → " to " landed wrong: " out)))))))

--- a/test/org/replikativ/spindel/dom/ref_test.cljc
+++ b/test/org/replikativ/spindel/dom/ref_test.cljc
@@ -6,6 +6,8 @@
             [org.replikativ.spindel.dom.elements :as el]
             [org.replikativ.spindel.dom.discharge :as disch]
             [org.replikativ.spindel.dom.foreign :as foreign]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as ctx]
             #?(:clj [org.replikativ.spindel.test-helpers :as th])))
 
 ;; =============================================================================
@@ -94,79 +96,97 @@
 
 ;; =============================================================================
 ;; Foreign Node Tests
+;;
+;; These bind an execution context, like every other DOM test — because a
+;; foreign node REQUIRES one. They used to call `foreign-node*` bare, and the
+;; first test was even named "creates a vnode without context", encoding the bug
+;; as intent. A context-free foreign node cannot reconcile its attrs (they froze
+;; at mount) and, through the macro, silently dropped its :on-mount/:on-unmount
+;; entirely — a div pretending to be an editor.
 ;; =============================================================================
 
+(defmacro with-ctx
+  "Run body with a fresh execution context bound — what a spin always provides."
+  [& body]
+  `(let [ctx# (ctx/create-execution-context)]
+     (binding [ec/*execution-context* ctx#]
+       ~@body)))
+
 (deftest test-foreign-node-creation
-  (testing "foreign-node creates a vnode without context"
-    (let [mount-calls (atom [])
-          unmount-calls (atom [])
-          vnode (foreign/foreign-node*
-                 {:file "test" :line 1 :column 1}
-                 {:class "editor"
-                  :on-mount (fn [el] (swap! mount-calls conj el))
-                  :on-unmount (fn [_] (swap! unmount-calls conj :unmount))})]
-      (is (= :div (:tag vnode)))
-      (is (= {:class "editor"} @(:attrs vnode)))
-      (is (fn? (:ref vnode))))))
+  (testing "foreign-node builds an ADDRESSED vnode, so its attrs can be reconciled"
+    (with-ctx
+      (let [mount-calls   (atom [])
+            unmount-calls (atom [])
+            vnode (foreign/foreign-node*
+                   {:file "test" :line 1 :column 1}
+                   {:class "editor"
+                    :on-mount   (fn [el] (swap! mount-calls conj el))
+                    :on-unmount (fn [_] (swap! unmount-calls conj :unmount))})]
+        (is (= :div (:tag vnode)))
+        (is (= {:class "editor"} @(:attrs vnode)))
+        (is (fn? (:ref vnode)))
+        (is (some? (:addr vnode))
+            "an :addr is what lets the reconciler diff attrs — without it :class
+             and :style are frozen at mount, and a foreign host can never be
+             hidden instead of unmounted")))))
 
 (deftest test-foreign-node-with-custom-tag
   (testing "foreign-node respects custom tag"
-    (let [vnode (foreign/foreign-node*
-                 {:file "test" :line 1 :column 1}
-                 {:tag :pre
-                  :class "code"})]
-      (is (= :pre (:tag vnode))))))
+    (with-ctx
+      (let [vnode (foreign/foreign-node*
+                   {:file "test" :line 1 :column 1}
+                   {:tag :pre :class "code"})]
+        (is (= :pre (:tag vnode)))))))
 
 (deftest test-foreign-node-mount-callback
   (testing "foreign-node mount callback is called during render"
-    (let [mount-calls (atom [])
-          vnode (foreign/foreign-node*
-                 {:file "test" :line 1 :column 1}
-                 {:on-mount (fn [el] (swap! mount-calls conj el))})
-          {:keys [discharge]} (disch/make-mock-discharge)]
-      ;; Render the foreign node
-      (disch/render-initial! discharge vnode)
-      ;; Mount callback should have been called via ref
-      (is (= 1 (count @mount-calls)))
-      (is (some? (first @mount-calls))))))
+    (with-ctx
+      (let [mount-calls (atom [])
+            vnode (foreign/foreign-node*
+                   {:file "test" :line 1 :column 1}
+                   {:on-mount (fn [el] (swap! mount-calls conj el))})
+            {:keys [discharge]} (disch/make-mock-discharge)]
+        (disch/render-initial! discharge vnode)
+        (is (= 1 (count @mount-calls)))
+        (is (some? (first @mount-calls)))))))
 
 (deftest test-foreign-node-unmount-callback
   (testing "foreign-node unmount callback is called on remove"
-    (let [unmount-calls (atom [])
-          vnode (foreign/foreign-node*
-                 {:file "test" :line 1 :column 1}
-                 {:on-unmount (fn [_] (swap! unmount-calls conj :unmounted))})
-          {:keys [discharge]} (disch/make-mock-discharge)
-          parent-el :mock-parent]
-      ;; First render
-      (disch/render-initial! discharge vnode)
-      (is (empty? @unmount-calls) "Unmount should not be called yet")
-      ;; Apply remove delta
-      (disch/apply-child-delta! discharge parent-el
-                                {:delta :remove :path [0] :old-value vnode})
-      (is (= 1 (count @unmount-calls))))))
+    (with-ctx
+      (let [unmount-calls (atom [])
+            vnode (foreign/foreign-node*
+                   {:file "test" :line 1 :column 1}
+                   {:on-unmount (fn [_] (swap! unmount-calls conj :unmounted))})
+            {:keys [discharge]} (disch/make-mock-discharge)
+            parent-el :mock-parent]
+        (disch/render-initial! discharge vnode)
+        (is (empty? @unmount-calls) "Unmount should not be called yet")
+        (disch/apply-child-delta! discharge parent-el
+                                  {:delta :remove :path [0] :old-value vnode})
+        (is (= 1 (count @unmount-calls)))))))
 
 (deftest test-foreign-node-error-handling
   (testing "foreign-node callback errors are caught"
-    (let [mount-error (atom false)
-          unmount-error (atom false)
-          vnode (foreign/foreign-node*
-                 {:file "test" :line 1 :column 1}
-                 {:on-mount (fn [_]
-                              (reset! mount-error true)
-                              (throw (#?(:clj Exception. :cljs js/Error.) "Mount error")))
-                  :on-unmount (fn [_]
-                                (reset! unmount-error true)
-                                (throw (#?(:clj Exception. :cljs js/Error.) "Unmount error")))})
-          {:keys [discharge]} (disch/make-mock-discharge)
-          parent-el :mock-parent]
+    (with-ctx
+      (let [mount-error (atom false)
+            unmount-error (atom false)
+            vnode (foreign/foreign-node*
+                   {:file "test" :line 1 :column 1}
+                   {:on-mount (fn [_]
+                                (reset! mount-error true)
+                                (throw (#?(:clj Exception. :cljs js/Error.) "Mount error")))
+                    :on-unmount (fn [_]
+                                  (reset! unmount-error true)
+                                  (throw (#?(:clj Exception. :cljs js/Error.) "Unmount error")))})
+            {:keys [discharge]} (disch/make-mock-discharge)
+            parent-el :mock-parent]
       ;; Should not throw on mount
-      (disch/render-initial! discharge vnode)
-      (is @mount-error "Mount callback should have been called")
+        (disch/render-initial! discharge vnode)
+        (is @mount-error "Mount callback should have been called")
       ;; Should not throw on unmount
-      (disch/apply-child-delta! discharge parent-el
-                                {:delta :remove :path [0] :old-value vnode})
-      (is @unmount-error "Unmount callback should have been called"))))
+        (disch/apply-child-delta! discharge parent-el
+                                  {:delta :remove :path [0] :old-value vnode})
+        (is @unmount-error "Unmount callback should have been called")))))
 
 ;; =============================================================================
 ;; In-place reconciliation tests (Π3)

--- a/test/org/replikativ/spindel/dom/ref_test.cljc
+++ b/test/org/replikativ/spindel/dom/ref_test.cljc
@@ -105,88 +105,96 @@
 ;; entirely — a div pretending to be an editor.
 ;; =============================================================================
 
-(defmacro with-ctx
-  "Run body with a fresh execution context bound — what a spin always provides."
-  [& body]
-  `(let [ctx# (ctx/create-execution-context)]
-     (binding [ec/*execution-context* ctx#]
-       ~@body)))
+(defn with-ctx
+  "Run `f` with a fresh execution context bound — what a spin always provides.
+
+   A FUNCTION, not a macro: a `defmacro` in a .cljc file is invisible to
+   ClojureScript unless the ns requires its own macros, so it silently compiles
+   to a function call and dies as a TypeError at runtime. A thunk sidesteps the
+   whole question and reads the same."
+  [f]
+  (let [ctx (ctx/create-execution-context)]
+    (binding [ec/*execution-context* ctx]
+      (f))))
 
 (deftest test-foreign-node-creation
   (testing "foreign-node builds an ADDRESSED vnode, so its attrs can be reconciled"
     (with-ctx
-      (let [mount-calls   (atom [])
-            unmount-calls (atom [])
-            vnode (foreign/foreign-node*
-                   {:file "test" :line 1 :column 1}
-                   {:class "editor"
-                    :on-mount   (fn [el] (swap! mount-calls conj el))
-                    :on-unmount (fn [_] (swap! unmount-calls conj :unmount))})]
-        (is (= :div (:tag vnode)))
-        (is (= {:class "editor"} @(:attrs vnode)))
-        (is (fn? (:ref vnode)))
-        (is (some? (:addr vnode))
-            "an :addr is what lets the reconciler diff attrs — without it :class
-             and :style are frozen at mount, and a foreign host can never be
-             hidden instead of unmounted")))))
+      (fn []
+        (let [mount-calls   (atom [])
+              unmount-calls (atom [])
+              vnode (foreign/foreign-node*
+                     {:file "test" :line 1 :column 1}
+                     {:class "editor"
+                      :on-mount   (fn [el] (swap! mount-calls conj el))
+                      :on-unmount (fn [_] (swap! unmount-calls conj :unmount))})]
+          (is (= :div (:tag vnode)))
+          (is (= {:class "editor"} @(:attrs vnode)))
+          (is (fn? (:ref vnode)))
+          (is (some? (:addr vnode))
+              "the :addr is what lets the reconciler diff attrs — without it :class
+               and :style freeze at mount, and a foreign host can never be HIDDEN
+               instead of unmounted, which is the only way to keep its state alive"))))))
 
 (deftest test-foreign-node-with-custom-tag
   (testing "foreign-node respects custom tag"
     (with-ctx
-      (let [vnode (foreign/foreign-node*
-                   {:file "test" :line 1 :column 1}
-                   {:tag :pre :class "code"})]
-        (is (= :pre (:tag vnode)))))))
+      (fn []
+        (let [vnode (foreign/foreign-node*
+                     {:file "test" :line 1 :column 1}
+                     {:tag :pre :class "code"})]
+          (is (= :pre (:tag vnode))))))))
 
 (deftest test-foreign-node-mount-callback
   (testing "foreign-node mount callback is called during render"
     (with-ctx
-      (let [mount-calls (atom [])
-            vnode (foreign/foreign-node*
-                   {:file "test" :line 1 :column 1}
-                   {:on-mount (fn [el] (swap! mount-calls conj el))})
-            {:keys [discharge]} (disch/make-mock-discharge)]
-        (disch/render-initial! discharge vnode)
-        (is (= 1 (count @mount-calls)))
-        (is (some? (first @mount-calls)))))))
+      (fn []
+        (let [mount-calls (atom [])
+              vnode (foreign/foreign-node*
+                     {:file "test" :line 1 :column 1}
+                     {:on-mount (fn [el] (swap! mount-calls conj el))})
+              {:keys [discharge]} (disch/make-mock-discharge)]
+          (disch/render-initial! discharge vnode)
+          (is (= 1 (count @mount-calls)))
+          (is (some? (first @mount-calls))))))))
 
 (deftest test-foreign-node-unmount-callback
   (testing "foreign-node unmount callback is called on remove"
     (with-ctx
-      (let [unmount-calls (atom [])
-            vnode (foreign/foreign-node*
-                   {:file "test" :line 1 :column 1}
-                   {:on-unmount (fn [_] (swap! unmount-calls conj :unmounted))})
-            {:keys [discharge]} (disch/make-mock-discharge)
-            parent-el :mock-parent]
-        (disch/render-initial! discharge vnode)
-        (is (empty? @unmount-calls) "Unmount should not be called yet")
-        (disch/apply-child-delta! discharge parent-el
-                                  {:delta :remove :path [0] :old-value vnode})
-        (is (= 1 (count @unmount-calls)))))))
+      (fn []
+        (let [unmount-calls (atom [])
+              vnode (foreign/foreign-node*
+                     {:file "test" :line 1 :column 1}
+                     {:on-unmount (fn [_] (swap! unmount-calls conj :unmounted))})
+              {:keys [discharge]} (disch/make-mock-discharge)
+              parent-el :mock-parent]
+          (disch/render-initial! discharge vnode)
+          (is (empty? @unmount-calls) "Unmount should not be called yet")
+          (disch/apply-child-delta! discharge parent-el
+                                    {:delta :remove :path [0] :old-value vnode})
+          (is (= 1 (count @unmount-calls))))))))
 
 (deftest test-foreign-node-error-handling
   (testing "foreign-node callback errors are caught"
     (with-ctx
-      (let [mount-error (atom false)
-            unmount-error (atom false)
-            vnode (foreign/foreign-node*
-                   {:file "test" :line 1 :column 1}
-                   {:on-mount (fn [_]
-                                (reset! mount-error true)
-                                (throw (#?(:clj Exception. :cljs js/Error.) "Mount error")))
-                    :on-unmount (fn [_]
-                                  (reset! unmount-error true)
-                                  (throw (#?(:clj Exception. :cljs js/Error.) "Unmount error")))})
-            {:keys [discharge]} (disch/make-mock-discharge)
-            parent-el :mock-parent]
-      ;; Should not throw on mount
-        (disch/render-initial! discharge vnode)
-        (is @mount-error "Mount callback should have been called")
-      ;; Should not throw on unmount
-        (disch/apply-child-delta! discharge parent-el
-                                  {:delta :remove :path [0] :old-value vnode})
-        (is @unmount-error "Unmount callback should have been called")))))
+      (fn []
+        (let [mount-error   (atom false)
+              unmount-error (atom false)
+              vnode (foreign/foreign-node*
+                     {:file "test" :line 1 :column 1}
+                     {:on-mount (fn [_]
+                                  (reset! mount-error true)
+                                  (throw (#?(:clj Exception. :cljs js/Error.) "Mount error")))
+                      :on-unmount (fn [_]
+                                    (reset! unmount-error true)
+                                    (throw (#?(:clj Exception. :cljs js/Error.) "Unmount error")))})
+              {:keys [discharge]} (disch/make-mock-discharge)
+              parent-el :mock-parent]
+          (disch/render-initial! discharge vnode)
+          (is @mount-error "Mount callback should have been called")
+          (disch/apply-child-delta! discharge parent-el
+                                    {:delta :remove :path [0] :old-value vnode})
+          (is @unmount-error "Unmount callback should have been called"))))))
 
 ;; =============================================================================
 ;; In-place reconciliation tests (Π3)


### PR DESCRIPTION
Three DOM-layer defects, found by asking why a Jitsi call in simmis dies
when you switch tabs. The call is the loud symptom; two of these are
silent.

### 1. A DOM move DESTROYED the node instead of moving it

`move-child!` was `removeChild` + `insertBefore`. For most elements that
is invisible. For anything holding state OUTSIDE the element — an
`<iframe>`'s browsing context, a `<video>`'s live `srcObject`, a WebGL
context, an editor's selection — removal runs the DOM *removing steps*,
which discard it. **A live call was destroyed by a mere sibling reorder.**

`Element.moveBefore()` moves without removing. Measured in Chromium, with
a counter living inside the iframe's document:

| | iframe state |
|---|---|
| `removeChild` + `insertBefore` | **destroyed** |
| `moveBefore` — sibling reorder | preserved |
| `moveBefore` — change of parent | preserved |

⚠️ **Index subtlety**: `moveBefore` is *atomic*, so the child is still
present when the reference node is chosen — indices do NOT shift as they
did when we removed first. Picking the wrong reference is an off-by-one
that silently misorders lists. Pinned by an exhaustive test over every
`(from,to)` on 5 nodes, on **both** the `moveBefore` and fallback paths.

The fallback is load-bearing, not decoration: `moveBefore` throws
`HierarchyRequestError` on disconnected nodes, and pre-2025 browsers lack
it. (That same throw also proves a React-style *detached* keep-alive cache
is impossible for iframes — worth knowing before anyone designs one.)

### 2. Fragment deltas carried a SLOT index where a CHILD index was due

`adjust-delta-paths` converted `:add`/`:remove`/`:update` from slot index
to flattened child index — but `:add-fragment`, `:remove-fragment`,
`:replace-with-fragment` and `:replace-fragment-with-single` fell through
**unadjusted**, and discharge then used `(first path)` as a DOM child
index.

Slots are not children: a `:nil` slot flattens to **zero** nodes, a
`:keyed` slot to **many**. So an `ifor-each` appearing after such a sibling
inserted its items at the wrong index. simmis's `columns-container` has
exactly this shape (drop zone → `ifor-each` → drop zone).

The existing `MockDischarge` is structurally blind to this — it does not
model `childNodes`, so a wrong index looks like a right one. Hence a new
test ns.

### 3. `foreign-node`'s attributes were frozen at mount

It built its container with `simple-element`, which carries no `:addr`, so
the reconciler had no cache to diff against and emitted no attr deltas.
**You could not toggle a foreign node's `:class` or `:style`.**

Not a corner case: *hiding* a foreign host instead of unmounting it is
exactly how its state is kept alive — and it is done with a class. Now
addressed via `build-element` when an execution context is bound, and
`simple-element` when there is none (SSR and unit tests build vdom with no
context; without a context there is no re-render, so frozen attrs cost
nothing).

### Tests

914 tests, 3159 assertions, 0 failures. The new
`dom/node_identity_test.cljc` **fails on the unfixed engine**.

### Not in this PR, deliberately

`.internal/dom-layer-assessment.md` (added here) concludes the reconciler
is **not** naive — the keyed diff emits zero moves for every shape simmis
produces — and that a **portal primitive should NOT be built for one use
case**. The remaining simmis symptom (tab switch *unmounts* the call,
which no move-fix can address) is solved app-side by keeping the host
connected and hiding it with `display:none` — verified to preserve the
iframe, and now actually possible thanks to fix 3.