### PR TITLE
fix(dom): the caches advance on COMMIT, not on compute (R3)

### DIFF
--- a/docs/engine-formalism.md
+++ b/docs/engine-formalism.md
@@ -689,6 +689,41 @@ Because a changed root re-mounts (and thus loses DOM state), **keep a spin's roo
 element structurally stable** and branch *inside* it. This is the loading-state
 idiom: one container with a stable key, `cond`/`if` on the content within.
 
+**R3 — The caches are a model of the DOM, so they advance on commit, not on
+compute.** `build-element` (and `ifor-each`) reconcile against the committed
+caches but write their results to a STAGING area (`[:dom/pending]`);
+`cache/commit-pending!` promotes staging only for addresses present in a vdom
+tree that actually reached the DOM. There are exactly four commit points —
+`initial-mount!`, both branches of `update-render!`, and `discharge-all!`. On
+the paths that evict (`update-render!`, `discharge-all!`), the commit sits
+immediately BEFORE the eviction flush, so an address unmounted in the same
+pass cannot be resurrected by its own promotion; `initial-mount!` evicts
+nothing, and commits once the tree is appended. The initial-mount commit is
+the one that matters most: a spin with no tracks runs its body exactly once,
+there — if its staging is not promoted then, it never is, and the next parent
+re-emission reconciles against nil and re-emits `:add` for a subtree the DOM
+already holds, duplicating it.
+
+Why this is a rule and not an optimization: the engine may abandon a body
+slice AFTER it has built its elements — a slice that suspends on an `await`
+is truncated and cancelled when a newer signal value resumes the track
+continuation above it (`truncate-stale-conts!`), and every improvement to
+cancellation correctness increases how often that happens. Advancing the
+caches at compute time meant an abandoned slice still moved the baseline: the
+committed run then reconciled against state the DOM had never seen, produced
+no deltas, and the change was lost silently — and because child deltas carry
+positions, the slot cache's fiction made the NEXT transition remove a live
+sibling at the wrong index. (Regression: `dom/superseded_run_test.clj`; the
+zero-op no-change re-render test there is the detector for a MISSED commit
+point — a tree whose staging is never promoted re-emits its whole mount as
+`:add` on the following pass.)
+
+Two scoped exceptions, stated so they are read as design rather than bugs:
+SSR builds stage and never commit (a one-shot context; the staging dies with
+it), and a vnode whose deltas were dropped for want of a bound element still
+commits with its tree — that case already logs `::deltas-dropped-unbound-addr`
+loudly and matches prior behaviour.
+
 ### Invariant summary table
 
 | composition          | glitch-free | no double-exec | no stale-cache | no orphan cont | deterministic id |

--- a/src/org/replikativ/spindel/dom/cache.cljc
+++ b/src/org/replikativ/spindel/dom/cache.cljc
@@ -85,6 +85,101 @@
   [addr attrs]
   (ec/swap-state! [:dom/attr-cache addr] (constantly attrs)))
 
