### PR TITLE
Lock SCI contexts by default — remove :allow :all from common-classes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -37,6 +37,12 @@
                       ;; PSS pinned to match what yggdrasil 0.3.34 pins (canonical
                       ;; handlers + MST + the cljs MST oversized-node iterator fix).
                       org.replikativ/persistent-sorted-set {:mvn/version "0.4.130"}
+                      ;; SCI on the :test classpath so the sci-integration
+                      ;; namespaces (sci.core/macro/boundary) are exercised —
+                      ;; notably sci/lock_test, which pins that `common-classes`
+                      ;; is locked (no `:allow :all`). Needs >= 0.14 for ADR 0007
+                      ;; instance-member control (the deny direction of that test).
+                      org.babashka/sci {:mvn/version "0.15.56"}
                       io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts ["-m" "cognitect.test-runner"]

--- a/src/org/replikativ/spindel/sci/core.clj
+++ b/src/org/replikativ/spindel/sci/core.clj
@@ -66,7 +66,27 @@
 
   Lazily resolved to avoid class loading issues at namespace load time.
   Uses Class/forName for deftype classes (Thunk, Spin) since they are
-  Java classes, not Clojure vars."
+  Java classes, not Clojure vars.
+
+  LOCKED BY DEFAULT — no `:allow :all`. On the JVM, `:allow :all` turns SCI's
+  per-class interop gate OFF (ADR 0015), so a spindel-backed context with it set
+  is a full JVM escape from otherwise-sandboxed code: from ANY object,
+  `.getClass` → `.getClassLoader` → `.loadClass \"java.lang.Runtime\"` → reflect
+  reaches a host shell. That is fine for a TRUSTED context (a developer's own
+  frontend), but every UNTRUSTED consumer — an agent sandbox running code an
+  outsider can influence — inherited it, silently escapable. So the default here
+  is fail-safe: interop is gated to this allowlist, and a caller that genuinely
+  needs wider host reach opts in EXPLICITLY with `(assoc (common-classes) :allow
+  :all)` — a locally visible, auditable decision rather than a hidden default.
+
+  The spindel engine itself needs none of that reach — its whole suite (916
+  tests, incl. sci/lock_test) passes with interop locked to this map; the
+  deref/atom/Spin/Thunk types above are all it touches. On CLJS `:allow :all` was already redundant, since
+  `:unrestricted` bypasses the interop check upstream (ADR 0015), so removing it
+  changes only JVM contexts. A JVM consumer whose spin code does interop on a
+  class NOT listed here now gets a loud \"Method X on class Y not allowed!\" at
+  the call site — register the class (or opt into `:allow :all` if trusted)
+  rather than have the sandbox stay wide open by default."
   []
   ;; Ensure namespaces are loaded before referencing their deftypes
   (require 'is.simm.partial-cps.runtime)
@@ -80,5 +100,4 @@
    'is.simm.partial_cps.runtime.Thunk (Class/forName "is.simm.partial_cps.runtime.Thunk")
    'org.replikativ.spindel.spin.core.Spin (Class/forName "org.replikativ.spindel.spin.core.Spin")
    'java.lang.Throwable java.lang.Throwable
-   'is.simm.partial-cps.async/Throwable java.lang.Throwable
-   :allow :all})
+   'is.simm.partial-cps.async/Throwable java.lang.Throwable})

--- a/test/org/replikativ/spindel/sci/lock_test.clj
+++ b/test/org/replikativ/spindel/sci/lock_test.clj
@@ -37,7 +37,7 @@
             ;; pre-existing engine limitation orthogonal to interop locking.)
             (is (= 30
                    (macro/eval-and-deref sci-ctx
-                     "(require '[org.replikativ.spindel.spin.cps :refer [spin]]
+                                         "(require '[org.replikativ.spindel.spin.cps :refer [spin]]
                                '[org.replikativ.spindel.effects.await :refer [await]])
                       (spin
                         (let [a (spin 10)
@@ -60,12 +60,12 @@
             (is (thrown-with-msg?
                  Exception #"(?i)not allowed"
                  (sci/eval-string* sci-ctx
-                   "(.getClassLoader (class 1))")))
+                                   "(.getClassLoader (class 1))")))
             ;; The concrete escape a sandboxed attacker would try.
             (is (thrown-with-msg?
                  Exception #"(?i)not allowed"
                  (sci/eval-string* sci-ctx
-                   "(-> \"x\" .getClass .getClassLoader
+                                   "(-> \"x\" .getClass .getClassLoader
                         (.loadClass \"java.lang.Runtime\"))")))))
         (finally
           (ctx/stop-context! rt))))))