+;; =============================================================================
+;; Staging — the caches model the DOM, so they advance on COMMIT, not on compute
+;; =============================================================================
+;;
+;; A reconciliation writes its result HERE, not into the committed caches. The
+;; committed caches are promoted only for addresses that appear in a vdom tree
+;; that was actually discharged (`commit-pending!`, called from
+;; `discharge-all!`).
+;;
+;; Why: a body slice can build its elements and then suspend on an `await`. If
+;; a newer signal value resumes the track continuation above it, `resume-body!`
+;; truncates and CANCELS that slice — its CPS chain never resolves, so its
+;; vnode never reaches the render effect. Advancing the caches while computing
+;; meant that abandoned run still moved the baseline: the next run reconciled
+;; against a value the DOM had never been told about, produced no deltas, and
+;; the change was lost with nothing logged.
+;;
+;; Worse, it compounded. A lost `:add` left the slot cache claiming a child the
+;; DOM never gained, so the following transition removed the wrong index — a
+;; live sibling — and every index after it was off by one.
+;;
+;; Staging makes abandonment free: a slice that never reaches the DOM never
+;; moves the baseline.
+
+(defn stage-attrs!
+  "Stage reconciled attrs for `addr`. Promoted by `commit-pending!`."
+  [addr attrs]
+  (ec/swap-state! [:dom/pending addr] (fn [m] (assoc m :attrs attrs))))
+
+(defn stage-slots!
+  "Stage reconciled slots for `addr`. Promoted by `commit-pending!`."
+  [addr slots]
+  (ec/swap-state! [:dom/pending addr] (fn [m] (assoc m :slots slots))))
+
+(defn stage-keyed!
+  "Stage an `ifor-each` keyed cache for its call-site `addr`."
+  [addr cache-data]
+  (ec/swap-state! [:dom/pending addr] (fn [m] (assoc m :keyed cache-data))))
+
+(defn- keyed-frag-addrs
+  "The `ifor-each` call-site addresses reachable from `slots`.
+
+   A `:keyed` slot holds a KeyedFragment whose `:addr` is the call site — an
+   address that appears on NO vnode, because `flatten-slot` splices the
+   fragment's items into `:children` and drops the fragment itself. The commit
+   sweep walks vnodes, so it cannot see these; they are reached the same way
+   `evict-cache!` reaches them, through the parent's slots."
+  [slots]
+  (into #{} (keep (fn [slot]
+                    (when (= :keyed (:type slot))
+                      (:addr (:value slot))))
+                  slots)))
+
+(defn commit-pending!
+  "Promote staged cache entries for `live-addrs`, and drop the rest.
+
+   `live-addrs` is every `:addr` in the vdom tree that was just discharged.
+   An address that was staged by a run whose output never reached the DOM is
+   absent from that set, so its staging is discarded and the committed cache
+   keeps describing what the DOM actually holds.
+
+   Fragment call sites are folded in transitively: they hang off a parent's
+   `:keyed` slots rather than off any vnode, and a fragment's own items can in
+   turn contain further fragments, so this closes over the staged slots until
+   the live set stops growing."
+  [live-addrs]
+  (let [pending (ec/get-state [:dom/pending])]
+    (when (seq pending)
+      (let [live (loop [live (set live-addrs)]
+                   (let [more (into live
+                                    (mapcat (fn [addr]
+                                              (keyed-frag-addrs (get-in pending [addr :slots])))
+                                            live))]
+                     (if (= (count more) (count live)) live (recur more))))]
+        (doseq [[addr entry] pending
+                :when (contains? live addr)]
+          (when (contains? entry :attrs)
+            (ec/swap-state! [:dom/attr-cache addr] (constantly (:attrs entry))))
+          (when (contains? entry :slots)
+            (ec/swap-state! [:dom/cache addr] (constantly (:slots entry))))
+          (when (contains? entry :keyed)
+            (ec/swap-state! [:dom/keyed-cache addr] (constantly (:keyed entry)))))
+        ;; Drop ONLY what was promoted. Staging for addresses outside this tree
+        ;; is kept, not discarded: a child spin resolves on its own schedule, so
+        ;; it can stage its build one pass and have its vnode embedded by the
+        ;; parent in a later one. Clearing wholesale destroyed that staging in
+        ;; between, the child's cache never advanced, and it re-emitted `:add`
+        ;; on the next build — duplicating its subtree (caught by
+        ;; cross-spin-rerender and ifor-each-oscillation).
+        ;;
+        ;; Retained staging is not a leak: a rebuild overwrites its address,
+        ;; `evict-cache!` drops it on unmount, and snapshot cleaning drops the
+        ;; whole map.
+        (ec/swap-state! [:dom/pending] (fn [m] (apply dissoc m (filter live (keys m)))))))))
+
 (defn evict-cache!
   "Drop all per-address engine state for an element address.
 
@@ -113,7 +208,10 @@
     (ec/swap-state! [:dom/cache] (fn [m] (dissoc m addr)))
     (ec/swap-state! [:dom/attr-cache] (fn [m] (dissoc m addr)))
     (ec/swap-state! [:dom/keyed-cache] (fn [m] (dissoc m addr)))
-    (ec/swap-state! [:dom/foreign] (fn [m] (dissoc m addr)))))
+    (ec/swap-state! [:dom/foreign] (fn [m] (dissoc m addr)))
+    ;; Staging too, or an unmounted address could be resurrected by a commit
+    ;; sweep that runs after the eviction.
+    (ec/swap-state! [:dom/pending] (fn [m] (dissoc m addr)))))
 
 ;; =============================================================================
 ;; Attribute Reconciliation

--- a/src/org/replikativ/spindel/dom/discharge.cljc
+++ b/src/org/replikativ/spindel/dom/discharge.cljc
@@ -906,6 +906,25 @@
         (cons vnode child-results)
         child-results))))
 
+(defn collect-addrs
+  "Every `:addr` in a vdom tree.
+
+  The sibling of `collect-nodes-with-deltas`, and deliberately NOT filtered by
+  deltas: this answers `which addresses did the DOM actually see this pass?`,
+  which is what decides whether a staged cache entry may be promoted
+  (`cache/commit-pending!`). A node created wholesale by `render-initial!`
+  carries no deltas of its own — it is still in the tree, and its caches must
+  still commit, or the next pass would re-emit its `:add` and duplicate it."
+  [vnode]
+  (if-not (map? vnode)
+    #{}
+    (let [children (when-let [ch (:children vnode)]
+                     (if (d/deltaable? ch) @ch ch))
+          from-children (into #{} (mapcat collect-addrs children))]
+      (if-let [a (:addr vnode)]
+        (conj from-children a)
+        from-children))))
+
 (defn discharge-all!
   "Discharge all deltas from vdom tree to target.
 
@@ -929,6 +948,12 @@
       (doseq [node nodes]
         (discharge-vnode! discharge node))
       (let [result (clear-deltas-deep vdom)]
+        ;; This tree reached the DOM, so the reconciliations that built it may
+        ;; now become the caches' model of it. Anything staged by a run whose
+        ;; output never got here is dropped — see `cache/commit-pending!`.
+        ;; Before the evictions: an address unmounted this pass must not be
+        ;; resurrected by the promotion.
+        (cache/commit-pending! (collect-addrs vdom))
         ;; Evict caches of addresses unmounted this pass that no live
         ;; element re-claimed (deferred — see flush-pending-evictions!).
         (flush-pending-evictions! discharge)

--- a/src/org/replikativ/spindel/dom/elements.cljc
+++ b/src/org/replikativ/spindel/dom/elements.cljc
@@ -125,8 +125,10 @@
         ;; Reconcile attrs with cache
         attr-deltas (cache/reconcile-attrs prev-attrs attrs-clean)
 
-        ;; Update attr cache
-        _ (cache/set-attr-cache! effective-addr attrs-clean)
+        ;; STAGE the attr cache — it is promoted only if this vnode is actually
+        ;; discharged (cache/commit-pending!). Advancing it here moved the
+        ;; baseline for runs that were later abandoned, losing their deltas.
+        _ (cache/stage-attrs! effective-addr attrs-clean)
 
         ;; Normalize children (handle text, nil, sequences)
         normalized-children (flatten-and-normalize children)
@@ -134,8 +136,10 @@
         ;; Reconcile children with cache
         {:keys [slots deltas]} (cache/reconcile-children prev-slot-cache normalized-children)
 
-        ;; Update slot cache
-        _ (cache/set-slot-cache! effective-addr slots)
+        ;; STAGE the slot cache — same reason as the attrs above. Child deltas
+        ;; carry POSITIONS, so a lost one does not merely miss an update: the
+        ;; next pass computes indices against a DOM that never received it.
+        _ (cache/stage-slots! effective-addr slots)
 
         ;; Flatten slots to final children vector
         final-children (cache/flatten-slots slots)

--- a/src/org/replikativ/spindel/dom/foreach.cljc
+++ b/src/org/replikativ/spindel/dom/foreach.cljc
@@ -57,6 +57,7 @@
   (:refer-clojure :exclude [await])
   (:require [org.replikativ.spindel.dom.fragment :as frag]
             [org.replikativ.spindel.dom.addressing :as addr]
+            [org.replikativ.spindel.dom.cache :as cache]
             [org.replikativ.spindel.incremental.interval :as iv]
             [org.replikativ.spindel.incremental.deltaable :as d]
             [org.replikativ.spindel.incremental.sequence-algebra :as sa]
@@ -141,8 +142,15 @@
 (defn- get-keyed-cache [addr]
   (ec/get-state [:dom/keyed-cache addr]))
 
-(defn- set-keyed-cache! [addr cache-data]
-  (ec/swap-state! [:dom/keyed-cache addr] (constantly cache-data)))
+(defn- set-keyed-cache!
+  "STAGE the keyed cache; `cache/commit-pending!` promotes it once the
+   fragment's items have actually been discharged.
+
+   Same asymmetry as the element caches, and the list path made it worse: the
+   fragment's delta embeds `:prev-items` inline, so an abandoned build both
+   moved the keyed baseline and poisoned the next diff."
+  [addr cache-data]
+  (cache/stage-keyed! addr cache-data))
 
 ;; =============================================================================
 ;; Delta derivation — package the keyed SequenceAlgebra diff for discharge

--- a/src/org/replikativ/spindel/dom/render.cljc
+++ b/src/org/replikativ/spindel/dom/render.cljc
@@ -27,6 +27,7 @@
   The spin re-runs whenever tracked signals change. Element macros
   produce vnodes with deltas attached that are discharged to the DOM."
   (:require [org.replikativ.spindel.dom.discharge :as disch]
+            [org.replikativ.spindel.dom.cache :as cache]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.engine.core :as ec]
             [replikativ.logging :as log]))
@@ -82,6 +83,12 @@
     ;; Append to container
     (when (and container root-el)
       (.appendChild container root-el))
+    ;; The whole tree just reached the DOM, so its reconciliations become the
+    ;; caches' model of it. This is the commit point that matters MOST: a spin
+    ;; with no tracks runs its body exactly once, here — if its staging is not
+    ;; promoted now, it never is, and the next parent re-emission reconciles
+    ;; against nil and re-emits `:add` for a subtree the DOM already holds.
+    (cache/commit-pending! (disch/collect-addrs vdom))
     ;; No transfer needed — address-based refs work with cleared vdom
     ;; (clear-deltas-deep preserves :addr fields)
     (assoc render-state
@@ -130,6 +137,10 @@
             (when container
               (set! (.-innerHTML container) "")
               (when root-el (.appendChild container root-el))))
+          ;; The new tree is in the DOM, so its reconciliations may become the
+          ;; caches' model of it. Before the evictions, so an address this pass
+          ;; unmounted is not resurrected by the promotion.
+          (cache/commit-pending! (disch/collect-addrs new-vdom))
           (disch/flush-pending-evictions! discharge))
         (assoc render-state :current-vdom (disch/clear-deltas-deep new-vdom)))
 
@@ -145,6 +156,11 @@
               (log/trace :render/delta-update {:nodes-with-deltas (count nodes-with-deltas)})
               (doseq [node nodes-with-deltas]
                 (disch/discharge-vnode! discharge node))))