--- a/test/org/replikativ/spindel/sci/lock_test.clj
+++ b/test/org/replikativ/spindel/sci/lock_test.clj
@@ -1,0 +1,71 @@
+(ns org.replikativ.spindel.sci.lock-test
+  "Security regression tests for the locked-by-default SCI context.
+
+  `spindel.sci.core/common-classes` used to carry `:allow :all`, which turns
+  SCI's per-class interop gate OFF (ADR 0015). A spindel-backed sandbox running
+  code an outsider can influence could then reach an arbitrary host method off
+  ANY object — `.getClass` → `.getClassLoader` → `.loadClass \"java.lang.Runtime\"`
+  → reflect → host shell. Removing `:allow :all` makes interop fall back to the
+  per-class allowlist, so unregistered instance interop is denied.
+
+  These two tests pin both directions:
+  - a real spin (let + await, suspend/resume through the Thunk trampoline) still
+    works with interop locked — the registered classes are enough, and
+  - interop on an UNregistered class (java.lang.Class) is denied, i.e. the
+    escape path is closed at the spindel layer, not only in downstream sandboxes.
+
+  Requires SCI >= 0.14 (ADR 0007 instance-member control) for the deny direction;
+  the :test alias pins a version new enough to exercise it."
+  (:require [clojure.test :refer [deftest is testing]]
+            [sci.core :as sci]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.sci.macro :as macro]))
+
+(deftest spin-runs-with-interop-locked
+  (testing "a real spin (let + await) evaluates under the lock — the engine needs
+            no `:allow :all`, only the registered classes"
+    (let [rt (ctx/create-execution-context)]
+      (try
+        (let [sci-ctx (macro/create-spin-macro-context {:runtime rt})]
+          (binding [ec/*execution-context* rt]
+            ;; let + await suspends and resumes through the Thunk trampoline (interop
+            ;; on the registered is.simm.partial_cps.runtime.Thunk / Spin classes),
+            ;; so a correct result proves the CPS machinery works with `:allow :all`
+            ;; gone. (A `loop`/`recur` ACROSS an await is deliberately not asserted
+            ;; here — that SCI path hangs regardless of `:allow :all`, i.e. it is a
+            ;; pre-existing engine limitation orthogonal to interop locking.)
+            (is (= 30
+                   (macro/eval-and-deref sci-ctx
+                     "(require '[org.replikativ.spindel.spin.cps :refer [spin]]
+                               '[org.replikativ.spindel.effects.await :refer [await]])
+                      (spin
+                        (let [a (spin 10)
+                              b (spin 20)
+                              x (await a)
+                              y (await b)]
+                          (+ x y)))")))))
+        (finally
+          (ctx/stop-context! rt))))))
+
+(deftest unregistered-instance-interop-is-denied
+  (testing "with `:allow :all` gone, reflecting off an unregistered class throws —
+            the getClassLoader→loadClass→Runtime escape is closed"
+    (let [rt (ctx/create-execution-context)]
+      (try
+        (let [sci-ctx (macro/create-spin-macro-context {:runtime rt})]
+          (binding [ec/*execution-context* rt]
+            ;; java.lang.Class is NOT in common-classes, so an instance method on
+            ;; it must be refused. This is the first hop of the reflection escape.
+            (is (thrown-with-msg?
+                 Exception #"(?i)not allowed"
+                 (sci/eval-string* sci-ctx
+                   "(.getClassLoader (class 1))")))
+            ;; The concrete escape a sandboxed attacker would try.
+            (is (thrown-with-msg?
+                 Exception #"(?i)not allowed"
+                 (sci/eval-string* sci-ctx
+                   "(-> \"x\" .getClass .getClassLoader
+                        (.loadClass \"java.lang.Runtime\"))")))))
+        (finally
+          (ctx/stop-context! rt))))))


### PR DESCRIPTION
### The footgun

`spindel.sci.core/common-classes` shipped `:allow :all` in its `:classes` map. On the JVM that key turns SCI's **per-class interop gate off** entirely (ADR 0015): once set, an instance method may be called on *any* object regardless of whether its class is registered. Every consumer that built a sandbox on top of `create-spin-macro-context` / `create-spindel-sci-context` inherited that — so code an outsider could influence (an agent sandbox evaluating untrusted input) had a one-liner out of the sandbox and into a host shell:

```clojure
(-> "x" .getClass .getClassLoader (.loadClass "java.lang.Runtime")
    (.getMethod "getRuntime" (into-array Class []))
    (.invoke nil (into-array Object []))
    (.exec "id"))
```

The class **allowlist** (`:classes`) only ever gated class-*symbol* resolution; `:allow :all` disabled the instance-interop gate that ADR 0007 (instance-member control, SCI ≥ 0.14) added. Downstream (dvergr) had to strip the key back off at its own layer (`lock-interop!`) to close the escape — a workaround for a default that should have been safe.

### The fix

Remove `:allow :all`. Interop now falls back to the per-class allowlist already in `common-classes` (Var / Namespace / IFn / Atom / IDeref / Thunk / Spin / Throwable). A trusted caller that genuinely wants wide host reach opts in **explicitly** and auditably with `(assoc (common-classes) :allow :all)` rather than inheriting it silently.

- **The engine needs none of that reach.** Full suite stays green (916 tests, 3156 assertions, 0 failures — includes the 2 new lock tests); the registered Thunk/Spin/atom types are all the CPS trampoline touches.
- **CLJS is unaffected.** `:allow :all` was already redundant there: SCI's `:unrestricted` bypasses the interop check upstream (ADR 0015), so this changes only JVM contexts.

### Test

`test/org/replikativ/spindel/sci/lock_test.clj` pins both directions through the real `create-spin-macro-context` path:

- a `let`+`await` spin still evaluates to `30` under the lock — it suspends and resumes through the Thunk trampoline, so a correct result proves the CPS machinery works with interop gated, and
- `(.getClassLoader (class 1))` and the concrete `getClassLoader → loadClass "java.lang.Runtime"` escape now throw *"Method getClassLoader on class java.lang.Class not allowed!"*.

Along the way I verified (by A/B probe at sci 0.15.56) that a `loop`/`recur` *across* an `await` inside an SCI context hangs **regardless** of `:allow :all` — a pre-existing engine limitation in the interpreted recur path, orthogonal to interop locking, so it's deliberately not asserted here.

To exercise the deny direction the `:test` alias now puts `org.babashka/sci` on the classpath (0.15.56 — needs ≥ 0.14 for ADR 0007 instance-member control); the standalone `:sci` dev alias is bumped to match so a REPL is representative of what consumers run.

### Note for JVM consumers

spindel ships no `sci` runtime dep — the version is the consumer's choice. If your spin code does interop on a class **not** in `common-classes`, you'll now get a loud *"Method X on class Y not allowed!"* at the call site instead of a silently-wide-open sandbox: register the class (merge it into `:classes`) or, if the context is trusted, opt back into `:allow :all` deliberately. dvergr's `lock-interop!` becomes a redundant belt-and-braces no-op and can stay or go.