+          ;; Commit the staged reconciliations for everything in the tree that
+          ;; just reached the DOM — NOT only the nodes that carried deltas: a
+          ;; subtree built wholesale by `render-initial!` has none of its own,
+          ;; and would otherwise re-emit `:add` on the next pass.
+          (cache/commit-pending! (disch/collect-addrs new-vdom))
           (disch/flush-pending-evictions! discharge))
 
         ;; Clear deltas for next render cycle

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -693,9 +693,11 @@
 
   Also:
   - Resets engine draining flag.
-  - Drops :dom/cache, :dom/attr-cache and :dom/keyed-cache, since slot,
-    attribute and keyed-list reconciliation state belongs to the previous
-    render pass and would mismatch the DOM the restored context renders into.
+  - Drops :dom/cache, :dom/attr-cache, :dom/keyed-cache and :dom/pending,
+    since slot, attribute and keyed-list reconciliation state belongs to the
+    previous render pass and would mismatch the DOM the restored context
+    renders into. :dom/pending holds reconciliations not yet promoted to
+    those caches, so it is render-pass state by the same argument.
 
   NOTE: Continuations are preserved for in-memory snapshot/restore.
   They will be dropped during serialization (since closures can't be serialized).
@@ -710,7 +712,7 @@
       (assoc :engine/draining? false)
 
       ;; Drop render-pass-specific DOM caches; restored context re-renders.
-      (dissoc :dom/cache :dom/attr-cache :dom/keyed-cache)
+      (dissoc :dom/cache :dom/attr-cache :dom/keyed-cache :dom/pending)
 
       ;; Mark in-flight spins as dirty
       (update :nodes

--- a/test/org/replikativ/spindel/dom/superseded_run_test.clj
+++ b/test/org/replikativ/spindel/dom/superseded_run_test.clj
@@ -1,0 +1,152 @@
+(ns org.replikativ.spindel.dom.superseded-run-test
+  "An ABANDONED body run must not move the DOM caches.
+
+   A body slice can build its elements and then suspend on an `await`. When a
+   newer signal value resumes the track continuation above it, `resume-body!`
+   truncates and CANCELS that slice — its CPS chain never resolves, so its
+   vnode never reaches the render effect. Before the staging fix, the slice's
+   cache writes were already in ctx state: the committed run then reconciled
+   against a baseline the DOM had never seen, produced no deltas, and the
+   change was silently lost.
+
+   Worse, it compounded: a lost `:add` left the slot cache claiming a child
+   the DOM never gained, so the NEXT transition removed the wrong index — a
+   live sibling.
+
+   The fix: `build-element`/`ifor-each` STAGE their reconciliations
+   (`[:dom/pending]`), and `cache/commit-pending!` promotes them only for
+   addresses present in a vdom tree that actually reached the DOM
+   (initial-mount!, update-render!'s two branches, discharge-all!)."
+  (:refer-clojure :exclude [await])
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [org.replikativ.spindel.dom.elements :as el]
+            [org.replikativ.spindel.dom.discharge :as disch]
+            [org.replikativ.spindel.dom.render :as render]
+            [org.replikativ.spindel.signal :as sig]
+            [org.replikativ.spindel.effects.track :refer [track]]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.spin.combinators :as comb]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.test-async :refer [await-drain]]
+            [org.replikativ.spindel.test-helpers :refer [with-ctx]]))
+
+(defn clean-context-fixture [f]
+  (binding [ec/*execution-context* nil]
+    (f)))
+
+(use-fixtures :each clean-context-fixture)
+
+;; =============================================================================
+;; 1. The measured bug: a superseded suspended run loses attr AND child deltas
+;; =============================================================================
+
+(deftest superseded-suspended-run-still-updates-the-dom
+  (testing "run builds, suspends, is superseded — the committed run must still
+            carry the attribute update and the conditional child"
+    (with-ctx [rt]
+      (let [{:keys [discharge log]} (disch/make-mock-discharge)
+            a (sig/signal 0)
+            s (spin
+               (let [{av :new} (track a)
+                     cls (if (pos? av) "editor readonly" "editor")
+                     v (el/div {:class cls}
+                               (when (pos? av) (el/span "BANNER")))]
+                 ;; Suspend AFTER building — the window in which a newer signal
+                 ;; value supersedes this slice.
+                 (await (comb/sleep 60))
+                 v))]
+        (render/render-spin! nil s discharge)
+        @s
+        (await-drain rt)
+        (Thread/sleep 150)
+        (reset! log [])
+        ;; Two changes in quick succession: the first run is superseded while
+        ;; suspended on the sleep. Both runs compute the SAME new state
+        ;; (readonly + banner), so before the fix the committed run reconciled
+        ;; against the abandoned run's cache writes and emitted nothing.
+        (reset! a 1)
+        (Thread/sleep 5)
+        (reset! a 2)
+        (Thread/sleep 400)
+        (await-drain rt)
+        (is (some #(and (= :set-attr (:op %)) (= :class (:attr %))
+                        (= "editor readonly" (:value %)))
+                  @log)
+            "class update must reach the DOM")
+        (is (some #(and (= :create-text (:op %)) (= "BANNER" (:text %))) @log)
+            "conditional child must reach the DOM")))))
+
+;; =============================================================================
+;; 2. The compounding corruption: the caches must stay a model of the DOM
+;; =============================================================================
+
+(deftest slot-cache-stays-synced-with-the-dom-across-supersession
+  (testing "after a superseded transition, the following transition operates on
+            children the DOM actually holds — not on the cache's fiction"
+    (with-ctx [rt]
+      (let [{:keys [discharge log]} (disch/make-mock-discharge)
+            a (sig/signal 0)
+            s (spin
+               (let [{av :new} (track a)
+                     v (el/div {:class "root"}
+                               (when (pos? av) (el/span {:class "banner"} "BANNER"))
+                               (el/p {:class "stable"} "STABLE"))]
+                 (await (comb/sleep 60))
+                 v))]
+        (render/render-spin! nil s discharge)
+        @s
+        (await-drain rt)
+        (Thread/sleep 200)
+        (reset! log [])
+        ;; Supersede: two changes before the first run resolves.
+        (reset! a 1)
+        (Thread/sleep 5)
+        (reset! a 2)
+        (Thread/sleep 400)
+        (await-drain rt)
+        (let [flip-on-ops @log]
+          ;; The banner must have actually been inserted. Before the fix it
+          ;; never was — while the slot cache claimed it existed.
+          (is (some #(and (= :create-text (:op %)) (= "BANNER" (:text %)))
+                    flip-on-ops)
+              "flip-on must insert the banner")
+          (reset! log [])
+          ;; A single clean change back. With the caches honest, this removes
+          ;; exactly the banner. Before the fix the DOM had no banner, so the
+          ;; removal at index 0 deleted the live STABLE <p> instead.
+          (reset! a 0)
+          (Thread/sleep 400)
+          (await-drain rt)
+          (let [removes (filter #(= :remove-child (:op %)) @log)]
+            (is (= 1 (count removes))
+                (str "flip-off removes exactly the banner, got " (vec removes)))))))))
+
+;; =============================================================================
+;; 3. The commit-protocol detector: no-change re-render emits ZERO ops
+;; =============================================================================
+
+(deftest no-change-rerender-emits-zero-ops
+  (testing "a body re-run that produces identical output discharges nothing —
+            the single most sensitive detector for a missed commit point: if a
+            tree's caches were never promoted, the re-run reconciles against
+            nil and re-emits the whole mount as :add deltas"
+    (with-ctx [rt]
+      (let [{:keys [discharge log]} (disch/make-mock-discharge)
+            a (sig/signal 0)
+            s (spin
+               (let [{_ :new} (track a)]
+                 ;; Output does not depend on the tracked value.
+                 (el/div {:class "shell"}
+                         (el/span {:class "static"} "Same")
+                         (el/p "Every time"))))]
+        (render/render-spin! nil s discharge)
+        @s
+        (await-drain rt)
+        (reset! log [])
+        (reset! a 1)
+        (await-drain rt)
+        (Thread/sleep 100)
+        (await-drain rt)
+        (is (empty? @log)
+            (str "identical output must produce zero DOM ops, got " (vec @log)))))))


### PR DESCRIPTION
## The bug

A body slice can build its elements and then suspend on an `await`. When a newer
signal value resumes the track continuation above it, `resume-body!` truncates
and **cancels** that slice — its CPS chain never resolves, so its vnode never
reaches the render effect. But its cache writes were already in ctx state:
`build-element` advanced the attr/slot caches unconditionally *while computing*
(`elements.cljc`), and `ifor-each` its keyed cache (`foreach.cljc`).

The committed run then reconciled against a baseline the DOM had never seen,
produced **no deltas**, and the change was lost with nothing logged. Measured in
simmis (probe on the failing transition, same address both lines):

```
render 1  prev="block-editor time-travel-readonly"  new="block-editor"
          attr-deltas=[{:delta :update :path [:class] …}]   ← computed, never discharged
render 2  prev="block-editor"                       new="block-editor"
          attr-deltas=nil                                   ← nothing left to say
DOM       "block-editor time-travel-readonly"               ← never patched
```

And it **compounds**: a lost `:add` leaves the slot cache claiming a child the
DOM never gained, so the *next* transition removes the wrong index — a live
sibling — and every index after it is off by one. Silent: no
`::deltas-dropped-unbound-addr`, no `::addr-collision`, no reject.

This is the downstream cost of the cancellation line of work (#27/#28, zombie
conts, stale conts): the engine learned to abandon runs cleanly, and the DOM
cache never learned that a run can be abandoned. Present in released v0.1.37.

## The fix — one invariant, not another guard

**R3 (new, engine-formalism §3.9): the caches are a model of the DOM, so they
advance only when the DOM does.**

- `build-element` / `ifor-each` **stage** their reconciliations
  (`[:dom/pending]`) instead of writing the caches.
- `cache/commit-pending!` promotes staging **only for addresses present in a
  vdom tree that actually reached the DOM**, folding in `ifor-each` call-site
  addresses transitively (they hang off `:keyed` slots, on no vnode).
- Four commit points: `initial-mount!`, both branches of `update-render!`,
  `discharge-all!` — before the eviction flush where one exists, so an address
  unmounted in the same pass is not resurrected.
- Only **promoted** staging is dropped: a child spin can stage in one pass and
  be embedded by its parent in a later one. (Clearing wholesale duplicated its
  subtree — caught during development by `cross-spin-rerender` /
  `ifor-each-oscillation`. The `initial-mount!` commit is the one a no-track
  spin gets exactly one shot at.)
- `evict-cache!` drops staging alongside the caches; `clean-in-flight-spins`
  drops `:dom/pending` with its siblings.

An abandoned slice now moves no baseline, by construction — abandonment is free.

## Deliberate scope notes

- **SSR** stages and never commits (one-shot context; staging dies with it) —
  stated in R3 rather than discovered.
- A vnode whose deltas were dropped for want of a bound element still commits
  with its tree; that case already logs loudly and matches prior behaviour.
- **Untested corner, flagged honestly:** a child spin that builds in a *forked*
  execution context whose vnode is discharged from the parent's resolve would
  stage in the fork's COW layer. Normal-path ctx lineage was verified same-object;
  the fork case wants an explicit test.
- Also corrects sharp-edges §6 (untracked file): its claimed mechanism — a
  synchronous tracked-signal write losing both runs — does **not** reproduce;
  the real trigger is supersession of a *suspended* run.

## Tests, verified in both directions

`dom/superseded_run_test.clj`:

| test | on main | with fix |
|---|---|---|
| `superseded-suspended-run-still-updates-the-dom` | **FAIL** (attr + conditional child never reach the DOM) | pass |
| `slot-cache-stays-synced-with-the-dom-across-supersession` | **FAIL** (banner never inserted; flip-off removes a live sibling) | pass |
| `no-change-rerender-emits-zero-ops` | pass | pass — **by design**: it detects a *missed commit point* (unpromoted staging re-emits the whole mount as `:add` on the next pass) |

Full suite: **919 tests, 3161 assertions, 0 failures, 0 errors.** cljfmt clean.

Verified end-to-end in simmis (local overlay): the time-travel enter/return
round trip now re-renders correctly, twice in a row — this was the
stuck-read-only-after-Back-to-now bug.

## Direction note (not this PR)

`collect-nodes-with-deltas`, `clear-deltas-deep` and now `collect-addrs` each
walk the full tree every pass, so the asymptotic case for build-time deltas is
already spent. The clean endpoint is pure build + commit-time diff against
`current-vdom` (which `render-state` already holds) — that boundary would
*delete* the per-address caches, this staging, `*applied-vnodes*`,
`mark-rendered!` and `clear-deltas-deep`, keeping `ifor-each`'s per-key
memoisation where the real incremental win lives. R3 makes the current design
sound and is subsumed by that direction, not opposed to it.