### PR TITLE
fix(dom): a live ifor-each cache was evicted with a dead parent

### DIFF
--- a/docs/engine-formalism.md
+++ b/docs/engine-formalism.md
@@ -689,40 +689,34 @@ Because a changed root re-mounts (and thus loses DOM state), **keep a spin's roo
 element structurally stable** and branch *inside* it. This is the loading-state
 idiom: one container with a stable key, `cond`/`if` on the content within.
 
-**R3 — The caches are a model of the DOM, so they advance on commit, not on
-compute.** `build-element` (and `ifor-each`) reconcile against the committed
-caches but write their results to a STAGING area (`[:dom/pending]`);
-`cache/commit-pending!` promotes staging only for addresses present in a vdom
-tree that actually reached the DOM. There are exactly four commit points —
-`initial-mount!`, both branches of `update-render!`, and `discharge-all!`. On
-the paths that evict (`update-render!`, `discharge-all!`), the commit sits
-immediately BEFORE the eviction flush, so an address unmounted in the same
-pass cannot be resurrected by its own promotion; `initial-mount!` evicts
-nothing, and commits once the tree is appended. The initial-mount commit is
-the one that matters most: a spin with no tracks runs its body exactly once,
-there — if its staging is not promoted then, it never is, and the next parent
-re-emission reconciles against nil and re-emits `:add` for a subtree the DOM
-already holds, duplicating it.
+**R3 — Reconciliation happens AT the commit point; the caches advance in the
+same step as the DOM write.** Builds are pure values: `build-element` and
+`for-each*` classify slots and package items — no cache reads, no diffing, no
+staged deltas. At the commit points (`initial-mount!` seeds caches from the
+mounted tree; `update-render!` runs `commit-reconcile!`, dom/commit) the
+arrived tree is diffed against the committed per-address caches and applied,
+and the caches are advanced in one step.
 
-Why this is a rule and not an optimization: the engine may abandon a body
-slice AFTER it has built its elements — a slice that suspends on an `await`
-is truncated and cancelled when a newer signal value resumes the track
-continuation above it (`truncate-stale-conts!`), and every improvement to
-cancellation correctness increases how often that happens. Advancing the
-caches at compute time meant an abandoned slice still moved the baseline: the
-committed run then reconciled against state the DOM had never seen, produced
-no deltas, and the change was lost silently — and because child deltas carry
-positions, the slot cache's fiction made the NEXT transition remove a live
-sibling at the wrong index. (Regression: `dom/superseded_run_test.clj`; the
-zero-op no-change re-render test there is the detector for a MISSED commit
-point — a tree whose staging is never promoted re-emits its whole mount as
-`:add` on the following pass.)
+Why this is a rule and not an implementation detail: it is what makes both
+abandonment AND repetition free. An abandoned body slice never touched
+anything, so nothing needs undoing. A body executed N times for one logical
+change — routine when a parent's `:await-reactive` cont re-fires per child
+re-completion — produces N pure values; the first commit advances the
+baseline, and every later build diffs against it and collapses to its genuine
+residual. The earlier design (compute-time reconciliation with staged caches
+promoted at commit) could not have the second property: N racing builds all
+diffed one uncommitted baseline and each carried the same `:add`, more than
+one of which could reach the DOM in separate passes (measured live: six
+builds of one container per settled expand, the same `:add` discharged
+twice); and the shared last-write-wins staging slot meant the committed
+baseline could advance past what the DOM actually held. (Acceptance:
+`dom/commit_reconcile_test.clj` — five distinct builds, one insert;
+`dom/jsdom_final_state_test.cljs` — the app-shape protocol on a real tree.)
 
-Two scoped exceptions, stated so they are read as design rather than bugs:
-SSR builds stage and never commit (a one-shot context; the staging dies with
-it), and a vnode whose deltas were dropped for want of a bound element still
-commits with its tree — that case already logs `::deltas-dropped-unbound-addr`
-loudly and matches prior behaviour.
+One prerequisite the rule imposes on builds: the vnode carries its slot
+structure (`:slots`), because `flatten-slots` destroys the `:nil`-slot
+information the commit diff needs for stable slot indices. And the diff runs
+against the ARRIVED TREE only — never against any build-side accumulation.
 
 **R4 — The environment travels with the continuation, never with the
 event.** A body slice always executes in the environment captured at its own

--- a/docs/engine-formalism.md
+++ b/docs/engine-formalism.md
@@ -724,6 +724,29 @@ it), and a vnode whose deltas were dropped for want of a bound element still
 commits with its tree — that case already logs `::deltas-dropped-unbound-addr`
 loudly and matches prior behaviour.
 
+**R4 — The environment travels with the continuation, never with the
+event.** A body slice always executes in the environment captured at its own
+suspension point (or construction, for a first slice): `(:bindings ctx)`,
+the addressing chain-head, and the transient dep tracking. The environment
+of the COMPLETER — whoever delivered the value that woke the slice — must
+never be observable. Enforced at three places: (1) `restore-slice-state!`
+REPLACES the context's bindings with the cont's snapshot (merge restored
+presence but not absence — a key the slice never bound leaked in from the
+resume context); (2) every continuation carries `:slice-state`, including
+`:external-await` conts (Deferred/Mailbox/thunk), whose `:cont-resume` and
+reject paths restore it; (3) the drain NORMALIZES its context to the
+creation-time `:base-bindings` — enqueue closures smuggle body-scoped
+context values into `trigger-drain!`, and an un-normalized drain executed
+whole cascades (including FIRST slices of fresh spins, whose construction
+scope is a delta merged onto the drain context) in a random body's
+environment. Violation symptom, measured before the rule: an element built
+after `(await (for-each* …))` was addressed under the last-completing
+ITEM's keyed scope, so its address changed with completion order — R1
+broken nondeterministically, the subtree re-minted every render.
+(Regression: `dom/jsdom_final_state_test.cljs`
+`fragment-parent-keeps-its-identity-across-rerender`; full derivation in
+`.internal/slice-environment-integrity.md`.)
+
 ### Invariant summary table
 
 | composition          | glitch-free | no double-exec | no stale-cache | no orphan cont | deterministic id |

--- a/src/org/replikativ/spindel/dom/browser.cljs
+++ b/src/org/replikativ/spindel/dom/browser.cljs
@@ -7,9 +7,10 @@
     (def d (browser/make-dom-discharge js/document))
     (disch/render-initial! d vdom)
     ;; Later, after vdom updates:
-    (disch/discharge-all! d updated-vdom)"
+    (refresh! d updated-vdom)"
   (:require [clojure.string :as str]
-            [org.replikativ.spindel.dom.discharge :as disch]))
+            [org.replikativ.spindel.dom.discharge :as disch]
+            [org.replikativ.spindel.dom.commit :as commit]))
 
 ;; =============================================================================
 ;; SVG namespace support
@@ -238,6 +239,9 @@
                   (disch/render-initial! discharge vdom))]
     (when root-el
       (.appendChild container root-el))
+    ;; seed the per-address caches from the mounted tree so a later
+    ;; `refresh!` (commit-time reconciliation) diffs against reality
+    (commit/seed-subtree-caches! vdom)
     discharge))
 
 (defn refresh!
@@ -246,10 +250,14 @@
    discharge: The discharge returned from mount!
    new-vdom: The updated virtual DOM tree
 
-   This diffs the new vdom against the previous state and applies
-   only the necessary changes to the DOM."
+   Commit-time reconciliation: the new tree is diffed against the
+   committed per-address caches at the point of writing (dom/commit),
+   and the caches advance in the same step."
   [discharge new-vdom]
-  (disch/discharge-all! discharge new-vdom))
+  (binding [disch/*rendered-addrs* (atom {})
+            disch/*pending-evictions* (atom #{})]
+    (commit/commit-reconcile! discharge new-vdom)
+    (disch/flush-pending-evictions! discharge)))
 
 (defn unmount!
   "Unmount a vdom tree from the DOM.

--- a/src/org/replikativ/spindel/dom/cache.cljc
+++ b/src/org/replikativ/spindel/dom/cache.cljc
@@ -138,6 +138,25 @@
                       (:addr (:value slot))))
                   slots)))
 
+(defn live-keyed-closure
+  "Extend `live-addrs` with the `ifor-each` call-site addresses reachable from
+   their COMMITTED slots, transitively.
+
+   The eviction counterpart to the closure `commit-pending!` runs over STAGED
+   slots, and needed for the same reason: a fragment call site appears on no
+   vnode, so a liveness set built from rendered vnodes never contains one.
+   Without this, a fragment is structurally exempt from the very check that
+   protects live addresses from eviction.
+
+   `commit-pending!` runs before `flush-pending-evictions!` at every call site,
+   so by eviction time the live tree's slots are already promoted here."
+  [live-addrs]
+  (loop [live (set live-addrs)]
+    (let [more (into live
+                     (mapcat #(keyed-frag-addrs (ec/get-state [:dom/cache %])))
+                     live)]
+      (if (= (count more) (count live)) live (recur more)))))
+
 (defn commit-pending!
   "Promote staged cache entries for `live-addrs`, and drop the rest.
 
@@ -199,19 +218,27 @@
   subtree containing an `ifor-each` retained `:by-key` (every rendered vnode,
   with its event-handler closures) for the lifetime of the context — the
   dominant leak in a long-lived session."
-  [addr]
-  (when addr
-    (doseq [slot (ec/get-state [:dom/cache addr])
-            :when (= :keyed (:type slot))]
-      (when-let [frag-addr (:addr (:value slot))]
-        (ec/swap-state! [:dom/keyed-cache] (fn [m] (dissoc m frag-addr)))))
-    (ec/swap-state! [:dom/cache] (fn [m] (dissoc m addr)))
-    (ec/swap-state! [:dom/attr-cache] (fn [m] (dissoc m addr)))
-    (ec/swap-state! [:dom/keyed-cache] (fn [m] (dissoc m addr)))
-    (ec/swap-state! [:dom/foreign] (fn [m] (dissoc m addr)))
-    ;; Staging too, or an unmounted address could be resurrected by a commit
-    ;; sweep that runs after the eviction.
-    (ec/swap-state! [:dom/pending] (fn [m] (dissoc m addr)))))
+  ([addr] (evict-cache! addr nil))
+  ([addr protected]
+   (when addr
+     (doseq [slot (ec/get-state [:dom/cache addr])
+             :when (= :keyed (:type slot))]
+       (when-let [frag-addr (:addr (:value slot))]
+         ;; `protected` guards the cascade against a dead parent taking a LIVE
+         ;; fragment's cache with it. The call-site address is stable across
+         ;; re-renders, so a superseded parent's slots still name the fragment
+         ;; the current parent renders; dropping it resets the keyed baseline to
+         ;; empty and the next render re-adds every item. Measured before the
+         ;; guard: a settled collapse turned 6 sections into 12.
+         (when-not (contains? protected frag-addr)
+           (ec/swap-state! [:dom/keyed-cache] (fn [m] (dissoc m frag-addr))))))
+     (ec/swap-state! [:dom/cache] (fn [m] (dissoc m addr)))
+     (ec/swap-state! [:dom/attr-cache] (fn [m] (dissoc m addr)))
+     (ec/swap-state! [:dom/keyed-cache] (fn [m] (dissoc m addr)))
+     (ec/swap-state! [:dom/foreign] (fn [m] (dissoc m addr)))
+     ;; Staging too, or an unmounted address could be resurrected by a commit
+     ;; sweep that runs after the eviction.
+     (ec/swap-state! [:dom/pending] (fn [m] (dissoc m addr))))))
 
 ;; =============================================================================
 ;; Attribute Reconciliation

--- a/src/org/replikativ/spindel/dom/cache.cljc
+++ b/src/org/replikativ/spindel/dom/cache.cljc
@@ -85,6 +85,20 @@
   [addr attrs]
   (ec/swap-state! [:dom/attr-cache addr] (constantly attrs)))
 
+(defn get-keyed-cache
+  "Get the committed `ifor-each` keyed cache for a fragment call-site
+  address. Returns {:by-key :items-by-key :order :was-sync?} or nil."
+  [addr]
+  (ec/get-state [:dom/keyed-cache addr]))
+
+(defn set-keyed-cache!
+  "Directly set the committed keyed cache for a fragment call-site address.
+  Used by the commit-time reconciliation walk (dom/commit), which advances
+  the baseline in the same step as the DOM write — NOT by builds, which
+  stage (`stage-keyed!`)."
+  [addr cache-data]
+  (ec/swap-state! [:dom/keyed-cache addr] (constantly cache-data)))
+
 ;; =============================================================================
 ;; Staging — the caches model the DOM, so they advance on COMMIT, not on compute
 ;; =============================================================================

--- a/src/org/replikativ/spindel/dom/cache.cljc
+++ b/src/org/replikativ/spindel/dom/cache.cljc
@@ -94,58 +94,31 @@
 (defn set-keyed-cache!
   "Directly set the committed keyed cache for a fragment call-site address.
   Used by the commit-time reconciliation walk (dom/commit), which advances
-  the baseline in the same step as the DOM write — NOT by builds, which
-  stage (`stage-keyed!`)."
+  the baseline in the same step as the DOM write. Builds are pure and never
+  touch the caches."
   [addr cache-data]
   (ec/swap-state! [:dom/keyed-cache addr] (constantly cache-data)))
 
 ;; =============================================================================
-;; Staging — the caches model the DOM, so they advance on COMMIT, not on compute
+;; Fragment call-site reachability (used by eviction liveness)
 ;; =============================================================================
 ;;
-;; A reconciliation writes its result HERE, not into the committed caches. The
-;; committed caches are promoted only for addresses that appear in a vdom tree
-;; that was actually discharged (`commit-pending!`, called from
-;; `discharge-all!`).
-;;
-;; Why: a body slice can build its elements and then suspend on an `await`. If
-;; a newer signal value resumes the track continuation above it, `resume-body!`
-;; truncates and CANCELS that slice — its CPS chain never resolves, so its
-;; vnode never reaches the render effect. Advancing the caches while computing
-;; meant that abandoned run still moved the baseline: the next run reconciled
-;; against a value the DOM had never been told about, produced no deltas, and
-;; the change was lost with nothing logged.
-;;
-;; Worse, it compounded. A lost `:add` left the slot cache claiming a child the
-;; DOM never gained, so the following transition removed the wrong index — a
-;; live sibling — and every index after it was off by one.
-;;
-;; Staging makes abandonment free: a slice that never reaches the DOM never
-;; moves the baseline.
-
-(defn stage-attrs!
-  "Stage reconciled attrs for `addr`. Promoted by `commit-pending!`."
-  [addr attrs]
-  (ec/swap-state! [:dom/pending addr] (fn [m] (assoc m :attrs attrs))))
-
-(defn stage-slots!
-  "Stage reconciled slots for `addr`. Promoted by `commit-pending!`."
-  [addr slots]
-  (ec/swap-state! [:dom/pending addr] (fn [m] (assoc m :slots slots))))
-
-(defn stage-keyed!
-  "Stage an `ifor-each` keyed cache for its call-site `addr`."
-  [addr cache-data]
-  (ec/swap-state! [:dom/pending addr] (fn [m] (assoc m :keyed cache-data))))
+;; NOTE on history: the caches used to advance through a build-time STAGING
+;; area promoted at commit (`stage-*` / `commit-pending!`, R3). That design was
+;; retired with commit-time reconciliation (dom/commit): builds are pure, the
+;; diff runs at the commit point against the committed caches, and the caches
+;; advance in the same step as the DOM write — so both hazards staging
+;; addressed (abandoned slices moving the baseline; N racing builds sharing one
+;; last-write-wins pending slot) are gone structurally.
 
 (defn- keyed-frag-addrs
   "The `ifor-each` call-site addresses reachable from `slots`.
 
    A `:keyed` slot holds a KeyedFragment whose `:addr` is the call site — an
    address that appears on NO vnode, because `flatten-slot` splices the
-   fragment's items into `:children` and drops the fragment itself. The commit
-   sweep walks vnodes, so it cannot see these; they are reached the same way
-   `evict-cache!` reaches them, through the parent's slots."
+   fragment's items into `:children` and drops the fragment itself. A
+   vnode-walking liveness sweep cannot see these; they are reached the same
+   way `evict-cache!` reaches them, through the parent's slots."
   [slots]
   (into #{} (keep (fn [slot]
                     (when (= :keyed (:type slot))
@@ -156,62 +129,17 @@
   "Extend `live-addrs` with the `ifor-each` call-site addresses reachable from
    their COMMITTED slots, transitively.
 
-   The eviction counterpart to the closure `commit-pending!` runs over STAGED
-   slots, and needed for the same reason: a fragment call site appears on no
-   vnode, so a liveness set built from rendered vnodes never contains one.
-   Without this, a fragment is structurally exempt from the very check that
-   protects live addresses from eviction.
-
-   `commit-pending!` runs before `flush-pending-evictions!` at every call site,
-   so by eviction time the live tree's slots are already promoted here."
+   A fragment call site appears on no vnode, so a liveness set built from
+   rendered vnodes never contains one; without this closure a fragment is
+   structurally exempt from the very check that protects live addresses from
+   eviction. The commit walk advances the committed slots BEFORE the eviction
+   flush runs, so the closure reads current data."
   [live-addrs]
   (loop [live (set live-addrs)]
     (let [more (into live
                      (mapcat #(keyed-frag-addrs (ec/get-state [:dom/cache %])))
                      live)]
       (if (= (count more) (count live)) live (recur more)))))
-
-(defn commit-pending!
-  "Promote staged cache entries for `live-addrs`, and drop the rest.
-
-   `live-addrs` is every `:addr` in the vdom tree that was just discharged.
-   An address that was staged by a run whose output never reached the DOM is
-   absent from that set, so its staging is discarded and the committed cache
-   keeps describing what the DOM actually holds.
-
-   Fragment call sites are folded in transitively: they hang off a parent's
-   `:keyed` slots rather than off any vnode, and a fragment's own items can in
-   turn contain further fragments, so this closes over the staged slots until
-   the live set stops growing."
-  [live-addrs]
-  (let [pending (ec/get-state [:dom/pending])]
-    (when (seq pending)
-      (let [live (loop [live (set live-addrs)]
-                   (let [more (into live
-                                    (mapcat (fn [addr]
-                                              (keyed-frag-addrs (get-in pending [addr :slots])))
-                                            live))]
-                     (if (= (count more) (count live)) live (recur more))))]
-        (doseq [[addr entry] pending
-                :when (contains? live addr)]
-          (when (contains? entry :attrs)
-            (ec/swap-state! [:dom/attr-cache addr] (constantly (:attrs entry))))
-          (when (contains? entry :slots)
-            (ec/swap-state! [:dom/cache addr] (constantly (:slots entry))))
-          (when (contains? entry :keyed)
-            (ec/swap-state! [:dom/keyed-cache addr] (constantly (:keyed entry)))))
-        ;; Drop ONLY what was promoted. Staging for addresses outside this tree
-        ;; is kept, not discarded: a child spin resolves on its own schedule, so
-        ;; it can stage its build one pass and have its vnode embedded by the
-        ;; parent in a later one. Clearing wholesale destroyed that staging in
-        ;; between, the child's cache never advanced, and it re-emitted `:add`
-        ;; on the next build — duplicating its subtree (caught by
-        ;; cross-spin-rerender and ifor-each-oscillation).
-        ;;
-        ;; Retained staging is not a leak: a rebuild overwrites its address,
-        ;; `evict-cache!` drops it on unmount, and snapshot cleaning drops the
-        ;; whole map.
-        (ec/swap-state! [:dom/pending] (fn [m] (apply dissoc m (filter live (keys m)))))))))
 
 (defn evict-cache!
   "Drop all per-address engine state for an element address.
@@ -249,10 +177,7 @@
      (ec/swap-state! [:dom/cache] (fn [m] (dissoc m addr)))
      (ec/swap-state! [:dom/attr-cache] (fn [m] (dissoc m addr)))
      (ec/swap-state! [:dom/keyed-cache] (fn [m] (dissoc m addr)))
-     (ec/swap-state! [:dom/foreign] (fn [m] (dissoc m addr)))
-     ;; Staging too, or an unmounted address could be resurrected by a commit
-     ;; sweep that runs after the eviction.
-     (ec/swap-state! [:dom/pending] (fn [m] (dissoc m addr))))))
+     (ec/swap-state! [:dom/foreign] (fn [m] (dissoc m addr))))))
 
 ;; =============================================================================
 ;; Attribute Reconciliation

--- a/src/org/replikativ/spindel/dom/commit.cljc
+++ b/src/org/replikativ/spindel/dom/commit.cljc
@@ -92,11 +92,22 @@
       (mapv cache/make-slot (plain-children vnode))))
 
 (defn- fragment-order+by-key
-  "[order by-key items-by-key] for a KeyedFragment's current items."
+  "[order by-key items] for a KeyedFragment's current items."
   [fragment]
   (let [items (frag/fragment-items fragment)
         order (mapv :key items)]
     [order (zipmap order items) items]))
+
+(defn- fragment-cache-value
+  "The committed keyed-cache entry for a fragment: vnodes by key + order,
+   plus `:items-by-key`/`:was-sync?` carried FROM the fragment (for-each*
+   attaches them) — they are what the per-key memoisation reads on the
+   next build. Absent on hand-built fragments -> memo simply misses."
+  [fragment order by-key]
+  {:by-key by-key
+   :items-by-key (or (:items-by-key fragment) {})
+   :order order
+   :was-sync? (boolean (:was-sync? fragment))})
 
 ;; =============================================================================
 ;; Cache seeding for fresh subtrees
@@ -114,10 +125,7 @@
     (frag/keyed-fragment? vnode)
     (let [[order by-key items] (fragment-order+by-key vnode)]
       (when-let [fa (:addr vnode)]
-        (cache/set-keyed-cache! fa {:by-key by-key
-                                    :items-by-key {}
-                                    :order order
-                                    :was-sync? true}))
+        (cache/set-keyed-cache! fa (fragment-cache-value vnode order by-key)))
       (doseq [item items] (seed-subtree-caches! item)))
 
     (and (core/vnode? vnode) (not (core/text-node? vnode)))
@@ -136,10 +144,7 @@
               :when (frag/keyed-fragment? v)]
         (let [[order by-key _] (fragment-order+by-key v)]
           (when-let [fa (:addr v)]
-            (cache/set-keyed-cache! fa {:by-key by-key
-                                        :items-by-key {}
-                                        :order order
-                                        :was-sync? true})))))
+            (cache/set-keyed-cache! fa (fragment-cache-value v order by-key))))))
 
     :else nil))
 
@@ -190,10 +195,7 @@
       (disch/apply-seq-diff! discharge parent-el diff prev-items))
     ;; advance the keyed baseline in the same step as the DOM write
     (when fa
-      (cache/set-keyed-cache! fa {:by-key by-key
-                                  :items-by-key {}
-                                  :order order
-                                  :was-sync? true}))
+      (cache/set-keyed-cache! fa (fragment-cache-value fragment order by-key)))
     ;; grown keys were created by apply-seq-diff!'s render-initial!
     (doseq [k grown-keys]
       (seed-subtree-caches! (get by-key k)))
@@ -278,10 +280,7 @@
                   :when (frag/keyed-fragment? value)]
             (let [[order by-key _] (fragment-order+by-key value)]
               (when-let [fa (:addr value)]
-                (cache/set-keyed-cache! fa {:by-key by-key
-                                            :items-by-key {}
-                                            :order order
-                                            :was-sync? true})))
+                (cache/set-keyed-cache! fa (fragment-cache-value value order by-key))))
             (doseq [item (frag/fragment-items value)]
               (seed-subtree-caches! item)))
           ;; 4. keyed-keyed slots: our own diff + recursion into survivors

--- a/src/org/replikativ/spindel/dom/commit.cljc
+++ b/src/org/replikativ/spindel/dom/commit.cljc
@@ -155,6 +155,12 @@
 (declare commit-reconcile!)
 (declare commit-reconcile*)
 
+;; One warn per unbound address per process — the condition persists across
+;; passes (the stranded subtree is recommitted on every parent re-emission),
+;; so unthrottled it floods the console: measured 89 identical lines for one
+;; defect. Same policy as discharge's logged-collisions.
+(defonce ^:private logged-unbound (atom #{}))
+
 (defn- created-value-addrs
   "Addresses of subtrees a set of just-applied child deltas CREATED (as
    opposed to reconciled in place). These get seeded caches and are excluded
@@ -231,7 +237,14 @@
       (if-not el
         ;; No element for a claimed-committed address: loud, not silent —
         ;; this is the commit-walk analogue of ::deltas-dropped-unbound-addr.
-        (log/warn ::commit-unbound-addr {:addr addr :tag (:tag vnode)})
+        ;; Known producer: an ::addr-collision earlier (two vnodes, one addr —
+        ;; e.g. an unkeyed component instantiated per scope); the collision
+        ;; winner's unmount strands the loser here, frozen.
+        (when-not (contains? @logged-unbound addr)
+          (swap! logged-unbound conj addr)
+          (log/warn ::commit-unbound-addr {:addr addr :tag (:tag vnode)
+                                           :class (:class (plain-attrs vnode))
+                                           :children (count (plain-children vnode))}))
         (let [;; --- attrs: committed -> arrived ---
               new-attrs (dissoc (plain-attrs vnode) :key :ref)
               prev-attrs (cache/get-attr-cache addr)

--- a/src/org/replikativ/spindel/dom/commit.cljc
+++ b/src/org/replikativ/spindel/dom/commit.cljc
@@ -148,6 +148,7 @@
 ;; =============================================================================
 
 (declare commit-reconcile!)
+(declare commit-reconcile*)
 
 (defn- created-value-addrs
   "Addresses of subtrees a set of just-applied child deltas CREATED (as
@@ -201,7 +202,7 @@
     ;; apply-seq-diff! itself; compatible ones were reconciled). Recurse to
     ;; bring their attrs/slots current against their own caches.
     (doseq [k (filter (set prev-order) order)]
-      (commit-reconcile! discharge (get by-key k)))
+      (commit-reconcile* discharge (get by-key k)))
     nil))
 
 (defn commit-reconcile!
@@ -215,6 +216,11 @@
    CURRENT state, which is exactly what should be applied.
 
    Returns nil."
+  [discharge vnode]
+  (binding [disch/*suppress-vnode-deltas* true]
+    (commit-reconcile* discharge vnode)))
+
+(defn- commit-reconcile*
   [discharge vnode]
   (when (and (core/vnode? vnode)
              (not (core/text-node? vnode))
@@ -292,5 +298,5 @@
                                (not (core/text-node? child))
                                (:addr child)
                                (not (contains? created (:addr child))))]
-              (commit-reconcile! discharge child))))))
+              (commit-reconcile* discharge child))))))
     nil))

--- a/src/org/replikativ/spindel/dom/commit.cljc
+++ b/src/org/replikativ/spindel/dom/commit.cljc
@@ -1,0 +1,296 @@
+(ns org.replikativ.spindel.dom.commit
+  "Commit-time reconciliation — the diff runs where the DOM is written.
+
+   Why this namespace exists. Under compute-time reconciliation
+   (`build-element` diffing against the committed caches and attaching
+   `:deltas` to the vnode) there is an unclosable window: when a body slice
+   re-executes N times before the first render pass commits — measured live:
+   six builds of one container during a single settled expand, driven by the
+   parent's `:await-reactive` cont re-firing per child re-completion — all N
+   builds diff against the SAME baseline, each carries the same `:add`, and
+   more than one distinct vnode object can reach the DOM in separate passes.
+   Every dedup guard is keyed on something (object identity, address, pass)
+   that some legitimate case must be allowed to pass. Worse, the staging that
+   R3 introduced is last-write-wins per address, so the committed baseline can
+   advance PAST what the DOM holds (silent lost updates), or aside of it.
+
+   The correction is structural, not another guard: compute the diff AT the
+   commit point, against the committed caches, and advance those caches in
+   the same step as the DOM write. A stale build arriving later then diffs
+   against the already-advanced baseline and collapses to its genuine
+   residual — usually nothing, and when it does carry a fresh change (the
+   last staggered update in a burst), exactly that change.
+
+   This is option D/E of `.internal/effect-state-design.md`, anticipated by
+   `repeat_execution_test.clj`'s unit property: \"against an ADVANCED
+   baseline, the second execution is a no-op\".
+
+   What this walk needs from a build that compute-time reconciliation did
+   not: the vnode must carry its SLOT STRUCTURE (`:slots` — the classified
+   `{:type :value}` vector), because `flatten-slots` destroys the `:nil`-slot
+   information the reconciler needs for stable slot indices. And the diff
+   must run against the ARRIVED TREE — never against staging, whose
+   last-write-wins-per-address semantics are exactly the desync this
+   namespace exists to remove.
+
+   Reuses the existing machinery relocated: `cache/reconcile-attrs`,
+   `cache/reconcile-children`, `sa/keyed-seq-diff` compute; `discharge`'s
+   `apply-child-delta!` / `apply-seq-diff!` / `render-initial!` apply.
+
+   Two behaviours differ deliberately from the compute-time path:
+
+   1. Addr-equal children produce NO delta (reconcile-slot's [:single
+      :single] unchanged case) — under compute-time semantics \"the child
+      handles its own deltas via discharge-vnode!\"; here there are no child
+      deltas, so the walk RECURSES into addr-equal children and diffs them
+      against their own per-address caches.
+
+   2. [:keyed :keyed] slot pairs are not answered from fragment build-time
+      deltas (there are none); the walk computes `keyed-seq-diff` itself,
+      from the committed keyed cache to the fragment's items.
+
+   Fresh subtrees (created here via `render-initial!` inside an applied
+   `:add`/`:update`/fragment delta) get their caches SEEDED from their
+   vnodes, not diffed — diffing a just-created subtree against its nil cache
+   would re-emit its whole mount."
+  (:require [org.replikativ.spindel.dom.core :as core]
+            [org.replikativ.spindel.dom.cache :as cache]
+            [org.replikativ.spindel.dom.fragment :as frag]
+            [org.replikativ.spindel.dom.discharge :as disch]
+            [org.replikativ.spindel.dom.foreach :as foreach]
+            [org.replikativ.spindel.incremental.sequence-algebra :as sa]
+            [org.replikativ.spindel.incremental.deltaable :as d]
+            [org.replikativ.spindel.engine.core :as ec]
+            [replikativ.logging :as log]))
+
+;; =============================================================================
+;; Helpers
+;; =============================================================================
+
+(defn- plain-attrs [vnode]
+  (let [a (:attrs vnode)]
+    (cond (nil? a) {}
+          (d/deltaable? a) @a
+          :else a)))
+
+(defn- plain-children [vnode]
+  (let [c (:children vnode)]
+    (cond (nil? c) []
+          (d/deltaable? c) @c
+          :else c)))
+
+(defn vnode-slots
+  "The slot-entry vector for a vnode in the commit walk.
+
+   Prefers the `:slots` the build attached (pre-flatten, `:nil` slots
+   preserved). Falls back to classifying the flattened children — correct
+   only when no conditional slot is currently nil, which is why builds must
+   carry `:slots`; the fallback keeps hand-constructed test vnodes and
+   legacy paths walkable."
+  [vnode]
+  (or (:slots vnode)
+      (mapv cache/make-slot (plain-children vnode))))
+
+(defn- fragment-order+by-key
+  "[order by-key items-by-key] for a KeyedFragment's current items."
+  [fragment]
+  (let [items (frag/fragment-items fragment)
+        order (mapv :key items)]
+    [order (zipmap order items) items]))
+
+;; =============================================================================
+;; Cache seeding for fresh subtrees
+;; =============================================================================
+
+(defn seed-subtree-caches!
+  "Write the per-address caches for a subtree that was just CREATED by
+   `render-initial!` — attrs, slots, and keyed caches derived from the
+   vnodes themselves. The subtree's DOM is exactly its tree, so its caches
+   must say so; without this, the next commit walk diffs the subtree
+   against nil and re-emits its whole mount (the very bug this namespace
+   removes, reintroduced one level down)."
+  [vnode]
+  (cond
+    (frag/keyed-fragment? vnode)
+    (let [[order by-key items] (fragment-order+by-key vnode)]
+      (when-let [fa (:addr vnode)]
+        (cache/set-keyed-cache! fa {:by-key by-key
+                                    :items-by-key {}
+                                    :order order
+                                    :was-sync? true}))
+      (doseq [item items] (seed-subtree-caches! item)))
+
+    (and (core/vnode? vnode) (not (core/text-node? vnode)))
+    (let [addr (:addr vnode)
+          slots (vnode-slots vnode)]
+      (when addr
+        (cache/set-attr-cache! addr (dissoc (plain-attrs vnode) :key :ref))
+        (cache/set-slot-cache! addr slots))
+      (doseq [slot slots
+              child (cache/flatten-slot slot)]
+        (seed-subtree-caches! child))
+      ;; a :keyed slot's fragment addr also needs its keyed cache
+      (doseq [slot slots
+              :when (= :keyed (:type slot))
+              :let [v (:value slot)]
+              :when (frag/keyed-fragment? v)]
+        (let [[order by-key _] (fragment-order+by-key v)]
+          (when-let [fa (:addr v)]
+            (cache/set-keyed-cache! fa {:by-key by-key
+                                        :items-by-key {}
+                                        :order order
+                                        :was-sync? true})))))
+
+    :else nil))
+
+;; =============================================================================
+;; The commit walk
+;; =============================================================================
+
+(declare commit-reconcile!)
+
+(defn- created-value-addrs
+  "Addresses of subtrees a set of just-applied child deltas CREATED (as
+   opposed to reconciled in place). These get seeded caches and are excluded
+   from the diff recursion."
+  [deltas]
+  (into #{}
+        (mapcat (fn [{:keys [delta value old-value]}]
+                  (case delta
+                    (:add :replace-fragment-with-single)
+                    (when-let [a (:addr value)] [a])
+                    ;; :update creates fresh only when NOT reconcilable —
+                    ;; mirror apply-child-delta!'s own decision
+                    :update
+                    (when (and (not (disch/reconcilable? old-value value))
+                               (:addr value))
+                      [(:addr value)])
+                    (:add-fragment :replace-with-fragment)
+                    (keep :addr (frag/fragment-items value))
+                    nil)))
+        deltas))
+
+(defn- commit-keyed-slot!
+  "Commit one [:keyed :keyed] slot: diff the fragment's items against the
+   COMMITTED keyed cache, apply, advance the cache, and return the item
+   addresses that were newly created (grown keys) so the caller can seed
+   them. Items surviving by key are recursed into by the caller."
+  [discharge parent-el fragment]
+  (let [fa (:addr fragment)
+        [order by-key items] (fragment-order+by-key fragment)
+        committed (when fa (cache/get-keyed-cache fa))
+        prev-order (or (:order committed) [])
+        prev-by-key (or (:by-key committed) {})
+        diff (sa/keyed-seq-diff order prev-order by-key prev-by-key
+                                foreach/vnode-value-equal?)
+        prev-items (mapv #(get prev-by-key %) prev-order)
+        grown-keys (remove (set prev-order) order)]
+    (when diff
+      (disch/apply-seq-diff! discharge parent-el diff prev-items))
+    ;; advance the keyed baseline in the same step as the DOM write
+    (when fa
+      (cache/set-keyed-cache! fa {:by-key by-key
+                                  :items-by-key {}
+                                  :order order
+                                  :was-sync? true}))
+    ;; grown keys were created by apply-seq-diff!'s render-initial!
+    (doseq [k grown-keys]
+      (seed-subtree-caches! (get by-key k)))
+    ;; surviving items may have changed internally OR been replaced by the
+    ;; diff's :change (render-initial! for incompatible ones is handled by
+    ;; apply-seq-diff! itself; compatible ones were reconciled). Recurse to
+    ;; bring their attrs/slots current against their own caches.
+    (doseq [k (filter (set prev-order) order)]
+      (commit-reconcile! discharge (get by-key k)))
+    nil))
+
+(defn commit-reconcile!
+  "Diff `vnode` against the committed per-address caches, apply the
+   difference through `discharge`, and advance the caches — one step.
+
+   Precondition: an element for `(:addr vnode)` exists in the discharge
+   (the initial mount goes through `render-initial!` + `seed-subtree-caches!`,
+   not through here). Safe to call repeatedly with stale builds: a build
+   older than the committed baseline diffs to its residual against the
+   CURRENT state, which is exactly what should be applied.
+
+   Returns nil."
+  [discharge vnode]
+  (when (and (core/vnode? vnode)
+             (not (core/text-node? vnode))
+             (:addr vnode))
+    (let [addr (:addr vnode)
+          el (disch/get-element discharge addr)]
+      (if-not el
+        ;; No element for a claimed-committed address: loud, not silent —
+        ;; this is the commit-walk analogue of ::deltas-dropped-unbound-addr.
+        (log/warn ::commit-unbound-addr {:addr addr :tag (:tag vnode)})
+        (let [;; --- attrs: committed -> arrived ---
+              new-attrs (dissoc (plain-attrs vnode) :key :ref)
+              prev-attrs (cache/get-attr-cache addr)
+              attr-deltas (cache/reconcile-attrs prev-attrs new-attrs)
+              ;; --- slots: committed -> arrived ---
+              new-slots (vnode-slots vnode)
+              prev-slots (cache/get-slot-cache addr)
+              new-children (mapv :value new-slots)
+              {:keys [slots deltas]} (cache/reconcile-children prev-slots new-children)
+              ;; [:keyed :keyed] pairs are OURS to diff (behaviour 2 in the
+              ;; ns docstring); reconcile-slot's :fragment-update reads
+              ;; build-time fragment deltas that no longer exist. Drop any
+              ;; it produced and remember the pairs for commit-keyed-slot!.
+              keyed-pairs (into []
+                                (keep-indexed
+                                 (fn [i slot]
+                                   (when (and (= :keyed (:type slot))
+                                              (= :keyed (:type (get prev-slots i)))
+                                              (frag/keyed-fragment? (:value slot)))
+                                     (:value slot))))
+                                slots)
+              structural-deltas (into [] (remove #(= :fragment-update (:delta %))) deltas)
+              adjusted (when (seq structural-deltas)
+                         (cache/adjust-delta-paths slots structural-deltas))]
+          ;; 1. attrs
+          (doseq [{:keys [delta path value]} attr-deltas]
+            (let [k (first path)]
+              (case delta
+                (:add :update) (disch/set-attribute! discharge el k value)
+                :remove (disch/remove-attribute! discharge el k)
+                nil)))
+          (cache/set-attr-cache! addr new-attrs)
+          ;; 2. structural child deltas (type transitions, adds, removes)
+          (doseq [dlt adjusted]
+            (disch/apply-child-delta! discharge el dlt))
+          (cache/set-slot-cache! addr slots)
+          ;; 3. fresh subtrees created in step 2 get seeded caches
+          (doseq [a (created-value-addrs structural-deltas)
+                  :let [child (some #(when (= a (:addr %)) %)
+                                    (map :value structural-deltas))]]
+            (when child (seed-subtree-caches! child)))
+          ;; fragments made visible in step 2 seed their keyed caches too
+          (doseq [{:keys [delta value]} structural-deltas
+                  :when (#{:add-fragment :replace-with-fragment} delta)
+                  :when (frag/keyed-fragment? value)]
+            (let [[order by-key _] (fragment-order+by-key value)]
+              (when-let [fa (:addr value)]
+                (cache/set-keyed-cache! fa {:by-key by-key
+                                            :items-by-key {}
+                                            :order order
+                                            :was-sync? true})))
+            (doseq [item (frag/fragment-items value)]
+              (seed-subtree-caches! item)))
+          ;; 4. keyed-keyed slots: our own diff + recursion into survivors
+          (doseq [fragment keyed-pairs]
+            (commit-keyed-slot! discharge el fragment))
+          ;; 5. recurse into addr-equal children (behaviour 1 in the ns
+          ;; docstring). Freshly created subtrees were seeded above, so
+          ;; recursing into them diffs to nothing — the recursion is uniform.
+          (let [created (created-value-addrs structural-deltas)]
+            (doseq [slot slots
+                    :when (= :single (:type slot))
+                    :let [child (:value slot)]
+                    :when (and (core/vnode? child)
+                               (not (core/text-node? child))
+                               (:addr child)
+                               (not (contains? created (:addr child))))]
+              (commit-reconcile! discharge child))))))
+    nil))

--- a/src/org/replikativ/spindel/dom/commit.cljc
+++ b/src/org/replikativ/spindel/dom/commit.cljc
@@ -219,8 +219,7 @@
 
    Returns nil."
   [discharge vnode]
-  (binding [disch/*suppress-vnode-deltas* true]
-    (commit-reconcile* discharge vnode)))
+  (commit-reconcile* discharge vnode))
 
 (defn- commit-reconcile*
   [discharge vnode]

--- a/src/org/replikativ/spindel/dom/discharge.cljc
+++ b/src/org/replikativ/spindel/dom/discharge.cljc
@@ -641,8 +641,20 @@
   ;; mutated it incrementally rather than rebuilding).
   (apply-attr-deltas! discharge el new-vnode)
   ;; Propagate child-level changes (both slot-reconciliation :deltas
-  ;; and :children DeltaableVector deltas).
-  (apply-child-deltas! discharge el new-vnode))
+  ;; and :children DeltaableVector deltas) — AT MOST ONCE per vnode
+  ;; object, through the same `*applied-vnodes*` gate as
+  ;; `discharge-vnode!`. A fragment item is reachable twice in one
+  ;; pass: the seq-diff `:change` reconciles it HERE, and the item is
+  ;; also SPLICED into its parent's `:children` (flatten-slot), so the
+  ;; delta tree-walk visits the same object again. Ungated, a
+  ;; conditional child's `:add` applied twice — measured as two
+  ;; identical `.section-items` inserted into one section by one body
+  ;; execution. Whichever path runs first wins; the other skips the
+  ;; child deltas (attrs above stay unguarded — re-setting an
+  ;; attribute to the same value is idempotent at the DOM).
+  (when-not (applied-seen?! *applied-vnodes* new-vnode)
+    (applied-add! *applied-vnodes* new-vnode)
+    (apply-child-deltas! discharge el new-vnode)))
 
 ;; =============================================================================
 ;; Child Delta Application (New Delta-Direct System)

--- a/src/org/replikativ/spindel/dom/discharge.cljc
+++ b/src/org/replikativ/spindel/dom/discharge.cljc
@@ -372,7 +372,7 @@
 ;; regular-element children is a follow-up.
 ;; =============================================================================
 
-(defn- reconcilable?
+(defn reconcilable?
   "True if old-vnode and new-vnode can be reconciled into the same DOM
    element — same shape, same address, same key, same tag.
 

--- a/src/org/replikativ/spindel/dom/discharge.cljc
+++ b/src/org/replikativ/spindel/dom/discharge.cljc
@@ -306,7 +306,6 @@
       (when-not (contains? new-attrs k)
         (remove-attribute! discharge el k)))))
 
-
 (declare reconcile-vnode!)
 
 ;; =============================================================================
@@ -672,7 +671,6 @@
 
     ;; Unknown delta type - ignore
     nil))
-
 
 ;; =============================================================================
 ;; Ref Callback Helpers

--- a/src/org/replikativ/spindel/dom/discharge.cljc
+++ b/src/org/replikativ/spindel/dom/discharge.cljc
@@ -156,6 +156,15 @@
 ;; drops the second cycle's deltas, leaving stale / duplicated DOM.
 (def ^:dynamic *applied-vnodes* nil)
 
+;; Bound true by the commit-time reconciliation walk (dom/commit). The walk
+;; computes every difference itself against the committed caches; vnode-
+;; attached build-time :deltas are frozen against whatever baseline that
+;; build happened to see and MUST NOT also apply — under the walk they are
+;; exactly the stale duplicates being eliminated. reconcile-vnode! keeps its
+;; value-based attr diff either way. TRANSITIONAL: once builds stop attaching
+;; :deltas (E step 5), the guarded branches become vacuous and this flag goes.
+(def ^:dynamic *suppress-vnode-deltas* false)
+
 ;; ----------------------------------------------------------------------------
 ;; Generational identity tracking for *applied-vnodes*
 ;; ----------------------------------------------------------------------------
@@ -636,10 +645,11 @@
    for any change they need propagated."
   [discharge el old-vnode new-vnode]
   (reconcile-attrs! discharge el old-vnode new-vnode)
+  (when-not *suppress-vnode-deltas*
   ;; Also honour any DeltaableMap attr-deltas on the new vnode (in
   ;; case the producer maintained the same map across renders and
   ;; mutated it incrementally rather than rebuilding).
-  (apply-attr-deltas! discharge el new-vnode)
+  (apply-attr-deltas! discharge el new-vnode))
   ;; Propagate child-level changes (both slot-reconciliation :deltas
   ;; and :children DeltaableVector deltas) — AT MOST ONCE per vnode
   ;; object, through the same `*applied-vnodes*` gate as
@@ -652,9 +662,10 @@
   ;; execution. Whichever path runs first wins; the other skips the
   ;; child deltas (attrs above stay unguarded — re-setting an
   ;; attribute to the same value is idempotent at the DOM).
-  (when-not (applied-seen?! *applied-vnodes* new-vnode)
-    (applied-add! *applied-vnodes* new-vnode)
-    (apply-child-deltas! discharge el new-vnode)))
+  (when-not *suppress-vnode-deltas*
+    (when-not (applied-seen?! *applied-vnodes* new-vnode)
+      (applied-add! *applied-vnodes* new-vnode)
+      (apply-child-deltas! discharge el new-vnode))))
 
 ;; =============================================================================
 ;; Child Delta Application (New Delta-Direct System)

--- a/src/org/replikativ/spindel/dom/discharge.cljc
+++ b/src/org/replikativ/spindel/dom/discharge.cljc
@@ -309,10 +309,18 @@
   ([] (flush-pending-evictions! nil))
   ([discharge]
    (when (and *pending-evictions* *rendered-addrs*)
-     (let [live (set (keys @*rendered-addrs*))]
+     ;; `*rendered-addrs*` holds only addresses that appear ON a vnode, and an
+     ;; `ifor-each` call site appears on none — `flatten-slot` splices the
+     ;; fragment's items into `:children` and drops the fragment. So a fragment
+     ;; could never be found live here, and was exempt from this whole check:
+     ;; a dead parent's stale `:keyed` slot cascaded into the cache of a
+     ;; fragment the LIVE parent was still rendering, and the next render
+     ;; diffed against an empty baseline and re-added every item. Close over
+     ;; the committed slots the same way `commit-pending!` does for staging.
+     (let [live (cache/live-keyed-closure (keys @*rendered-addrs*))]
        (doseq [addr @*pending-evictions*]
          (when-not (contains? live addr)
-           (cache/evict-cache! addr)
+           (cache/evict-cache! addr live)
            (when discharge (remove-element! discharge addr))))))))
 
 ;; =============================================================================

--- a/src/org/replikativ/spindel/dom/discharge.cljc
+++ b/src/org/replikativ/spindel/dom/discharge.cljc
@@ -128,118 +128,8 @@
 ;; =============================================================================
 
 (declare render-initial!)
-(declare clear-deltas-deep)
 (declare call-ref!)
 (declare call-refs-on-unmount!)
-
-;; Track vnodes that have been fully rendered via render-initial!
-;; These should not have their deltas applied again.
-(def ^:dynamic *rendered-vnodes* nil)
-
-;; Tracks vnode objects whose :deltas have already been applied by
-;; discharge-vnode! at some point in the render-effect's lifetime.
-;;
-;; Unlike *rendered-vnodes* which is per-cycle, this set is bound by the
-;; render effect once and persists across re-render cycles. It exists to
-;; deal with the cross-spin reuse case: a cached spin result (an aside
-;; vnode) carries its initial-reconciliation :deltas forever; without
-;; this set, every time a parent re-emits and embeds the cached child
-;; vnode, the same :deltas fire again, duplicating children in the DOM.
-;;
-;; Identity comparison is the WHOLE point: a *new* vnode at the same
-;; addr with new deltas (e.g. a rebuild because the spin re-ran, OR a
-;; fresh build-element output that just happens to be value-equal to a
-;; prior cycle's vnode) is a different object and MUST get its deltas
-;; applied. Value comparison here is a correctness bug — when a source
-;; oscillates back to an equal state, two distinct render cycles
-;; produce value-equal parent vnodes, and a value-keyed set silently
-;; drops the second cycle's deltas, leaving stale / duplicated DOM.
-(def ^:dynamic *applied-vnodes* nil)
-
-;; Bound true by the commit-time reconciliation walk (dom/commit). The walk
-;; computes every difference itself against the committed caches; vnode-
-;; attached build-time :deltas are frozen against whatever baseline that
-;; build happened to see and MUST NOT also apply — under the walk they are
-;; exactly the stale duplicates being eliminated. reconcile-vnode! keeps its
-;; value-based attr diff either way. TRANSITIONAL: once builds stop attaching
-;; :deltas (E step 5), the guarded branches become vacuous and this flag goes.
-(def ^:dynamic *suppress-vnode-deltas* false)
-
-;; ----------------------------------------------------------------------------
-;; Generational identity tracking for *applied-vnodes*
-;; ----------------------------------------------------------------------------
-;;
-;; Requirements: (a) IDENTITY semantics — "have I seen THIS object?",
-;; never "an equal one"; (b) bounded memory — a naive identity set held
-;; for the render-effect's whole life pins every vnode ever discharged.
-;;
-;; The JVM has no weak *identity* map in the stdlib (`WeakHashMap` is
-;; value-keyed; `IdentityHashMap` is strong). So instead of relying on
-;; GC we bound memory explicitly with two generations, :prev and :cur,
-;; rotated once per discharge cycle (`rotate-applied!`). A cached spin
-;; result that is still being re-embedded is re-touched into :cur every
-;; cycle, so it never ages out while live; once its spin re-runs and it
-;; stops being embedded, it falls out within two cycles. CLJS keeps a
-;; bare js/WeakSet — JS WeakSet is already weak AND identity-keyed — so
-;; the generational machinery is a CLJ-only no-op there.
-;;
-;; synchronizedSet because multiple async-dispatch threads can drive
-;; concurrent discharge passes against the same applied-set.
-
-#?(:clj
-   (defn- identity-vnode-set []
-     (Collections/synchronizedSet
-      (Collections/newSetFromMap (IdentityHashMap.)))))
-
-(defn make-applied-vnodes
-  "Create a fresh applied-vnodes tracker (one per render-effect).
-
-   CLJ: an atom holding `{:prev <identity-set> :cur <identity-set>}`.
-   CLJS: a js/WeakSet (already weak + identity-keyed).
-
-   Identity-based 'have I seen THIS object?' semantics; memory is
-   bounded to ~2 discharge cycles via `rotate-applied!`."
-  []
-  #?(:clj  (atom {:prev (identity-vnode-set) :cur (identity-vnode-set)})
-     :cljs (js/WeakSet.)))
-
-(defn- applied-seen?!
-  "Identity check: was this exact vnode object already discharged in
-   this cycle or the previous one? Nil-safe on the set arg.
-
-   Side effect: when the vnode is found only in the older (:prev)
-   generation, it is refreshed into :cur — so a cached spin result
-   that keeps being re-embedded never ages out across the rotation."
-  [s vnode]
-  (and s
-       #?(:clj  (let [{:keys [prev cur]} @s]
-                  (cond
-                    (.contains ^java.util.Set cur vnode)  true
-                    (.contains ^java.util.Set prev vnode) (do (.add ^java.util.Set cur vnode)
-                                                              true)
-                    :else false))
-          :cljs (.has s vnode))))
-
-(defn- applied-add!
-  "Mark this vnode object as applied in the current generation.
-   No-op when the set is nil."
-  [s vnode]
-  (when s
-    #?(:clj  (.add ^java.util.Set (:cur @s) vnode)
-       :cljs (.add s vnode)))
-  nil)
-
-(defn- rotate-applied!
-  "Advance the applied-vnodes generations at a discharge-cycle
-   boundary: this cycle's :cur becomes :prev and a fresh empty :cur
-   starts. Bounds memory to the last two cycles' worth of applied
-   vnodes. CLJS's js/WeakSet is GC-managed, so this is a no-op there."
-  [s]
-  #?(:clj  (when s
-             (swap! s (fn [{:keys [cur]}]
-                        {:prev cur :cur (identity-vnode-set)})))
-     :cljs nil)
-  nil)
 
 ;; Track addresses claimed during the current render pass. If two different
 ;; vnodes try to claim the same :addr we have an addressing collision —
@@ -347,14 +237,6 @@
       :remove (remove-attribute! discharge el attr-name)
       nil)))
 
-(defn apply-attr-deltas!
-  "Apply all attribute deltas from vnode to element."
-  [discharge el vnode]
-  (when-let [attrs (:attrs vnode)]
-    (when-let [attr-deltas (d/get-deltas attrs)]
-      (doseq [delta attr-deltas]
-        (apply-attr-delta! discharge el delta)))))
-
 ;; =============================================================================
 ;; Key-aware reconciliation
 ;;
@@ -424,8 +306,6 @@
       (when-not (contains? new-attrs k)
         (remove-attribute! discharge el k)))))
 
-(declare apply-child-deltas!)
-(declare apply-attr-deltas!)
 
 (declare reconcile-vnode!)
 
@@ -627,45 +507,13 @@
 
    Two sources of changes are propagated to the reused element:
 
-   1. Attribute diff between old-vnode and new-vnode. Computed by
-      `reconcile-attrs!` — this catches changes that aren't expressed
-      as DeltaableMap deltas (e.g. fresh attrs on a re-constructed
-      vnode).
-
-   2. The new-vnode's own `:deltas` field (from slot reconciliation)
-      and `:children`-DeltaableVector deltas. These describe per-child
-      changes the producer already computed; `apply-child-deltas!`
-      walks them. Attribute deltas on the new-vnode's DeltaableMap are
-      applied via `apply-attr-deltas!` so the same attribute-delta
-      vocabulary the existing discharge consumes is honoured.
-
-   Deep structural child reconciliation (matching arbitrary new
-   children to old children by `:key` when no child-delta path exists)
-   is deferred — producers currently emit the explicit delta vocabulary
-   for any change they need propagated."
+   Only the attribute diff between old-vnode and new-vnode, computed by
+   `reconcile-attrs!`. Child-level changes are NOT applied here — under
+   commit-time reconciliation (dom/commit) the walk recurses into
+   addr-equal children and diffs them against their own per-address
+   caches; builds attach no deltas of their own."
   [discharge el old-vnode new-vnode]
-  (reconcile-attrs! discharge el old-vnode new-vnode)
-  (when-not *suppress-vnode-deltas*
-  ;; Also honour any DeltaableMap attr-deltas on the new vnode (in
-  ;; case the producer maintained the same map across renders and
-  ;; mutated it incrementally rather than rebuilding).
-  (apply-attr-deltas! discharge el new-vnode))
-  ;; Propagate child-level changes (both slot-reconciliation :deltas
-  ;; and :children DeltaableVector deltas) — AT MOST ONCE per vnode
-  ;; object, through the same `*applied-vnodes*` gate as
-  ;; `discharge-vnode!`. A fragment item is reachable twice in one
-  ;; pass: the seq-diff `:change` reconciles it HERE, and the item is
-  ;; also SPLICED into its parent's `:children` (flatten-slot), so the
-  ;; delta tree-walk visits the same object again. Ungated, a
-  ;; conditional child's `:add` applied twice — measured as two
-  ;; identical `.section-items` inserted into one section by one body
-  ;; execution. Whichever path runs first wins; the other skips the
-  ;; child deltas (attrs above stay unguarded — re-setting an
-  ;; attribute to the same value is idempotent at the DOM).
-  (when-not *suppress-vnode-deltas*
-    (when-not (applied-seen?! *applied-vnodes* new-vnode)
-      (applied-add! *applied-vnodes* new-vnode)
-      (apply-child-deltas! discharge el new-vnode))))
+  (reconcile-attrs! discharge el old-vnode new-vnode))
 
 ;; =============================================================================
 ;; Child Delta Application (New Delta-Direct System)
@@ -675,12 +523,8 @@
   "Apply a single child delta from slot reconciliation."
   [discharge el delta]
   (case (:delta delta)
-    ;; Simple add: render and insert
-    ;; IMPORTANT: After render-initial!, mark the vnode subtree as rendered to prevent
-    ;; double-application. The vnode may have deltas from element* reconciliation
-    ;; against empty cache, but render-initial! already creates all children.
-    ;; Without marking, those deltas would be applied again when discharge-vnode!
-    ;; processes the child vnodes (since they're in the pre-computed nodes-with-deltas list).
+    ;; Simple add: render and insert. The caller (the commit walk) seeds
+    ;; the created subtree's caches afterwards — see dom/commit.
     :add
     (let [{:keys [path value]} delta
           index (first path)
@@ -829,199 +673,6 @@
     ;; Unknown delta type - ignore
     nil))
 
-(defn apply-child-deltas!
-  "Apply all child deltas from vnode to element.
-
-  Deltas come from two sources:
-  1. The :deltas field set by element* during slot reconciliation
-  2. The DeltaableVector children (from dom/append-child, dom/update-child, etc.)"
-  [discharge el vnode]
-  ;; Apply slot reconciliation deltas
-  (when-let [deltas (:deltas vnode)]
-    (doseq [delta deltas]
-      (apply-child-delta! discharge el delta)))
-  ;; Apply DeltaableVector children deltas (from direct manipulation)
-  (when-let [children (:children vnode)]
-    (when-let [child-deltas (d/get-deltas children)]
-      (doseq [delta child-deltas]
-        (apply-child-delta! discharge el delta)))))
-
-;; =============================================================================
-;; VNode Discharge
-;; =============================================================================
-
-(defn discharge-vnode!
-  "Discharge all deltas from a vnode to the target element.
-
-  Applies:
-  1. Attribute deltas (from DeltaableMap)
-  2. Child deltas (from slot reconciliation :deltas field)
-
-  Skips vnodes that were already fully rendered via render-initial! during
-  this discharge cycle (tracked in *rendered-vnodes*), AND vnodes whose
-  deltas have already been applied earlier in this render-effect's
-  lifetime (tracked in *applied-vnodes*, set up by create-render-effect).
-  The latter protects against cross-spin reuse: a cached spin result's
-  vnode carries its initial-reconciliation :deltas; without this guard,
-  every parent re-emission that embeds the same vnode object would
-  re-apply those deltas, duplicating children in the DOM."
-  [discharge vnode]
-  (when vnode
-    (let [is-rendered? (and *rendered-vnodes* (contains? @*rendered-vnodes* vnode))
-          is-applied?  (applied-seen?! *applied-vnodes* vnode)]
-      (log/debug ::discharge-vnode {:tag (:tag vnode)
-                                    :is-rendered? is-rendered?
-                                    :is-applied? is-applied?
-                                    :has-child-deltas (boolean (seq (:deltas vnode)))
-                                    :child-delta-count (count (:deltas vnode))
-                                    :rendered-set-size (when *rendered-vnodes* (count @*rendered-vnodes*))})
-      (when-not (or is-rendered? is-applied?)
-        (let [el (get-element discharge (:addr vnode))]
-          (when-not el
-            ;; A vnode that CARRIES DELTAS but whose address has no bound DOM
-            ;; element means those updates are about to be dropped on the floor.
-            ;; That is never intentional: it is the signature of reconcile and
-            ;; discharge disagreeing about identity (the parent declared the
-            ;; child unchanged, so no element was ever created at the child's
-            ;; new address). Silently skipping it froze whole subtrees with a
-            ;; single debug line. Log loudly, once per address.
-            (when (and (seq (:deltas vnode))
-                       (not (contains? @logged-unbound (:addr vnode))))
-              (swap! logged-unbound conj (:addr vnode))
-              (log/error ::deltas-dropped-unbound-addr
-                         {:addr (:addr vnode)
-                          :tag (:tag vnode)
-                          :delta-count (count (:deltas vnode))
-                          :hint (str "This vnode's updates were discarded: no DOM "
-                                     "element is bound to its address. Usually a "
-                                     "structural change the parent's reconcile "
-                                     "did not emit a delta for.")}))
-            (log/debug ::element-not-found {:addr (:addr vnode) :tag (:tag vnode)
-                                            :delta-count (count (:deltas vnode))}))
-          (when el
-            ;; Apply attribute deltas
-            (apply-attr-deltas! discharge el vnode)
-
-            ;; Apply child deltas (from new delta-direct system)
-            (apply-child-deltas! discharge el vnode)
-
-            ;; Mark this vnode object as applied so future render cycles
-            ;; that encounter the SAME vnode (e.g. a cached spin result
-            ;; embedded by a re-emitting parent) skip re-applying.
-            (applied-add! *applied-vnodes* vnode)))))))
-
-;; =============================================================================
-;; Tree Walking
-;; =============================================================================
-
-(defn collect-nodes-with-deltas
-  "Walk vdom tree and collect all nodes that have deltas.
-
-  A node has deltas if:
-  - It has attribute deltas (from DeltaableMap)
-  - It has child deltas (from :deltas field)"
-  [vnode]
-  (when vnode
-    (let [has-attr-deltas? (and (:attrs vnode) (d/has-deltas? (:attrs vnode)))
-          has-child-deltas? (or (seq (:deltas vnode))
-                                (and (:children vnode) (d/has-deltas? (:children vnode))))
-          has-deltas? (or has-attr-deltas? has-child-deltas?)
-          children (when-let [ch (:children vnode)]
-                     (if (d/deltaable? ch) @ch ch))
-          child-results (mapcat collect-nodes-with-deltas children)]
-      (when has-deltas?
-        (log/debug ::collected-node-with-deltas {:tag (:tag vnode)
-                                                 :child-delta-count (count (:deltas vnode))
-                                                 :deltas (mapv #(select-keys % [:delta :path]) (:deltas vnode))}))
-      (if has-deltas?
-        (cons vnode child-results)
-        child-results))))
-
-(defn collect-addrs
-  "Every `:addr` in a vdom tree.
-
-  The sibling of `collect-nodes-with-deltas`, and deliberately NOT filtered by
-  deltas: this answers `which addresses did the DOM actually see this pass?`,
-  which is what decides whether a staged cache entry may be promoted
-  (`cache/commit-pending!`). A node created wholesale by `render-initial!`
-  carries no deltas of its own — it is still in the tree, and its caches must
-  still commit, or the next pass would re-emit its `:add` and duplicate it."
-  [vnode]
-  (if-not (map? vnode)
-    #{}
-    (let [children (when-let [ch (:children vnode)]
-                     (if (d/deltaable? ch) @ch ch))
-          from-children (into #{} (mapcat collect-addrs children))]
-      (if-let [a (:addr vnode)]
-        (conj from-children a)
-        from-children))))
-
-(defn discharge-all!
-  "Discharge all deltas from vdom tree to target.
-
-  1. Collect all nodes with deltas
-  2. Apply each node's deltas (skipping those rendered via render-initial!)
-  3. Clear deltas for next render cycle
-
-  Uses *rendered-vnodes* dynamic var to track vnodes that have been fully
-  rendered during this cycle. This prevents double-application of deltas
-  when a parent's :add delta triggers render-initial! for a child that
-  also appears in the nodes-with-deltas list.
-
-  Returns the vdom with deltas cleared."
-  [discharge vdom]
-  (binding [*rendered-vnodes* (atom #{})
-            *rendered-addrs* (atom {})
-            *pending-evictions* (atom #{})]
-    (let [nodes (collect-nodes-with-deltas vdom)]
-      (log/debug ::discharge-all {:nodes-count (count nodes)
-                                  :nodes-with-deltas (mapv (fn [n] {:tag (:tag n) :deltas (:deltas n)}) nodes)})
-      (doseq [node nodes]
-        (discharge-vnode! discharge node))
-      (let [result (clear-deltas-deep vdom)]
-        ;; This tree reached the DOM, so the reconciliations that built it may
-        ;; now become the caches' model of it. Anything staged by a run whose
-        ;; output never got here is dropped — see `cache/commit-pending!`.
-        ;; Before the evictions: an address unmounted this pass must not be
-        ;; resurrected by the promotion.
-        (cache/commit-pending! (collect-addrs vdom))
-        ;; Evict caches of addresses unmounted this pass that no live
-        ;; element re-claimed (deferred — see flush-pending-evictions!).
-        (flush-pending-evictions! discharge)
-        ;; Advance the applied-vnodes generations so memory stays
-        ;; bounded while cross-cycle cached-result protection holds.
-        (rotate-applied! *applied-vnodes*)
-        result))))
-
-;; =============================================================================
-;; Delta Clearing
-;; =============================================================================
-
-(defn clear-deltas
-  "Clear deltas from a single vnode."
-  [vnode]
-  (cond-> vnode
-    (:attrs vnode) (update :attrs d/clear-deltas)
-    (:children vnode) (update :children d/clear-deltas)
-    (:deltas vnode) (dissoc :deltas)))
-
-(defn clear-deltas-deep
-  "Recursively clear deltas from vnode and all descendants."
-  [vnode]
-  (cond
-    (nil? vnode) nil
-
-    (core/text-node? vnode) vnode
-
-    :else
-    (let [cleared (clear-deltas vnode)
-          children (:children cleared)]
-      (if children
-        (let [child-vec (if (d/deltaable? children) @children children)]
-          (assoc cleared :children
-                 (d/deltaable-vector
-                  (mapv clear-deltas-deep child-vec))))
-        cleared))))
 
 ;; =============================================================================
 ;; Ref Callback Helpers
@@ -1087,29 +738,10 @@
 ;; Initial Render (create all elements)
 ;; =============================================================================
 
-(defn- mark-rendered!
-  "Mark a vnode as rendered in *rendered-vnodes* if tracking is active.
-
-  Also marks it as 'applied' in the long-lived `*applied-vnodes*` set if
-  bound. `render-initial!` walks a vnode's :children list directly to
-  create the DOM tree, which effectively consumes the equivalent of its
-  initial-reconciliation :deltas. Without registering the vnode as
-  applied, the next discharge cycle would walk the SAME vnode (when a
-  parent re-emits with this cached child) and re-apply those deltas to
-  the existing DOM element, duplicating children — the cross-spin reuse
-  bug."
-  [vnode]
-  (when vnode
-    (when *rendered-vnodes*
-      (swap! *rendered-vnodes* conj vnode))
-    (applied-add! *applied-vnodes* vnode)))
-
 (defn render-initial!
   "Render entire vdom tree to target for initial mount.
 
-  Creates all elements and stores references.
-  Also marks all rendered vnodes in *rendered-vnodes* to prevent
-  double-application of deltas during discharge-all!."
+  Creates all elements and stores references."
   [discharge vnode]
   (cond
     (nil? vnode)
@@ -1119,20 +751,17 @@
     (let [el (create-text! discharge (:content vnode))]
       ;; Text nodes don't have :addr — skip storing ref since they're
       ;; always replaced wholesale and never looked up by address
-      (mark-rendered! vnode)
       el)
 
     (core/fragment? vnode)
     ;; Fragments don't create an element, just render children
     (let [children (when-let [ch (:children vnode)]
                      (if (d/deltaable? ch) @ch ch))]
-      (mark-rendered! vnode)
       (mapv #(render-initial! discharge %) children))
 
     (frag/keyed-fragment? vnode)
     ;; KeyedFragment: render all items
     (do
-      (mark-rendered! vnode)
       (mapv #(render-initial! discharge %) (frag/fragment-items vnode)))
 
     (core/vnode? vnode)
@@ -1143,8 +772,6 @@
       (set-element! discharge (:addr vnode) el)
       ;; Detect duplicate :addr claims (e.g., siblings from `for` instead of ifor-each)
       (register-addr! vnode)
-      ;; Mark as rendered to prevent double delta application
-      (mark-rendered! vnode)
 
       ;; Set all attributes (defer :value until after children for <select>)
       (let [raw-attrs (when-let [attrs (:attrs vnode)]

--- a/src/org/replikativ/spindel/dom/elements.cljc
+++ b/src/org/replikativ/spindel/dom/elements.cljc
@@ -115,64 +115,36 @@
                          (addr/keyed-child-address my-addr k)
                          my-addr)
 
-        ;; Get previous caches
-        prev-slot-cache (cache/get-slot-cache effective-addr)
-        prev-attrs (cache/get-attr-cache effective-addr)
-
         ;; Clean attrs (remove :key and :ref which are handled separately)
         attrs-clean (dissoc attrs :key :ref)
 
-        ;; Reconcile attrs with cache
-        attr-deltas (cache/reconcile-attrs prev-attrs attrs-clean)
-
-        ;; STAGE the attr cache — it is promoted only if this vnode is actually
-        ;; discharged (cache/commit-pending!). Advancing it here moved the
-        ;; baseline for runs that were later abandoned, losing their deltas.
-        _ (cache/stage-attrs! effective-addr attrs-clean)
-
-        ;; Normalize children (handle text, nil, sequences)
+        ;; Normalize children (handle text, nil, sequences) and classify
+        ;; into slots. The build is PURE: no cache reads, no diffing, no
+        ;; staging. Reconciliation happens once, at the commit point
+        ;; (dom/commit), against the committed caches — a build may run any
+        ;; number of times, or be abandoned entirely, and neither changes
+        ;; what the device shows. (Compute-time reconciliation could not
+        ;; have that property: N builds racing before a commit all diffed
+        ;; the same baseline and each carried the same :add.)
         normalized-children (flatten-and-normalize children)
+        slots (mapv cache/make-slot normalized-children)
 
-        ;; Reconcile children with cache
-        {:keys [slots deltas]} (cache/reconcile-children prev-slot-cache normalized-children)
-
-        ;; STAGE the slot cache — same reason as the attrs above. Child deltas
-        ;; carry POSITIONS, so a lost one does not merely miss an update: the
-        ;; next pass computes indices against a DOM that never received it.
-        _ (cache/stage-slots! effective-addr slots)
-
-        ;; Flatten slots to final children vector
-        final-children (cache/flatten-slots slots)
-
-        ;; Adjust delta paths to absolute indices
-        adjusted-deltas (when (seq deltas)
-                          (cache/adjust-delta-paths slots deltas))
-
-        ;; Build vnode with attrs that carry deltas
         key-val (:key attrs)
-        ref-fn (:ref attrs)
-        attrs-with-deltas (org.replikativ.spindel.incremental.deltaable/deltaable-map-with-deltas
-                           attrs-clean attr-deltas)
-        vnode (cond-> {:tag tag
-                       :addr effective-addr
-                       :attrs attrs-with-deltas
-                       ;; The classified slot structure, pre-flatten. The
-                       ;; commit-time reconciliation walk (dom/commit) diffs
-                       ;; the ARRIVED TREE against the committed caches, and
-                       ;; `flatten-slots` destroys exactly what it needs: a
-                       ;; conditional slot currently nil must occupy its slot
-                       ;; index as `:nil`, or every later sibling's position
-                       ;; shifts and the diff mis-addresses them.
-                       :slots slots
-                       :children (org.replikativ.spindel.incremental.deltaable/deltaable-vector
-                                  (vec final-children))}
-                key-val (assoc :key key-val)
-                ref-fn (assoc :ref ref-fn))]
-
-    ;; Attach child deltas if any
-    (if (seq adjusted-deltas)
-      (assoc vnode :deltas adjusted-deltas)
-      vnode)))
+        ref-fn (:ref attrs)]
+    (cond-> {:tag tag
+             :addr effective-addr
+             ;; delta-FREE deltaable: same deref-able value shape consumers
+             ;; and tests have always seen, minus the build-time deltas
+             :attrs (org.replikativ.spindel.incremental.deltaable/deltaable-map attrs-clean)
+             ;; The classified slot structure, pre-flatten: a conditional
+             ;; slot currently nil must occupy its slot index as `:nil`, or
+             ;; every later sibling's position shifts and the commit diff
+             ;; mis-addresses them.
+             :slots slots
+             :children (org.replikativ.spindel.incremental.deltaable/deltaable-vector
+                        (vec (cache/flatten-slots slots)))}
+      key-val (assoc :key key-val)
+      ref-fn (assoc :ref ref-fn))))
 
 ;; =============================================================================
 ;; Legacy Element* (for backwards compatibility)

--- a/src/org/replikativ/spindel/dom/elements.cljc
+++ b/src/org/replikativ/spindel/dom/elements.cljc
@@ -156,6 +156,14 @@
         vnode (cond-> {:tag tag
                        :addr effective-addr
                        :attrs attrs-with-deltas
+                       ;; The classified slot structure, pre-flatten. The
+                       ;; commit-time reconciliation walk (dom/commit) diffs
+                       ;; the ARRIVED TREE against the committed caches, and
+                       ;; `flatten-slots` destroys exactly what it needs: a
+                       ;; conditional slot currently nil must occupy its slot
+                       ;; index as `:nil`, or every later sibling's position
+                       ;; shifts and the diff mis-addresses them.
+                       :slots slots
                        :children (org.replikativ.spindel.incremental.deltaable/deltaable-vector
                                   (vec final-children))}
                 key-val (assoc :key key-val)

--- a/src/org/replikativ/spindel/dom/elements.cljc
+++ b/src/org/replikativ/spindel/dom/elements.cljc
@@ -28,8 +28,9 @@
         (await (some-async-component))    ;; await now works!
         (el/span \"hello\")))
 
-  Each element gets unique address based on position in tree.
-  Conditionals work naturally - nil slots produce add/remove deltas."
+  Each element gets a unique address based on position in tree.
+  Conditionals work naturally - a nil slot occupies its index as :nil,
+  and the commit-time diff (dom/commit) turns transitions into add/remove."
   (:require [org.replikativ.spindel.dom.core :as core]
             [org.replikativ.spindel.dom.addressing :as addr]
             [org.replikativ.spindel.dom.cache :as cache]
@@ -95,7 +96,7 @@
 ;; =============================================================================
 
 (defn build-element
-  "Create a vnode with delta tracking from already-evaluated children.
+  "Create a PURE vnode from already-evaluated children.
 
   This is the new CPS-aware runtime implementation. Children are evaluated
   by the macro expansion (with proper slot context), then passed here.
@@ -106,7 +107,7 @@
     attrs - Attribute map
     children - Vector of already-evaluated children (vnodes, text, nil, KeyedFragment)
 
-  Returns: VNode with :deltas if any changes detected"
+  Returns: VNode (a plain value; reconciliation happens at commit)"
   [tag my-addr attrs children]
   (let [;; When element has a :key, derive a unique cache address so that
         ;; multiple keyed elements at the same source location (e.g. in map)

--- a/src/org/replikativ/spindel/dom/foreach.cljc
+++ b/src/org/replikativ/spindel/dom/foreach.cljc
@@ -186,19 +186,19 @@
    decide whether per-key vnode memoisation is safe — substituting a
    cached vnode would flip the result type if the render-fn now
    returns a spin."
-  [my-addr resolved-items prev-by-key prev-order was-sync?]
-  (let [by-key (into {} (map (juxt :key :vnode) resolved-items))
-        items-by-key (into {} (keep (fn [r]
+  [my-addr resolved-items _prev-by-key _prev-order was-sync?]
+  (let [items-by-key (into {} (keep (fn [r]
                                       (when (contains? r :item)
                                         [(:key r) (:item r)])))
                            resolved-items)
-        order (mapv :key resolved-items)
         items (mapv :vnode resolved-items)
-        deltas (build-seq-diff order prev-order by-key prev-by-key)]
-    (set-keyed-cache! my-addr {:by-key by-key
-                               :items-by-key items-by-key
-                               :order order
-                               :was-sync? was-sync?})
+        ;; PURE: no diff, no staging. The commit walk (dom/commit) diffs
+        ;; the fragment's items against the committed keyed cache and
+        ;; advances it in the same step as the DOM write. `:items-by-key`
+        ;; and `:was-sync?` ride the fragment so the walk can carry them
+        ;; into the cache — they are what the per-key memoisation above
+        ;; reads on the next build.
+        deltas nil]
     ;; Stamp the ifor-each call-site address onto the fragment. The keyed cache
     ;; lives at `[:dom/keyed-cache my-addr]`, and `my-addr` appears on NO vnode:
     ;; items carry `keyed-child-address(my-addr, k)`. Without this stamp
@@ -206,7 +206,10 @@
     ;; holds `:by-key` (every rendered vnode, with its event-handler closures)
     ;; and `:items-by-key` — so unmounting a subtree containing an ifor-each
     ;; retained the whole rendered list for the lifetime of the context.
-    (assoc (frag/keyed-fragment items deltas) :addr my-addr)))
+    (assoc (frag/keyed-fragment items deltas)
+           :addr my-addr
+           :items-by-key items-by-key
+           :was-sync? was-sync?)))
 
 ;; =============================================================================
 ;; for-each*
@@ -237,8 +240,10 @@
                                      (not= ::miss cached-item)
                                      (= cached-item item)
                                      (plain-element-vnode? cached-vnode))
+                      ;; cached vnodes are pure values under commit-time
+                      ;; reconciliation — nothing to strip on reuse
                       vnode (if memo-hit?
-                              (clear-stale-deltas cached-vnode)
+                              cached-vnode
                               (addr/with-keyed-context-fn my-addr k
                                 #(render-fn item)))]
                   {:key k :vnode vnode :item item}))
@@ -256,16 +261,15 @@
        (loop [remaining items-with-keys
               resolved []]
          (if (empty? remaining)
-           (let [fresh-cache (get-keyed-cache my-addr)
-                 fresh-by-key (or (:by-key fresh-cache) {})
-                 fresh-order (or (:order fresh-cache) [])]
-             (build-fragment-result my-addr resolved fresh-by-key fresh-order false))
+           ;; build is pure — no prev capture, no re-read; the commit walk
+           ;; diffs against whatever is committed WHEN THIS FRAGMENT LANDS
+           (build-fragment-result my-addr resolved nil nil false)
            (let [{:keys [key vnode item]} (first remaining)
                  resolved-vnode (if (spin? vnode) (await vnode) vnode)]
              (recur (rest remaining)
                     (conj resolved {:key key :vnode resolved-vnode :item item}))))))
       ;; Sync path
-      (build-fragment-result my-addr items-with-keys prev-by-key prev-order true))))
+      (build-fragment-result my-addr items-with-keys nil nil true))))
 
 ;; =============================================================================
 ;; Macro

--- a/src/org/replikativ/spindel/dom/foreach.cljc
+++ b/src/org/replikativ/spindel/dom/foreach.cljc
@@ -104,76 +104,12 @@
        (not (spin? v))
        (not (frag/keyed-fragment? v))))
 
-(defn- clear-stale-deltas
-  "Strip any `:deltas` field from a vnode and its children. Required
-   when reusing a memoised vnode — the discharge tree-walk would
-   otherwise re-apply prior deltas and duplicate DOM children."
-  [vnode]
-  (when vnode
-    (cond
-      (and (map? vnode) (contains? vnode :content) (not (contains? vnode :tag)))
-      vnode
-
-      (and (map? vnode) (contains? vnode :tag))
-      (let [cleared (dissoc vnode :deltas)
-            cleared (if-let [attrs (:attrs cleared)]
-                      (assoc cleared :attrs (d/clear-deltas attrs))
-                      cleared)
-            children (:children cleared)]
-        (if children
-          (let [child-vec (if (d/deltaable? children) @children children)]
-            (assoc cleared :children
-                   (d/deltaable-vector (mapv clear-stale-deltas child-vec))))
-          cleared))
-
-      (frag/keyed-fragment? vnode)
-      ;; Preserve `:addr` — it is what lets `call-refs-on-unmount!` evict the
-      ;; keyed cache at this ifor-each's call site.
-      (assoc (frag/keyed-fragment (mapv clear-stale-deltas (frag/fragment-items vnode))
-                                  nil)
-             :addr (:addr vnode))
-
-      :else vnode)))
-
 ;; =============================================================================
 ;; Cache access
 ;; =============================================================================
 
 (defn- get-keyed-cache [addr]
   (ec/get-state [:dom/keyed-cache addr]))
-
-(defn- set-keyed-cache!
-  "STAGE the keyed cache; `cache/commit-pending!` promotes it once the
-   fragment's items have actually been discharged.
-
-   Same asymmetry as the element caches, and the list path made it worse: the
-   fragment's delta embeds `:prev-items` inline, so an abandoned build both
-   moved the keyed baseline and poisoned the next diff."
-  [addr cache-data]
-  (cache/stage-keyed! addr cache-data))
-
-;; =============================================================================
-;; Delta derivation — package the keyed SequenceAlgebra diff for discharge
-;; =============================================================================
-
-(defn- build-seq-diff
-  "Build the discharge-layer `:seq-diff` delta for the fragment.
-
-   The keyed-sequence diff itself is computed by the incremental layer
-   (`sequence-algebra/keyed-seq-diff`) — identity is the item key, and
-   per-key change is detected with structural vnode equality. This
-   function only packages the resulting SequenceAlgebra diff as the
-   `:seq-diff` delta the discharge tree-walk consumes, attaching
-   `:prev-items` (the previous vnodes in DOM order) that `apply-seq-diff!`
-   needs.
-
-   Returns the delta in a wrapping vector, or nil when nothing changed."
-  [order prev-order by-key prev-by-key]
-  (when-let [diff (sa/keyed-seq-diff order prev-order by-key prev-by-key
-                                     vnode-value-equal?)]
-    [{:delta :seq-diff
-      :diff diff
-      :prev-items (mapv #(get prev-by-key %) prev-order)}]))
 
 ;; =============================================================================
 ;; Fragment build (sync and async paths)

--- a/src/org/replikativ/spindel/dom/foreach.cljc
+++ b/src/org/replikativ/spindel/dom/foreach.cljc
@@ -70,7 +70,7 @@
 ;; VNode helpers
 ;; =============================================================================
 
-(defn- vnode-value-equal?
+(defn vnode-value-equal?
   "Compare two vnodes by their semantic value, not object identity.
    Vnodes contain DeltaableMap/Vector instances that are fresh each
    render, so identity-based `=` would always be false. We dereference

--- a/src/org/replikativ/spindel/dom/render.cljc
+++ b/src/org/replikativ/spindel/dom/render.cljc
@@ -28,6 +28,7 @@
   produce vnodes with deltas attached that are discharged to the DOM."
   (:require [org.replikativ.spindel.dom.discharge :as disch]
             [org.replikativ.spindel.dom.cache :as cache]
+            [org.replikativ.spindel.dom.commit :as commit]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.engine.core :as ec]
             [replikativ.logging :as log]))
@@ -83,12 +84,14 @@
     ;; Append to container
     (when (and container root-el)
       (.appendChild container root-el))
-    ;; The whole tree just reached the DOM, so its reconciliations become the
-    ;; caches' model of it. This is the commit point that matters MOST: a spin
-    ;; with no tracks runs its body exactly once, here — if its staging is not
-    ;; promoted now, it never is, and the next parent re-emission reconciles
-    ;; against nil and re-emits `:add` for a subtree the DOM already holds.
-    (cache/commit-pending! (disch/collect-addrs vdom))
+    ;; The whole tree just reached the DOM: SEED the caches from the tree
+    ;; itself. This replaces promoting the build's staging — staging is
+    ;; last-write-wins per address, so when several builds raced before this
+    ;; mount, the staged value could describe a build the DOM never received.
+    ;; The tree the DOM holds is the only sound source. (Commit point
+    ;; ordering unchanged; this is still the commit point that matters most —
+    ;; a spin with no tracks runs its body exactly once, here.)
+    (commit/seed-subtree-caches! vdom)
     ;; No transfer needed — address-based refs work with cleared vdom
     ;; (clear-deltas-deep preserves :addr fields)
     (assoc render-state
@@ -137,10 +140,11 @@
             (when container
               (set! (.-innerHTML container) "")
               (when root-el (.appendChild container root-el))))
-          ;; The new tree is in the DOM, so its reconciliations may become the
-          ;; caches' model of it. Before the evictions, so an address this pass
-          ;; unmounted is not resurrected by the promotion.
-          (cache/commit-pending! (disch/collect-addrs new-vdom))
+          ;; The new tree is in the DOM: seed its caches from the tree (same
+          ;; reasoning as initial-mount! — the arrived tree is the authority,
+          ;; not last-write-wins staging). Before the evictions, so an address
+          ;; this pass unmounted is not resurrected by the seeding.
+          (commit/seed-subtree-caches! new-vdom)
           (disch/flush-pending-evictions! discharge))
         (assoc render-state :current-vdom (disch/clear-deltas-deep new-vdom)))
 
@@ -151,16 +155,17 @@
         (binding [disch/*rendered-vnodes* (atom #{})
                   disch/*rendered-addrs* (atom {})
                   disch/*pending-evictions* (atom #{})]
-          (let [nodes-with-deltas (disch/collect-nodes-with-deltas new-vdom)]
-            (when (seq nodes-with-deltas)
-              (log/trace :render/delta-update {:nodes-with-deltas (count nodes-with-deltas)})
-              (doseq [node nodes-with-deltas]
-                (disch/discharge-vnode! discharge node))))
-          ;; Commit the staged reconciliations for everything in the tree that
-          ;; just reached the DOM — NOT only the nodes that carried deltas: a
-          ;; subtree built wholesale by `render-initial!` has none of its own,
-          ;; and would otherwise re-emit `:add` on the next pass.
-          (cache/commit-pending! (disch/collect-addrs new-vdom))
+          ;; COMMIT-TIME RECONCILIATION (dom/commit): diff the arrived tree
+          ;; against the committed caches, apply, and advance the caches in
+          ;; the same step. Build-time :deltas on the vnodes are IGNORED —
+          ;; they were computed against whatever baseline the build happened
+          ;; to see, and when N builds race before a commit they all carry
+          ;; the same :add (measured: six builds of one container per settled
+          ;; expand, the same :add discharged in two passes). Here a stale
+          ;; build diffs against the advanced baseline and collapses to its
+          ;; genuine residual. Unmount refs + deferred evictions flow through
+          ;; the same apply-child-delta! paths as before.
+          (commit/commit-reconcile! discharge new-vdom)
           (disch/flush-pending-evictions! discharge))
 
         ;; Clear deltas for next render cycle

--- a/src/org/replikativ/spindel/dom/render.cljc
+++ b/src/org/replikativ/spindel/dom/render.cljc
@@ -1,20 +1,16 @@
 (ns org.replikativ.spindel.dom.render
   "Reactive rendering - connects spindel's signal system to DOM.
 
-  **Delta-Direct Rendering (New Model):**
+  **Commit-time reconciliation:**
 
-  In the delta-direct model, there is no diffing:
   1. Elements are macros that capture source location
-  2. Each element has a stable address (from source-loc + parent + slot)
-  3. Elements cache their children by slot position
-  4. On re-render, slot reconciliation produces deltas directly
-  5. Deltas are discharged to the DOM without re-diffing
-
-  The render! function:
-  1. Executes a spin that produces vdom with deltas
-  2. Mounts vdom to the DOM container (first render)
-  3. Re-executes when tracked signals change
-  4. Discharges deltas directly to the DOM (no diffing)
+  2. Each element has a stable address (source-loc + parent + slot)
+  3. Builds are PURE VALUES - no cache reads, no deltas, no staging
+  4. At the commit point the arrived tree is diffed against the
+     committed per-address caches (dom/commit) and the caches advance
+     in the same step as the DOM write
+  5. A stale build committed later diffs against the already-advanced
+     baseline and collapses to its genuine residual
 
   Usage:
     (render! container
@@ -24,8 +20,8 @@
             (ifor-each :id new
               (fn [todo] (el/li (:text todo))))))))
 
-  The spin re-runs whenever tracked signals change. Element macros
-  produce vnodes with deltas attached that are discharged to the DOM."
+  The spin re-runs whenever tracked signals change; each completion's
+  tree is committed through dom/commit."
   (:require [org.replikativ.spindel.dom.discharge :as disch]
             [org.replikativ.spindel.dom.cache :as cache]
             [org.replikativ.spindel.dom.commit :as commit]
@@ -78,9 +74,7 @@
             (set! (.-innerHTML container) ""))
         ;; Render initial vdom
         root-el (binding [disch/*rendered-addrs* (atom {})]
-                  (disch/render-initial! discharge vdom))
-        ;; Clear deltas for next render cycle
-        cleared-vdom (disch/clear-deltas-deep vdom)]
+                  (disch/render-initial! discharge vdom))]
     ;; Append to container
     (when (and container root-el)
       (.appendChild container root-el))
@@ -94,27 +88,17 @@
     (commit/seed-subtree-caches! vdom)
     ;; No transfer needed — address-based refs work with cleared vdom
     ;; (clear-deltas-deep preserves :addr fields)
+    ;; builds are pure values — nothing to clear
     (assoc render-state
-           :current-vdom cleared-vdom
+           :current-vdom vdom
            :mounted? true)))
 
 (defn update-render!
-  "Apply vdom changes to DOM using delta-direct rendering.
-
-  In the new model:
-  1. Vnodes arrive with deltas already computed (from element* slot reconciliation)
-  2. We collect all nodes with deltas
-  3. We discharge deltas directly (no diffing)
-  4. We clear deltas for next render cycle
-
-  Uses *rendered-vnodes* to track vnodes that are fully rendered during
-  this cycle. When a parent's :add delta triggers render-initial! for a child,
-  the child vnode is marked as rendered. If the same child appears in the
-  nodes-with-deltas list (because it had deltas from element* reconciliation
-  against empty cache), discharge-vnode! will skip it to prevent double-rendering.
-
-  DOM refs are stored by stable address (:addr on vnodes), so no transfer
-  is needed between old and new vdom objects."
+  "Apply an arrived vdom tree to the DOM via commit-time reconciliation
+  (dom/commit): diff against the committed per-address caches, apply,
+  advance the caches in the same step. DOM refs are stored by stable
+  address (:addr on vnodes), so no transfer is needed between old and
+  new vdom objects."
   [render-state new-vdom]
   (let [{:keys [container discharge current-vdom]} render-state]
     (cond
@@ -130,8 +114,7 @@
       (do
         (log/debug :render/root-replace {:old (:addr current-vdom)
                                          :new (:addr new-vdom)})
-        (binding [disch/*rendered-vnodes* (atom #{})
-                  disch/*rendered-addrs* (atom {})
+        (binding [disch/*rendered-addrs* (atom {})
                   disch/*pending-evictions* (atom #{})]
           ;; Refs get their nil call and caches are SCHEDULED (not yet dropped):
           ;; foreign nodes (TipTap et al.) rely on this to release resources.
@@ -146,14 +129,13 @@
           ;; this pass unmounted is not resurrected by the seeding.
           (commit/seed-subtree-caches! new-vdom)
           (disch/flush-pending-evictions! discharge))
-        (assoc render-state :current-vdom (disch/clear-deltas-deep new-vdom)))
+        (assoc render-state :current-vdom new-vdom))
 
       :else
       (do
         ;; Discharge deltas directly - no diffing needed
         ;; DOM refs found by address, no transfer needed
-        (binding [disch/*rendered-vnodes* (atom #{})
-                  disch/*rendered-addrs* (atom {})
+        (binding [disch/*rendered-addrs* (atom {})
                   disch/*pending-evictions* (atom #{})]
           ;; COMMIT-TIME RECONCILIATION (dom/commit): diff the arrived tree
           ;; against the committed caches, apply, and advance the caches in
@@ -167,11 +149,7 @@
           ;; the same apply-child-delta! paths as before.
           (commit/commit-reconcile! discharge new-vdom)
           (disch/flush-pending-evictions! discharge))
-
-        ;; Clear deltas for next render cycle
-        ;; No ref transfer needed — cleared vnodes carry same :addr values
-        (let [cleared-vdom (disch/clear-deltas-deep new-vdom)]
-          (assoc render-state :current-vdom cleared-vdom))))))
+        (assoc render-state :current-vdom new-vdom)))))
 
 ;; =============================================================================
 ;; Render! API
@@ -205,38 +183,23 @@
 
   The returned function should be called with the vdom result.
 
-  Each render effect carries a long-lived `*applied-vnodes*` set that
-  tracks vnode objects whose deltas have already been applied. This is
-  what makes cached spin results safe to embed in a re-emitting parent:
-  the same vnode object encountered in a later cycle is recognized and
-  its deltas are not re-applied (which would duplicate children — the
-  cross-spin reuse bug).
-
-  Storage: a weak set (CLJ: `Collections/newSetFromMap` over
-  `WeakHashMap`, wrapped in `synchronizedSet` to tolerate parallel
-  signal-change drains; CLJS: `js/WeakSet`). Identity semantics — when
-  a spin re-runs and produces a fresh cached result, the OLD vnode is
-  no longer referenced via the spin's :result cache and the weak set
-  lets it become GC-eligible rather than pinning it for the lifetime
-  of the render effect (which would leak unboundedly in long-running
-  apps)."
+  Builds are pure values, so cached spin results embedded by a
+  re-emitting parent are safe by construction: committing the same
+  state twice diffs to nothing. No per-object applied tracking is
+  needed."
   [container discharge]
-  (let [state-atom (atom (->RenderState container discharge nil false))
-        applied    (disch/make-applied-vnodes)]
+  (let [state-atom (atom (->RenderState container discharge nil false))]
     (fn [vdom]
       (when vdom
-        (let [state @state-atom
-              has-deltas? (seq (:deltas vdom))]
+        (let [state @state-atom]
           (log/debug ::render-effect-callback {:mounted? (:mounted? state)
-                                               :vdom-tag (:tag vdom)
-                                               :vdom-has-deltas? has-deltas?
-                                               :vdom-deltas (:deltas vdom)})
-          (binding [disch/*applied-vnodes* applied]
-            (if (:mounted? state)
-              ;; Update with delta-direct rendering
-              (swap! state-atom update-render! vdom)
-              ;; Initial mount
-              (reset! state-atom (initial-mount! state vdom)))))))))
+                                               :vdom-tag (:tag vdom)})
+          (if (:mounted? state)
+            ;; Commit-time reconciliation (dom/commit) — diff the arrived
+            ;; tree against the committed caches at the point of writing
+            (swap! state-atom update-render! vdom)
+            ;; Initial mount
+            (reset! state-atom (initial-mount! state vdom))))))))
 
 ;; =============================================================================
 ;; Integration with Spin System

--- a/src/org/replikativ/spindel/dom/ssr.cljc
+++ b/src/org/replikativ/spindel/dom/ssr.cljc
@@ -10,7 +10,16 @@
     (ssr/render-to-string (el/div {:class \"app\"} (el/h1 \"Hello\")))"
   (:require [clojure.string :as str]
             [org.replikativ.spindel.dom.core :as core]
-            [org.replikativ.spindel.dom.fragment :as frag]))
+            [org.replikativ.spindel.dom.fragment :as frag]
+            [org.replikativ.spindel.incremental.deltaable :as d]))
+
+(defn- plain
+  "Attrs/children as a plain value — builds attach plain maps/vectors under
+   commit-time reconciliation, but legacy vnodes may still carry deltaables."
+  [x]
+  (cond (nil? x) nil
+        (d/deltaable? x) @x
+        :else x))
 
 ;; =============================================================================
 ;; HTML Escaping
@@ -83,15 +92,15 @@
     (str/join (map render-to-string (:items vnode)))
 
     (core/fragment? vnode)
-    (str/join (map render-to-string @(:children vnode)))
+    (str/join (map render-to-string (plain (:children vnode))))
 
     (core/element-node? vnode)
     (let [tag (name (:tag vnode))
-          attrs (render-attrs @(:attrs vnode))
+          attrs (render-attrs (plain (:attrs vnode)))
           void? (void-element? (:tag vnode))]
       (if void?
         (str "<" tag attrs " />")
-        (let [children (str/join (map render-to-string @(:children vnode)))]
+        (let [children (str/join (map render-to-string (plain (:children vnode))))]
           (str "<" tag attrs ">" children "</" tag ">"))))
 
     :else ""))

--- a/src/org/replikativ/spindel/effects/await.cljc
+++ b/src/org/replikativ/spindel/effects/await.cljc
@@ -443,6 +443,15 @@
               :kind :external-await
               :source-loc source-loc
               :cancel-token cancel-token
+              ;; Same per-slice snapshot the Spin-await cont carries. We
+              ;; are on the awaiter's stack here, so the ambient context
+              ;; IS the environment the post-await slice must resume in.
+              ;; Without it, the `:cont-resume` handler resumed the slice
+              ;; in the DRAIN's environment — historically whatever
+              ;; body-scoped context was smuggled through the enqueue
+              ;; closure, i.e. sometimes accidentally right, never
+              ;; guaranteed. See .internal/slice-environment-integrity.md.
+              :slice-state (capture-slice-state (ec/current-execution-context) spin-id)
               ;; `:cancel!` takes the engine context to record the
               ;; cancellation in. Engine truncation sites pass the
               ;; context they're operating on, which is what makes

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -266,15 +266,26 @@
         ;; Counter of drains currently past the function-entry guard.
         ;; stop-context! polls this down to 0 before returning.
         drain-active (atom 0)]
-    (->ExecutionContext
-     fork-id
-     atom-backend
-     nil    ; No parent for root
-     executor
-     bindings
-     metadata
-     running
-     drain-active)))
+    (-> (->ExecutionContext
+         fork-id
+         atom-backend
+         nil    ; No parent for root
+         executor
+         bindings
+         metadata
+         running
+         drain-active)
+        ;; The creation-time bindings, stamped so the drain can NORMALIZE:
+        ;; body-scoped context values (with :dom/* scope etc. assoc'd on)
+        ;; are smuggled into `trigger-drain!` through enqueue closures, and
+        ;; without normalization the whole event cascade — including FIRST
+        ;; slices of freshly created spins, whose construction scope is a
+        ;; select-keys DELTA merged onto the drain context — executes in a
+        ;; random body's environment. Every derived value keeps this key
+        ;; (assoc on a record preserves extra keys), so any smuggled
+        ;; context still knows its pristine base.
+        ;; See .internal/slice-environment-integrity.md.
+        (assoc :base-bindings bindings))))
 
 (defn stop-context!
   "Quiesce an execution context.
@@ -543,16 +554,25 @@
                         :else
                         parent-metadata)]
 
-    (let [fork (->ExecutionContext
-                fork-id
-                overlay-backend
-                parent-ctx  ; Keep parent reference
-                (:executor parent-ctx)  ; Share executor (for now)
-                merged-bindings
-                fork-metadata
-                (:running parent-ctx)        ; Share parent's lifecycle flag
-                (:drain-active parent-ctx)   ; Share parent's drain-active counter
-                )]
+    (let [fork (-> (->ExecutionContext
+                    fork-id
+                    overlay-backend
+                    parent-ctx  ; Keep parent reference
+                    (:executor parent-ctx)  ; Share executor (for now)
+                    merged-bindings
+                    fork-metadata
+                    (:running parent-ctx)        ; Share parent's lifecycle flag
+                    (:drain-active parent-ctx)   ; Share parent's drain-active counter
+                    )
+                   ;; The fork's creation-time bindings (parent base +
+                   ;; fork overrides) — same drain-normalization stamp as
+                   ;; create-execution-context. Deliberately built from
+                   ;; the parent's BASE, not the parent's possibly
+                   ;; body-scoped current value.
+                   (assoc :base-bindings
+                          (merge (or (:base-bindings parent-ctx)
+                                     (:bindings parent-ctx))
+                                 bindings)))]
       ;; Undo the parent's in-flight mailbox CLAIMS in the fork's world:
       ;; each pending :cont-resume popped its waiter from the (CoW-shared)
       ;; mailbox state before the fork — re-register the waiter into the

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -713,11 +713,10 @@
 
   Also:
   - Resets engine draining flag.
-  - Drops :dom/cache, :dom/attr-cache, :dom/keyed-cache and :dom/pending,
+  - Drops :dom/cache, :dom/attr-cache and :dom/keyed-cache,
     since slot, attribute and keyed-list reconciliation state belongs to the
     previous render pass and would mismatch the DOM the restored context
-    renders into. :dom/pending holds reconciliations not yet promoted to
-    those caches, so it is render-pass state by the same argument.
+    renders into.
 
   NOTE: Continuations are preserved for in-memory snapshot/restore.
   They will be dropped during serialization (since closures can't be serialized).
@@ -732,7 +731,7 @@
       (assoc :engine/draining? false)
 
       ;; Drop render-pass-specific DOM caches; restored context re-renders.
-      (dissoc :dom/cache :dom/attr-cache :dom/keyed-cache :dom/pending)
+      (dissoc :dom/cache :dom/attr-cache :dom/keyed-cache)
 
       ;; Mark in-flight spins as dirty
       (update :nodes

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -140,6 +140,33 @@
 ;; Forward declaration for generation boundary cleanup
 (declare clear-all-await-continuations!)
 (declare cache-result!)
+(declare restore-slice-state!)
+
+(defn- cont-by-cancel-token
+  "The `:external-await` cont in `[:await-conts spin-id]` carrying
+  `cancel-token`, or nil. One-shot waiter resumes (`:cont-resume` events,
+  `reject-owning-spin!`) identify their await this way — the waiter entry
+  popped from the primitive's state carries the token, not the cont id."
+  [context spin-id cancel-token]
+  (when (and spin-id cancel-token)
+    (first (filter #(= (:cancel-token %) cancel-token)
+                   (vals (rtp/get-state context [:await-conts spin-id]))))))
+
+(defn- slice-context
+  "The context a one-shot waiter's slice must resume in: the cont's
+  `:slice-state` snapshot restored over `context` when the cont still
+  exists, `context` unchanged otherwise (waiter registered outside an
+  await — nothing captured, nothing to restore). The environment travels
+  with the continuation, never with the event — a slice resumed in the
+  DELIVERER's environment computes addresses/scope from whatever body
+  happened to complete last (measured: .internal/slice-environment-
+  integrity.md)."
+  [context spin-id cancel-token]
+  (if-let [cont (cont-by-cancel-token context spin-id cancel-token)]
+    (if (:slice-state cont)
+      (restore-slice-state! context spin-id cont)
+      context)
+    context))
 
 ;; =============================================================================
 ;; Inline delivery/posting (to avoid cyclic dependency with spin/sync)
@@ -192,10 +219,16 @@
     (if cont
       (do
         (try
-          (binding [ec/*execution-context* context
-                    ec/*spin-id* spin-id
-                    pcps-async/*in-trampoline* false]
-            (when-let [rj (:reject-fn cont)] (rj error)))
+          ;; The reject path is a body slice too — `catch`/`finally`
+          ;; run in it. Restore the cont's captured environment, same
+          ;; as the resolve path (`slice-context` in `:cont-resume`).
+          (let [rctx (if (:slice-state cont)
+                       (restore-slice-state! context spin-id cont)
+                       context)]
+            (binding [ec/*execution-context* rctx
+                      ec/*spin-id* spin-id
+                      pcps-async/*in-trampoline* false]
+              (when-let [rj (:reject-fn cont)] (rj error))))
           (catch #?(:clj Throwable :cljs :default) _ nil))
         (rtp/swap-state! context [:await-conts spin-id]
                          (fn [m] (dissoc m cont-id))))
@@ -550,11 +583,26 @@
     same ids as on the first run. Falls back to the body-start value
     when no snapshot was captured.
 
-  - `:bindings` — merged onto the current context bindings (snapshot
-    wins) and returned as a NEW context. The other two are state
-    mutations; this one is a value the caller must `binding`.
+  - `:bindings` — REPLACES the current context bindings and is returned
+    as a NEW context. The other two are state mutations; this one is a
+    value the caller must `binding`.
 
-  Returns the context with `:slice-state`'s `:bindings` merged in."
+    Replacement, not merge: the snapshot is the FULL `(:bindings ctx)`
+    map at the suspend point, so it already contains everything the
+    slice could legitimately see (fork-local config included — the body
+    ran on this context, so creation-time bindings are inside every
+    snapshot it takes). Merge restored presence but not ABSENCE: a key
+    the slice never had bound survived from whatever context the drain
+    happened to be running on — and the drain context can be a
+    body-scoped value smuggled through `enqueue-completion-event!`'s
+    closure (see .internal/slice-environment-integrity.md). Measured
+    consequence: a parent resuming from `(await (for-each* …))`
+    inherited the last-completing ITEM's `:dom/parent-addr`, its
+    element was addressed under that item's keyed scope, and the
+    address changed with completion order — re-minting the subtree
+    every render.
+
+  Returns the context with `:slice-state`'s `:bindings` swapped in."
   [context spin-id cont]
   (let [{:keys [bindings chain-head tracking]} (:slice-state cont)]
     (when tracking
@@ -563,7 +611,7 @@
                                  (or chain-head
                                      (addressing/body-start-chain-head spin-id)))
     (cond-> context
-      bindings (update :bindings merge bindings))))
+      bindings (assoc :bindings bindings))))
 
 ;; -----------------------------------------------------------------------------
 ;; Continuation storage — split by the comonad / monad nature of the cont:
@@ -1166,8 +1214,13 @@
               (log/trace :engine/cont-resume-repost {:site site :spin-id spin-id})
               (mailbox value))
             nil)
-          (do
-            (guarded-resume! context site spin-id cancel-token resolve value)
+          ;; Resume the slice in ITS OWN captured environment, not the
+          ;; drain's. `slice-context` restores the owning cont's
+          ;; `:slice-state` (bindings + chain-head + dep tracking); the
+          ;; re-binding is what the resumed body code actually reads.
+          (let [rctx (slice-context context spin-id cancel-token)]
+            (binding [ec/*execution-context* rctx]
+              (guarded-resume! rctx site spin-id cancel-token resolve value))
             nil))))
 
     ;; GC cleanup request — the JVM Cleaner / JS FinalizationRegistry saw the
@@ -1206,7 +1259,21 @@
 
   Returns: Number of events processed"
   [context executor]
-  (let [running       (:running context)
+  (let [;; NORMALIZE: run the drain on the context's creation-time
+        ;; bindings, never on a body-scoped value. `trigger-drain!` is
+        ;; reached through enqueue closures that captured the context at
+        ;; an await point — a value that can carry another body's
+        ;; :dom/parent-addr etc. Processing events on it made the whole
+        ;; cascade execute in a random body's environment: resumed slices
+        ;; leaked absent-key scope through restore (now replace), and
+        ;; FIRST slices of fresh spins (construction scope is a delta
+        ;; merged onto this context) inherited it wholesale. Slices get
+        ;; their environment exclusively from their cont's :slice-state.
+        ;; Contexts without the stamp (snapshot/restored) pass through.
+        context (if-some [bb (:base-bindings context)]
+                  (assoc context :bindings bb)
+                  context)
+        running       (:running context)
         drain-active  (:drain-active context)]
     (cond
       ;; Function-entry guard: drop drains on a stopped context. New drain

--- a/test/org/replikativ/spindel/dom/browser_test.cljs
+++ b/test/org/replikativ/spindel/dom/browser_test.cljs
@@ -7,6 +7,7 @@
             [org.replikativ.spindel.dom.elements :as el]
             [org.replikativ.spindel.dom.discharge :as disch]
             [org.replikativ.spindel.dom.browser :as browser]
+            [org.replikativ.spindel.dom.commit :as commit]
             ["jsdom" :refer [JSDOM]]))
 
 ;; Element macros (el/div, el/span, ...) write into the bound execution
@@ -166,16 +167,10 @@
       (is (= "old" (.getAttribute div "class")))
       (is (= "test" (.getAttribute div "id")))
 
-      ;; Update attributes (simulating what would happen in real usage)
-      ;; First clear deltas from initial render
-      (let [v1-cleared (dom/clear-deltas v1)
-            ;; Then update attributes
-            v2 (dom/update-attrs v1-cleared {:class "new" :id "test"})]
-        ;; Re-store element reference for v2
-        (disch/set-element! discharge v2 div)
-        ;; Apply deltas
-        (disch/discharge-vnode! discharge v2)
-        ;; Verify update
+      ;; Update via commit-time reconciliation: a fresh build of the new
+      ;; state, diffed against the committed caches at the point of writing
+      (let [v2 (assoc v1 :attrs {:class "new" :id "test"})]
+        (commit/commit-reconcile! discharge v2)
         (is (= "new" (.getAttribute div "class")))
         (is (= "test" (.getAttribute div "id")))))))
 
@@ -189,12 +184,9 @@
       ;; Verify initial state
       (is (= "bar" (.getAttribute div "data-foo")))
 
-      ;; Remove data-foo attribute
-      (let [v1-cleared (dom/clear-deltas v1)
-            v2 (dom/update-attrs v1-cleared {:class "test"})]
-        (disch/set-element! discharge v2 div)
-        (disch/discharge-vnode! discharge v2)
-        ;; Attribute should be removed
+      ;; Remove data-foo: absent from the new build's attrs -> removed
+      (let [v2 (assoc v1 :attrs {:class "test"})]
+        (commit/commit-reconcile! discharge v2)
         (is (not (.hasAttribute div "data-foo")))
         (is (= "test" (.getAttribute div "class")))))))
 
@@ -206,16 +198,18 @@
   (testing "Append child via delta"
     (let [doc (make-test-document)
           body (get-body doc)
-          v1 (el/ul (el/li "Item 1"))
+          ;; one source location — identity is the address; the second slot
+          ;; is :nil in v1 and an element in v2, the canonical conditional
+          build (fn [two?] (el/ul (el/li "Item 1")
+                                  (when two? (el/li "Item 2"))))
+          v1 (build false)
           discharge (browser/mount! body v1)
           ul (.-firstChild body)]
       (is (= 1 (.-length (.-children ul))))
 
-      ;; Append a new child
-      (let [v1-cleared (dom/clear-deltas v1)
-            v2 (dom/append-child v1-cleared (el/li "Item 2"))]
-        (disch/set-element! discharge v2 ul)
-        (disch/discharge-vnode! discharge v2)
+      ;; Append via commit-time reconciliation of a fresh build
+      (let [v2 (build true)]
+        (commit/commit-reconcile! discharge v2)
         (is (= 2 (.-length (.-children ul))))
         (is (= "Item 2" (.-textContent (aget (.-children ul) 1))))))))
 

--- a/test/org/replikativ/spindel/dom/commit_reconcile_test.clj
+++ b/test/org/replikativ/spindel/dom/commit_reconcile_test.clj
@@ -1,0 +1,204 @@
+(ns org.replikativ.spindel.dom.commit-reconcile-test
+  "Unit tests for commit-time reconciliation (dom/commit) — the property the
+   compute-time path cannot have.
+
+   THE property: N distinct builds of the same state, committed in sequence,
+   produce the DOM change ONCE. Under compute-time reconciliation every build
+   diffs against the same uncommitted baseline and carries the same `:add`;
+   here the first commit advances the baseline in the same step as the DOM
+   write, so every later build — a DIFFERENT object, which no identity-keyed
+   guard can catch — diffs to nothing. This is the N-builds window measured
+   live in simmis (six builds of one container per settled expand, the same
+   `:add` discharged in two passes; see jsdom_final_state_test.cljs, the
+   deliberately-failing acceptance test).
+
+   These tests drive `commit-reconcile!` directly against `MockDischarge`
+   with hand-built vnodes carrying explicit `:slots` — no engine, no spins,
+   no timing. Op-count assertions only (creates/inserts/removes/set-attrs):
+   the earlier replay-the-log-into-a-tree metric was measured unsound
+   (repeat_execution_test.clj records why), but op counts on a SINGLE
+   ADDRESS with single-digit expectations are exactly what the mock can
+   answer."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [org.replikativ.spindel.dom.commit :as commit]
+            [org.replikativ.spindel.dom.cache :as cache]
+            [org.replikativ.spindel.dom.discharge :as disch]
+            [org.replikativ.spindel.dom.fragment :as frag]
+            [org.replikativ.spindel.incremental.sequence-algebra :as sa]
+            [org.replikativ.spindel.dom.foreach :as foreach]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.test-helpers :refer [with-ctx]]))
+
+(defn clean-context-fixture [f]
+  (binding [ec/*execution-context* nil]
+    (f)))
+
+(use-fixtures :each clean-context-fixture)
+
+;; =============================================================================
+;; Construction helpers — explicit :slots, the carrier the commit walk needs
+;; =============================================================================
+
+(defn- vn
+  "A vnode with explicit slot structure. `:children` derived by flattening,
+   as build-element does."
+  [tag addr attrs & slot-values]
+  (let [slots (mapv cache/make-slot slot-values)]
+    {:tag tag :addr addr :attrs attrs
+     :slots slots
+     :children (cache/flatten-slots slots)}))
+
+(defn- text [s] {:tag :text :content s})
+
+(defn- ops [log & kinds]
+  (let [ks (set kinds)]
+    (count (filter #(ks (:op %)) @log))))
+
+(defn- mount!
+  "Initial mount as production does it: render + seed caches. Returns the log."
+  [discharge root]
+  (disch/render-initial! discharge root)
+  (commit/seed-subtree-caches! root))
+
+;; =============================================================================
+;; 0. The keyed unit property (the de-risk probe from the evaluation)
+;; =============================================================================
+
+(deftest keyed-diff-against-advanced-baseline-is-nil
+  (testing "keyed-seq-diff twice against ONE baseline grows twice; against
+            the ADVANCED baseline it is nil — the keyed analogue of
+            repeat_execution_test's attr/child property"
+    (let [prev-order []
+          prev-by-key {}
+          item {:tag :li :addr :el-item-a :key "a" :attrs {} :children []}
+          order ["a"]
+          by-key {"a" item}
+          d1 (sa/keyed-seq-diff order prev-order by-key prev-by-key
+                                foreach/vnode-value-equal?)
+          d2 (sa/keyed-seq-diff order prev-order by-key prev-by-key
+                                foreach/vnode-value-equal?)]
+      (is (= 1 (:grow d1)))
+      (is (= 1 (:grow d2)) "unadvanced baseline re-grows — the duplication")
+      (is (nil? (sa/keyed-seq-diff order order by-key by-key
+                                   foreach/vnode-value-equal?))
+          "advanced baseline: no diff"))))
+
+;; =============================================================================
+;; 1. THE property: N distinct builds, one insert
+;; =============================================================================
+
+(deftest n-builds-one-insert
+  (testing "a conditional child appears; five distinct builds of the new
+            state committed in sequence insert it exactly once"
+    (with-ctx [_rt]
+      (let [{:keys [discharge log]} (disch/make-mock-discharge)
+            base (vn :div :el-shell {:class "shell"} nil (text "static"))
+            ;; five DISTINCT builds of the expanded state — distinct objects,
+            ;; equal content: exactly what the N-builds window produces and
+            ;; what identity-keyed guards cannot catch
+            build (fn [] (vn :div :el-shell {:class "shell"}
+                             (vn :ul :el-items {:class "items"} (text "one"))
+                             (text "static")))]
+        (mount! discharge base)
+        (reset! log [])
+        (dotimes [_ 5]
+          (commit/commit-reconcile! discharge (build)))
+        (is (= 1 (ops log :create-element))
+            "the <ul> is created once across five commits")
+        ;; :insert-child only — the ul's own text child arrives via
+        ;; :append-child inside its render-initial!, which is part of the ONE
+        ;; legitimate creation, not a second slot-level insert
+        (is (= 1 (ops log :insert-child))
+            (str "one slot-level insert, got ops: " (vec @log)))))))
+
+(deftest stale-build-after-removal-does-not-resurrect
+  (testing "expand build replayed AFTER the collapse committed: the stale
+            :add diffs against the advanced (collapsed) baseline as a
+            legitimate re-add — but a collapse build replayed after expand
+            removes once, not twice (no live-sibling deletion)"
+    (with-ctx [_rt]
+      (let [{:keys [discharge log]} (disch/make-mock-discharge)
+            collapsed (fn [] (vn :div :el-shell {:class "shell"} nil (text "s")))
+            expanded  (fn [] (vn :div :el-shell {:class "shell"}
+                                 (vn :ul :el-items {:class "items"} (text "one"))
+                                 (text "s")))]
+        (mount! discharge (expanded))
+        (reset! log [])
+        ;; collapse committed once, then the SAME collapse state committed
+        ;; again from a distinct stale build
+        (commit/commit-reconcile! discharge (collapsed))
+        (commit/commit-reconcile! discharge (collapsed))
+        (is (= 1 (ops log :remove-child))
+            (str "exactly one removal — a second one would delete the live "
+                 "text sibling at that index; got " (vec @log)))))))
+
+(deftest attrs-advance-with-the-write
+  (testing "an attr change applies once across distinct builds; a genuinely
+            newer build still applies its residual"
+    (with-ctx [_rt]
+      (let [{:keys [discharge log]} (disch/make-mock-discharge)
+            v (fn [cls] (vn :div :el-shell {:class cls} (text "s")))]
+        (mount! discharge (v "a"))
+        (reset! log [])
+        (commit/commit-reconcile! discharge (v "b"))
+        (commit/commit-reconcile! discharge (v "b"))   ; stale duplicate
+        (is (= 1 (ops log :set-attr)) "one write for two b-builds")
+        (commit/commit-reconcile! discharge (v "c"))   ; genuinely newer
+        (is (= 2 (ops log :set-attr)) "the residual of a newer build applies")))))
+
+;; =============================================================================
+;; 2. The keyed path: fragment growth commits once
+;; =============================================================================
+
+(defn- li [k]
+  {:tag :li :addr (keyword (str "el-li-" k)) :key k
+   :attrs {} :slots [(cache/make-slot (text k))] :children [(text k)]})
+
+(defn- shell-with-frag
+  "Shell whose single slot is a KeyedFragment of `ks`."
+  [ks]
+  (let [items (mapv li ks)
+        fragment (assoc (frag/keyed-fragment items nil) :addr :el-frag)]
+    {:tag :div :addr :el-shell :attrs {:class "shell"}
+     :slots [(cache/make-slot fragment)]
+     :children (vec items)}))
+
+(deftest fragment-growth-commits-once
+  (testing "an item appears in the fragment; three distinct builds insert it
+            once — the .sub-items duplication of the acceptance test, at
+            unit scale"
+    (with-ctx [_rt]
+      (let [{:keys [discharge log]} (disch/make-mock-discharge)]
+        (mount! discharge (shell-with-frag ["a" "b"]))
+        (reset! log [])
+        (dotimes [_ 3]
+          (commit/commit-reconcile! discharge (shell-with-frag ["a" "b" "c"])))
+        (is (= 1 (ops log :create-element))
+            (str "the new <li> is created once, got " (vec @log)))))))
+
+(deftest nested-conditional-inside-fragment-item-commits-once
+  (testing "the app shape at unit scale: a fragment item's OWN conditional
+            child appears; repeated commits of distinct builds insert the
+            nested container once (recursion into surviving keyed items)"
+    (with-ctx [_rt]
+      (let [{:keys [discharge log]} (disch/make-mock-discharge)
+            item (fn [open?]
+                   (let [slots [(cache/make-slot (text "hd"))
+                                (cache/make-slot
+                                 (when open?
+                                   (vn :ul :el-sub {:class "sub"} (text "p"))))]]
+                     {:tag :div :addr :el-item-a :key "a" :attrs {}
+                      :slots slots :children (cache/flatten-slots slots)}))
+            shell (fn [open?]
+                    (let [fragment (assoc (frag/keyed-fragment [(item open?)] nil)
+                                          :addr :el-frag)]
+                      {:tag :div :addr :el-shell :attrs {}
+                       :slots [(cache/make-slot fragment)]
+                       :children [(item open?)]}))]
+        (mount! discharge (shell false))
+        (reset! log [])
+        (dotimes [_ 4]
+          (commit/commit-reconcile! discharge (shell true)))
+        (is (= 1 (ops log :create-element))
+            (str "the nested <ul> is created once across four distinct "
+                 "builds, got " (vec @log)))))))

--- a/test/org/replikativ/spindel/dom/cross_spin_rerender_test.clj
+++ b/test/org/replikativ/spindel/dom/cross_spin_rerender_test.clj
@@ -10,11 +10,13 @@
   The bug this guards against: the cached child vnode carries the
   :deltas computed by `build-element`'s initial reconciliation
   (`[:add header at 0, :add content at 1]`). Without dedup, each
-  parent re-emission walks the cached vnode in `collect-nodes-with-deltas`
+  parent re-emission used to re-walk the cached vnode's stale deltas
   and re-applies those :add deltas to the (existing) DOM element,
-  duplicating children. The fix lives in `discharge-vnode!` /
+  duplicating children. HISTORY: first fixed by an identity-keyed
   `mark-rendered!` / `create-render-effect` and uses an
-  `*applied-vnodes*` set that persists across re-render cycles for
+  applied-vnodes set; now structural — builds are pure values and
+  commit-time reconciliation (dom/commit) diffs them, so re-embedding
+  a cached result commits to nothing. The test guards the outcome for
   one render-effect."
   (:refer-clojure :exclude [await])
   (:require [clojure.test :refer [deftest is testing use-fixtures]]

--- a/test/org/replikativ/spindel/dom/jsdom_final_state_test.cljs
+++ b/test/org/replikativ/spindel/dom/jsdom_final_state_test.cljs
@@ -257,3 +257,59 @@
       (is (= 1 (n-matching body ".root")) "exactly one root")
       (is (kept? (.querySelector body ".root"))
           "an await between track and element must not change the address"))))
+
+;; =============================================================================
+;; 3. OPEN, SEPARATE DEFECT: the fragment's parent is re-minted each re-render
+;; =============================================================================
+;;
+;; Found while diagnosing the eviction bug, and NOT fixed by it. Probing
+;; `render-initial!` showed the nav getting a NEW address on every re-render:
+;;
+;;   mount   nav :el-12707852...
+;;   expand  nav :el-17fec733...   <- re-minted, whole subtree rebuilt
+;;
+;; R1 says identity IS the address, so a stable call site must keep its
+;; address; re-minting rebuilds the world on every render. The two tests above
+;; isolate the trigger: `track -> await -> element` preserves node identity
+;; (both pass), so neither the await nor the track is at fault on its own. It
+;; is the awaited ifor-each FRAGMENT child that destabilises the parent.
+;;
+;; The address is `content-hash[source-loc, parent-addr, slot-index]` — all
+;; three of which should be stable here — so the cause is likelier in the
+;; chain-head cursor the addressing layer forks for fragment items
+;; (dom/addressing `with-item-scope`, engine/addressing get/set-chain-head!).
+;; That is engine-level and deserves its own change; the eviction fix above is
+;; independent of it and complete on its own.
+;;
+;; This test FAILS. It is the acceptance criterion for that follow-up.
+
+(deftest-async fragment-parent-keeps-its-identity-across-rerender
+  (testing "a parent whose child is an awaited ifor-each fragment must be
+            reconciled in place, not re-created"
+    (let [body (fresh-body)
+          discharge (browser/make-dom-discharge (.-ownerDocument body))
+          open-set (sig/signal #{})
+          ids ["a" "b" "c"]
+          section-fn (fn [{:keys [id open?]}]
+                       (spin
+                        (await (comb/sleep 1))
+                        (el/div {:key id :class "section"}
+                                (when open? (el/ul {:class "section-items"})))))
+          root (spin
+                (let [{os :new} (track open-set)
+                      frag (await (foreach/for-each*
+                                   {:file "jsdom-identity" :line 1 :column 1}
+                                   :id section-fn
+                                   (mapv (fn [id] {:id id
+                                                   :open? (contains? os id)})
+                                         ids)))]
+                  (el/nav {:class "shell"} frag)))]
+      (render/render-spin! body root discharge)
+      (<? (comb/sleep 200))
+      (is (= 3 (n-matching body ".section")) "mounted")
+      (stamp! (.querySelector body ".shell"))
+      (reset! open-set #{"b"})
+      (<? (comb/sleep 300))
+      (is (= 3 (n-matching body ".section")) "still three sections")
+      (is (kept? (.querySelector body ".shell"))
+          "R1: the nav's address must be stable across re-renders"))))

--- a/test/org/replikativ/spindel/dom/jsdom_final_state_test.cljs
+++ b/test/org/replikativ/spindel/dom/jsdom_final_state_test.cljs
@@ -1,0 +1,259 @@
+(ns org.replikativ.spindel.dom.jsdom-final-state-test
+  "Assertions on the REAL tree: what is on screen after the toggles settle.
+
+   Why this namespace exists. The JVM harness asserts on `MockDischarge`'s op
+   log, and that log cannot answer \"what is attached\": `remove-child!` is
+   INDEX-addressed and `child-index-of` returns nil (the mock has no DOM), so
+   `apply-seq-diff!` silently falls back to offset 0. Replaying the log into a
+   tree and counting reachable nodes — the obvious workaround — reports ZERO
+   live containers for a clean, fully-drained expand that unquestionably
+   renders. Op counts are the only trustworthy readout there, and they cannot
+   express the defect we are chasing, which is stated as a NODE COUNT:
+   collapsing and re-expanding a sidebar section in simmis went 9 -> 15.
+
+   Here the discharge is `dom/browser`'s real `DOMDischarge` over a jsdom
+   document, so `child-index-of` is real, fragment offsets are real, and the
+   assertion is a `querySelectorAll` — the same measurement taken in Chrome.
+
+   Coordination note: CLJS is single-threaded, so `await-drain` (which blocks)
+   is JVM-only — a synchronous wait cannot observe `setTimeout`. Awaiting a
+   `comb/sleep` is the only way to yield to the event loop, and it is how the
+   engine's own async ops resolve. That is coordination, not a timing patch:
+   the fixture's own children resolve through the same mechanism."
+  (:refer-clojure :exclude [await])
+  (:require [cljs.test :refer-macros [is testing use-fixtures]]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.dom.elements :as el]
+            [org.replikativ.spindel.dom.browser :as browser]
+            [org.replikativ.spindel.dom.render :as render]
+            [org.replikativ.spindel.dom.foreach :as foreach]
+            [org.replikativ.spindel.signal :as sig]
+            [org.replikativ.spindel.effects.track :refer [track]]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.spin.combinators :as comb]
+            [org.replikativ.spindel.spin.cps :refer-macros [spin]]
+            [org.replikativ.spindel.test-async :refer [<?] :refer-macros [deftest-async <?]]
+            ["jsdom" :refer [JSDOM]]))
+
+(def ^:private current-test-ctx (atom nil))
+
+(use-fixtures :each
+  {:before (fn [] (let [c (ctx/create-execution-context)]
+                    (reset! current-test-ctx c)
+                    (set! ec/*execution-context* c)))
+   :after  (fn [] (when-let [c @current-test-ctx]
+                    (ctx/stop-context! c)
+                    (set! ec/*execution-context* nil)
+                    (reset! current-test-ctx nil)))})
+
+(defn- fresh-body []
+  (let [dom (JSDOM. "<!DOCTYPE html><html><body></body></html>")]
+    (.-body (.-document (.-window dom)))))
+
+(defn- n-matching
+  "How many nodes match `sel` — the harness equivalent of the browser count."
+  [body sel]
+  (.-length (.querySelectorAll body sel)))
+
+;; =============================================================================
+;; 0. The harness proves itself before it is trusted
+;; =============================================================================
+;;
+;; The JVM replay metric FAILED exactly here — it reported 0 for a state that
+;; definitely renders. Any final-state harness must pass this before its
+;; verdict on the interesting case means anything.
+
+(deftest-async harness-reports-what-is-actually-on-screen
+  (testing "a clean expand and collapse, fully settled between"
+    (let [body (fresh-body)
+          discharge (browser/make-dom-discharge (.-ownerDocument body))
+          open? (sig/signal false)
+          root (spin
+                (let [{o :new} (track open?)]
+                  (el/div {:class "shell"}
+                          (when o
+                            (el/ul {:class "section-items"}
+                                   (el/li "one"))))))]
+      (render/render-spin! body root discharge)
+      (<? (comb/sleep 50))
+      (is (= 0 (n-matching body ".section-items")) "collapsed at mount")
+      (reset! open? true)
+      (<? (comb/sleep 50))
+      (is (= 1 (n-matching body ".section-items"))
+          "expanded: exactly one container is on screen")
+      (reset! open? false)
+      (<? (comb/sleep 50))
+      (is (= 0 (n-matching body ".section-items"))
+          "collapsed again: the container is gone"))))
+
+;; =============================================================================
+;; 1. A duplication bug, stated as a node count — MEASURED, both versions
+;; =============================================================================
+;;
+;; The shape the browser duplicates on: expansion state lives IN the ifor-each
+;; item (sharp-edge #2 forces this — closure variables are invisible to the
+;; diff), so toggling one section changes that item's value and every section
+;; re-renders.
+;;
+;; What these two tests establish, on a real jsdom tree:
+;;
+;;   in-flight toggles : 6 sections become 12, and 2 containers remain
+;;   SETTLED toggles   : mount 6 ok; settled EXPAND 6 + 1 container ok;
+;;                       settled COLLAPSE -> 12 sections, container NOT removed
+;;
+;; So the race is NOT required. A single fully-settled collapse duplicates the
+;; fragment. And the numbers are IDENTICAL on pre-R3 (f9dc70e~1) and on R3, so
+;; this is NOT the R3 staging regression — it is an older, independent defect
+;; in the ifor-each collapse path that both releases carry.
+;;
+;; That also means it is a candidate explanation for the duplications seen in
+;; simmis before R3 ever existed. It does NOT explain the 0.1.37-vs-0.1.38 A/B
+;; measured in Chrome (9 stays 9 / 9 becomes 15); that difference is still
+;; unaccounted for, and may be a second mechanism layered on this one.
+;;
+;; These tests FAIL on both versions today. They are the acceptance criterion
+;; for the fix, not a description of working behaviour.
+
+(deftest-async collapse-expand-in-flight-does-not-duplicate
+  (testing "after in-flight collapse/expand cycles, exactly one items
+            container is on screen"
+    (let [body (fresh-body)
+          discharge (browser/make-dom-discharge (.-ownerDocument body))
+          open-set (sig/signal #{})
+          ids ["a" "b" "c" "d" "e" "f"]
+          section-fn (fn [{:keys [id open?]}]
+                       (spin
+                        (await (comb/sleep 1))
+                        (el/div {:key id :class "section"}
+                                (when open?
+                                  (el/ul {:class "section-items"}
+                                         (el/li "one")
+                                         (el/li "two"))))))
+          root (spin
+                (let [{os :new} (track open-set)
+                      frag (await (foreach/for-each*
+                                   {:file "jsdom-final-state" :line 1 :column 1}
+                                   :id section-fn
+                                   (mapv (fn [id] {:id id
+                                                   :open? (contains? os id)})
+                                         ids)))]
+                  (el/nav {:class "shell"} frag)))]
+      (render/render-spin! body root discharge)
+      (<? (comb/sleep 100))
+      (is (= 0 (n-matching body ".section-items")) "nothing expanded at mount")
+      (is (= 6 (n-matching body ".section")) "all sections mounted")
+      ;; Expand / collapse / expand with no settle in between, three times.
+      (<? (comb/sleep 1))
+      (reset! open-set #{"c"})
+      (<? (comb/sleep 1))
+      (reset! open-set #{})
+      (<? (comb/sleep 1))
+      (reset! open-set #{"c"})
+      (<? (comb/sleep 150))
+      (reset! open-set #{})
+      (<? (comb/sleep 1))
+      (reset! open-set #{"c"})
+      (<? (comb/sleep 150))
+      (reset! open-set #{})
+      (<? (comb/sleep 1))
+      (reset! open-set #{"c"})
+      (<? (comb/sleep 300))
+      (is (= 6 (n-matching body ".section"))
+          (str "the section list must not grow, got "
+               (n-matching body ".section")))
+      (is (= 1 (n-matching body ".section-items"))
+          (str "exactly one items container may be on screen, got "
+               (n-matching body ".section-items"))))))
+
+;; Is the in-flight race required, or does the same shape duplicate even when
+;; every toggle is allowed to settle? This separates "supersession mishandled"
+;; from "ifor-each re-render duplicates" — a much wider defect.
+
+(deftest-async collapse-expand-settled-does-not-duplicate
+  (testing "same shape, every toggle fully settled"
+    (let [body (fresh-body)
+          discharge (browser/make-dom-discharge (.-ownerDocument body))
+          open-set (sig/signal #{})
+          ids ["a" "b" "c" "d" "e" "f"]
+          section-fn (fn [{:keys [id open?]}]
+                       (spin
+                        (await (comb/sleep 1))
+                        (el/div {:key id :class "section"}
+                                (when open?
+                                  (el/ul {:class "section-items"}
+                                         (el/li "one")
+                                         (el/li "two"))))))
+          root (spin
+                (let [{os :new} (track open-set)
+                      frag (await (foreach/for-each*
+                                   {:file "jsdom-settled" :line 1 :column 1}
+                                   :id section-fn
+                                   (mapv (fn [id] {:id id
+                                                   :open? (contains? os id)})
+                                         ids)))]
+                  (el/nav {:class "shell"} frag)))]
+      (render/render-spin! body root discharge)
+      (<? (comb/sleep 200))
+      (is (= 6 (n-matching body ".section")) "mount")
+      (reset! open-set #{"c"})
+      (<? (comb/sleep 300))
+      (is (= 6 (n-matching body ".section")) "after settled expand")
+      (is (= 1 (n-matching body ".section-items")) "one container open")
+      (reset! open-set #{})
+      (<? (comb/sleep 300))
+      (is (= 6 (n-matching body ".section")) "after settled collapse")
+      (is (= 0 (n-matching body ".section-items")) "container closed"))))
+
+;; =============================================================================
+;; 2. Isolation: is the root element PRESERVED across a re-render?
+;; =============================================================================
+;;
+;; While diagnosing the above, `render-initial!` was observed minting a NEW
+;; address for the root element on every re-render — the old one evicted, the
+;; whole subtree rebuilt. That is what R1 ("identity is the address") forbids,
+;; and rebuilding the world each render is also why so much churn reaches the
+;; discharge layer.
+;;
+;; These two isolate the trigger. Both spins track the same signal and emit the
+;; same element; they differ ONLY in whether an `await` sits between the track
+;; and the element construction. Node identity is checked directly: a property
+;; stamped on the mounted node survives iff the node was reconciled in place.
+
+(defn- stamp! [el] (set! (.-__spindelMark el) "kept") el)
+(defn- kept? [el] (= "kept" (.-__spindelMark el)))
+
+(deftest-async element-identity-survives-rerender-without-await
+  (testing "track -> element, no await between"
+    (let [body (fresh-body)
+          discharge (browser/make-dom-discharge (.-ownerDocument body))
+          n (sig/signal 0)
+          root (spin
+                (let [{v :new} (track n)]
+                  (el/div {:class "root"} (el/span (str "n=" v)))))]
+      (render/render-spin! body root discharge)
+      (<? (comb/sleep 50))
+      (stamp! (.querySelector body ".root"))
+      (reset! n 1)
+      (<? (comb/sleep 100))
+      (is (= 1 (n-matching body ".root")) "exactly one root")
+      (is (kept? (.querySelector body ".root"))
+          "the root node must be reconciled in place, not recreated"))))
+
+(deftest-async element-identity-survives-rerender-with-await
+  (testing "track -> await -> element (the shape the nav uses)"
+    (let [body (fresh-body)
+          discharge (browser/make-dom-discharge (.-ownerDocument body))
+          n (sig/signal 0)
+          root (spin
+                (let [{v :new} (track n)
+                      _ (await (comb/sleep 1))]
+                  (el/div {:class "root"} (el/span (str "n=" v)))))]
+      (render/render-spin! body root discharge)
+      (<? (comb/sleep 100))
+      (stamp! (.querySelector body ".root"))
+      (reset! n 1)
+      (<? (comb/sleep 200))
+      (is (= 1 (n-matching body ".root")) "exactly one root")
+      (is (kept? (.querySelector body ".root"))
+          "an await between track and element must not change the address"))))

--- a/test/org/replikativ/spindel/dom/jsdom_final_state_test.cljs
+++ b/test/org/replikativ/spindel/dom/jsdom_final_state_test.cljs
@@ -274,12 +274,37 @@
 ;; (both pass), so neither the await nor the track is at fault on its own. It
 ;; is the awaited ifor-each FRAGMENT child that destabilises the parent.
 ;;
-;; The address is `content-hash[source-loc, parent-addr, slot-index]` — all
-;; three of which should be stable here — so the cause is likelier in the
-;; chain-head cursor the addressing layer forks for fragment items
-;; (dom/addressing `with-item-scope`, engine/addressing get/set-chain-head!).
-;; That is engine-level and deserves its own change; the eviction fix above is
-;; independent of it and complete on its own.
+;; ROOT CAUSE, measured. The address is
+;; `content-hash[source-loc, parent-addr, slot-index]`. Probing all three at the
+;; nav's construction, across two renders:
+;;
+;;   render 1  parent=:keyed-0435e69b  slot=0  chain=:spin-07ecfb2e  (item c)
+;;   render 2  parent=:keyed-1653f3a8  slot=0  chain=:spin-07ecfb2e  (item b)
+;;
+;; slot and the spin chain-head are STABLE. The parent is not — and it is a
+;; `:keyed-...` address, i.e. an `ifor-each` ITEM's scope. The outer body's
+;; element is being addressed as though it lived inside one of the fragment's
+;; items, and WHICH item varies per render (c, then b). That nondeterminism is
+;; the instability. The per-item keyed addresses are themselves stable
+;; (`:keyed-0435e69b` is item c in both renders), so item addressing is fine.
+;;
+;; The mechanism: `with-keyed-context-fn` installs `:dom/parent-addr` with a
+;; synchronous `binding` around a thunk that only STARTS async work — the item
+;; render-fn returns a spin, so the `finally` fires immediately (the ENTER/EXIT
+;; pairs all print during the synchronous kick-off, before any item body
+;; resolves). The scope therefore does not track the item's continuation, and
+;; when the parent body resumes from `(await (for-each* ...))` it inherits the
+;; ambient context left by whichever item continuation resumed last.
+;;
+;; This is why the two tests above pass: with no fragment there is no keyed
+;; scope to leak, so `track -> await -> element` is stable.
+;;
+;; The fix must make the keyed scope part of the item spin's captured context
+;; (re-established per continuation, torn down when it completes) rather than a
+;; synchronous dynamic binding, and/or have a resuming body restore its OWN dom
+;; bindings instead of inheriting ambient ones. That is engine-level and
+;; deserves its own change; the eviction fix above is independent of it and
+;; complete on its own.
 ;;
 ;; This test FAILS. It is the acceptance criterion for that follow-up.
 

--- a/test/org/replikativ/spindel/dom/jsdom_final_state_test.cljs
+++ b/test/org/replikativ/spindel/dom/jsdom_final_state_test.cljs
@@ -338,3 +338,133 @@
       (is (= 3 (n-matching body ".section")) "still three sections")
       (is (kept? (.querySelector body ".shell"))
           "R1: the nav's address must be stable across re-renders"))))
+
+;; =============================================================================
+;; 4. The REAL nav shape: await INSIDE the element build
+;; =============================================================================
+;;
+;; Everything above awaits the fragment FIRST and then builds the element
+;; around the result. simmis's nav (nav.cljc:731) does the opposite — the
+;; `await` sits inside the `el/div`'s child thunk:
+;;
+;;   (el/div {:class "nav-section"}
+;;     header
+;;     (when-not collapsed
+;;       (el/div {:class "nav-section-items"}
+;;         (await (ifor-each :kb/id kb-items render-kb-subsection-spin)))))
+;;
+;; so ELEMENT CONSTRUCTION ITSELF suspends: partial-cps splits build-element's
+;; child evaluation across an async boundary. The items are spins that TRACK
+;; their own signals and contain a further (sync) ifor-each with their own
+;; conditional container — the nested `.sub-items` here.
+;;
+;; Measured in Chrome (dev build carrying every fix above): from a CLEAN
+;; state, every SETTLED expand inserted the subtree TWICE and every collapse
+;; removed it once — deterministic, +1 outer & +5 nested containers per
+;; toggle cycle, no race required. Probing the live app pinned the shape:
+;; the container was BUILT 6+ times during one expand (the parent's slice
+;; re-ran once per subsection re-completion — they all track the toggled
+;; signal, and each KB's pages signal fires at its own real time), and the
+;; same `:add` was discharged in TWO SEPARATE update-render! passes from two
+;; DIFFERENT vnode objects. `*applied-vnodes*` is identity-keyed by design,
+;; so distinct builds pass it; R3's commit does not help because every build
+;; reconciled against the committed baseline BEFORE the first pass promoted
+;; it. That window — N builds diffing one uncommitted baseline, >1 of them
+;; reaching the DOM in separate passes — is inherent to compute-time
+;; reconciliation, and is exactly what moving reconciliation to COMMIT time
+;; closes (effect-state-design.md option D/E; repeat_execution_test's
+;; docstring predicted this fix shape).
+;;
+;; Reproduction required ALL of: (1) the await inside the element build,
+;; (2) reactive per-item sub-spins tracking the toggled signal, (3) nested
+;; conditional containers, (4) staggered per-item signal changes landing in
+;; separate drains, and (5) — the one that finally made it fire — an OUTER
+;; root spin awaiting the section, whose :await-reactive cont re-fires per
+;; section re-completion so separate passes embed different-era builds.
+;;
+;; THIS TEST FAILS (6 nested containers instead of 3 after one settled
+;; expand). It is the acceptance criterion for the commit-time
+;; reconciliation change.
+
+(deftest-async await-inside-element-child-does-not-duplicate
+  (testing "collapse and re-expand a section whose element build suspends on
+            an awaited fragment of reactive sub-spins — one container each"
+    (let [body (fresh-body)
+          discharge (browser/make-dom-discharge (.-ownerDocument body))
+          ;; the toggled signal is a SET tracked by the parent AND every
+          ;; subsection — nav's `nav-collapsed-projects`. Toggling "kbs"
+          ;; changes the set VALUE, so every tracker fires even though only
+          ;; the parent's own membership changed: a diamond across the
+          ;; await boundary (parent re-runs AND each item re-completes,
+          ;; re-firing the parent's :await-reactive cont).
+          collapsed (sig/signal #{})
+          ;; one pages-signal per KB — the app's kb-pages, updated by each
+          ;; KB-CONN at its own real time. Each update is a SEPARATE
+          ;; :signal-change event re-running the section through the item's
+          ;; track, so builds land in separate drains/render passes instead
+          ;; of coalescing — the ingredient the browser trace showed (six
+          ;; builds of the container, :add discharged in TWO passes).
+          pages {"wiki" (sig/signal ["p1"]) "assist" (sig/signal ["p1"])
+                 "notes" (sig/signal ["p1"])}
+          kbs [{:id "wiki"} {:id "assist"} {:id "notes"}]
+          subsection (fn [kb]
+                       (spin
+                        (let [{c :new} (track collapsed)
+                              {ps :new} (track (get pages (:id kb)))]
+                          (el/div {:key (:id kb) :class "nav-subsection"}
+                                  (el/span (str (:id kb) "-" (count ps)))
+                                  (when-not (contains? c (:id kb))
+                                    (el/div {:class "sub-items"}
+                                          (foreach/for-each*
+                                           {:file "jsdom-nav-shape" :line 2 :column 1}
+                                           :id
+                                           (fn [p] (el/li {:key (:id p)} (:id p)))
+                                           [{:id (str (:id kb) "-p1")}
+                                            {:id (str (:id kb) "-p2")}])))))))
+          ;; the SECTION spin — reactive, created once
+          section (spin
+                   (let [{c :new} (track collapsed)]
+                     (el/div {:class "nav-section"}
+                             (el/div {:class "nav-title"} "Memory")
+                             (when-not (contains? c "kbs")
+                               (el/div {:class "section-items"}
+                                       (await (foreach/for-each*
+                                               {:file "jsdom-nav-shape" :line 1 :column 1}
+                                               :id subsection kbs)))))))
+          ;; the ROOT wraps it, as nav's root wraps its sections: the root's
+          ;; :await-reactive cont re-fires on every section re-completion, so
+          ;; each render pass can embed a DIFFERENT-ERA section build
+          root (spin
+                (el/div {:class "nav-shell"}
+                        (await section)))]
+      (render/render-spin! body root discharge)
+      (<? (comb/sleep 300))
+      (is (= 1 (n-matching body ".section-items")) "mounted: one outer container")
+      (is (= 3 (n-matching body ".sub-items")) "mounted: three nested containers")
+      (swap! collapsed conj "kbs")
+      (<? (comb/sleep 300))
+      (is (= 0 (n-matching body ".section-items")) "settled collapse: outer gone")
+      (swap! collapsed disj "kbs")
+      ;; the app's expand is not one event: KBs (re)connect and their pages
+      ;; signals fire at staggered times while the section is still settling
+      (<? (comb/sleep 30))
+      (reset! (get pages "wiki") ["p1" "p2"])
+      (<? (comb/sleep 40))
+      (reset! (get pages "assist") ["p1" "p2"])
+      (<? (comb/sleep 40))
+      (reset! (get pages "notes") ["p1" "p2"])
+      (<? (comb/sleep 500))
+      (is (= 1 (n-matching body ".section-items"))
+          (str "settled expand: ONE outer container, got "
+               (n-matching body ".section-items")))
+      (is (= 3 (n-matching body ".sub-items"))
+          (str "settled expand: three nested containers, got "
+               (n-matching body ".sub-items")))
+      ;; second cycle — accumulation is the app signature (+6 per cycle)
+      (swap! collapsed conj "kbs")
+      (<? (comb/sleep 300))
+      (swap! collapsed disj "kbs")
+      (<? (comb/sleep 500))
+      (is (= 1 (n-matching body ".section-items"))
+          (str "cycle 2: still one outer container, got "
+               (n-matching body ".section-items"))))))

--- a/test/org/replikativ/spindel/dom/jsdom_final_state_test.cljs
+++ b/test/org/replikativ/spindel/dom/jsdom_final_state_test.cljs
@@ -415,12 +415,12 @@
                                   (el/span (str (:id kb) "-" (count ps)))
                                   (when-not (contains? c (:id kb))
                                     (el/div {:class "sub-items"}
-                                          (foreach/for-each*
-                                           {:file "jsdom-nav-shape" :line 2 :column 1}
-                                           :id
-                                           (fn [p] (el/li {:key (:id p)} (:id p)))
-                                           [{:id (str (:id kb) "-p1")}
-                                            {:id (str (:id kb) "-p2")}])))))))
+                                            (foreach/for-each*
+                                             {:file "jsdom-nav-shape" :line 2 :column 1}
+                                             :id
+                                             (fn [p] (el/li {:key (:id p)} (:id p)))
+                                             [{:id (str (:id kb) "-p1")}
+                                              {:id (str (:id kb) "-p2")}])))))))
           ;; the SECTION spin — reactive, created once
           section (spin
                    (let [{c :new} (track collapsed)]

--- a/test/org/replikativ/spindel/dom/render_test.cljc
+++ b/test/org/replikativ/spindel/dom/render_test.cljc
@@ -146,16 +146,16 @@
 (deftest test-address-based-element-refs
   (testing "Element references are stored and found by address"
     (let [{:keys [discharge]} (disch/make-mock-discharge)
-          v1 (el/div {:class "test"} (el/span "Hello"))
-          _ (disch/render-initial! discharge v1)]
-      ;; Element should be findable by its address
+          ;; one source location, invoked twice — builds are pure values
+          ;; under commit-time reconciliation, and identity is the address
+          build (fn [] (el/div {:class "test"} (el/span "Hello")))
+          v1 (build)
+          _ (disch/render-initial! discharge v1)
+          v1b (build)]
       (is (some? (disch/get-element discharge (:addr v1))))
-      ;; After clear-deltas-deep, new objects carry same :addr
-      (let [cleared (disch/clear-deltas-deep v1)]
-        (is (= (:addr v1) (:addr cleared))
-            "Cleared vdom should preserve address")
-        ;; Element should still be findable via the cleared vdom's address
-        (is (some? (disch/get-element discharge (:addr cleared))))))))
+      (is (= (:addr v1) (:addr v1b))
+          "a rebuild from the same source location carries the same address")
+      (is (some? (disch/get-element discharge (:addr v1b)))))))
 
 ;; =============================================================================
 ;; Delta-Direct Rendering Tests (CLJ only - requires await-drain)

--- a/test/org/replikativ/spindel/dom/repeat_execution_test.clj
+++ b/test/org/replikativ/spindel/dom/repeat_execution_test.clj
@@ -1,0 +1,140 @@
+(ns org.replikativ.spindel.dom.repeat-execution-test
+  "A body executed MORE THAN ONCE for one commit must produce the same DOM as
+   executing it once.
+
+   This is the second half of the invariant `superseded_run_test` covers. That
+   one asserts an ABANDONED run changes nothing; this one asserts a REPEATED
+   run changes nothing extra. They fail on opposite releases, which is the
+   point:
+
+     spindel 0.1.37 (pre-R3)  — repeat is safe, abandonment CORRUPTS
+     spindel 0.1.38 (R3)      — abandonment is safe, repeat DUPLICATES
+
+   Neither is correct. R3 removed the compute-time cache write that had been
+   doing double duty as BOTH the reconciliation baseline AND an
+   already-emitted marker; separating the baseline was right, and nothing
+   replaced the marker. `*applied-vnodes*` cannot be it — it is object-identity
+   keyed by design, so two vnodes from two executions are invisible to it.
+
+   Measured downstream before this test existed: collapsing and re-expanding a
+   sidebar section in simmis went from 9 containers to 15, because the expand's
+   `:add` was applied twice.
+
+   The fix these tests define acceptance for is not another dedup guard but
+   moving reconciliation to commit time, so that promoting the baseline and
+   applying the delta are ONE step — a second execution then diffs against an
+   already-advanced baseline and collapses to nothing."
+  (:refer-clojure :exclude [await])
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [org.replikativ.spindel.dom.elements :as el]
+            [org.replikativ.spindel.dom.discharge :as disch]
+            [org.replikativ.spindel.dom.render :as render]
+            [org.replikativ.spindel.dom.cache :as cache]
+            [org.replikativ.spindel.signal :as sig]
+            [org.replikativ.spindel.effects.track :refer [track]]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.dom.foreach :refer [ifor-each]]
+            [org.replikativ.spindel.test-async :refer [await-drain]]
+            [org.replikativ.spindel.test-helpers :refer [with-ctx]]))
+
+(defn clean-context-fixture [f]
+  (binding [ec/*execution-context* nil]
+    (f)))
+
+(use-fixtures :each clean-context-fixture)
+
+(defn- op-counts
+  "Structural ops only — creates and inserts. Attribute writes are idempotent
+   at the DOM level (setting the same class twice is invisible), but an extra
+   `insert-child!` is a second node on screen."
+  [log]
+  {:creates (count (filter #(= :create-element (:op %)) @log))
+   :inserts (count (filter #(= :insert-child (:op %)) @log))})
+
+;; =============================================================================
+;; 1. The unit-level property, on the reconcilers themselves
+;; =============================================================================
+;;
+;; This one does not need the engine at all, and it states the mechanism in the
+;; smallest possible form: reconciling twice against an UNADVANCED baseline
+;; emits the delta twice; advancing the baseline as part of the first
+;; reconciliation makes the second a no-op. Everything below is this property
+;; wearing more machinery.
+
+(deftest reconciling-twice-against-one-baseline-emits-twice
+  (testing "attrs: the shape of the duplication, in isolation"
+    (let [committed {:class "editor"}
+          built     {:class "editor readonly"}
+          twice     [(cache/reconcile-attrs committed built)
+                     (cache/reconcile-attrs committed built)]]
+      (is (= 1 (count (first twice))))
+      (is (= 1 (count (second twice)))
+          "against an unadvanced baseline, the second execution re-emits")
+      ;; and the property the fix must establish:
+      (is (empty? (cache/reconcile-attrs built built))
+          "against an ADVANCED baseline, the second execution is a no-op")))
+
+  (testing "children: the same shape for a conditional child appearing"
+    (let [collapsed [{:type :nil :value nil}]
+          child     {:tag :div :addr :el-items}
+          r1        (cache/reconcile-children collapsed [child])
+          r2        (cache/reconcile-children collapsed [child])]
+      (is (= 1 (count (:deltas r1))))
+      (is (= 1 (count (:deltas r2)))
+          "unadvanced baseline re-emits the :add — this is the 9 -> 15")
+      (is (empty? (:deltas (cache/reconcile-children (:slots r1) [child])))
+          "advanced baseline emits nothing"))))
+
+;; =============================================================================
+;; NOT YET REPRODUCED end-to-end — read before trying again
+;; =============================================================================
+;;
+;; The browser duplicates reliably: collapsing and re-expanding simmis's sidebar
+;; Memory section goes 9 -> 15 `.nav-section-items` on 0.1.38 and stays at 9 on
+;; 0.1.37. Two harness fixtures FAILED to reproduce it, both passing on the
+;; buggy version:
+;;
+;;   1. conditional child = an awaited plain child spin
+;;   2. conditional child = an awaited `ifor-each` whose render-fn returns spins
+;;      (the literal shape of nav.cljc:735) — mount 8 creates, 3 collapse/expand
+;;      cycles reached 29 against a 32 budget, i.e. no duplication
+;;
+;;   3. item-identity-changing `ifor-each` (expansion state assoc'd INTO the
+;;      item, per sharp-edge #2, so the per-key memo misses and every section
+;;      re-renders) + two async levels + toggling WITHOUT draining between, so
+;;      an expand supersedes an in-flight collapse
+;;
+;; Attempt 3 was aimed by browser instrumentation, which had measured the
+;; missing ingredient directly: ONE expand ran 18 element builds and 56
+;; discharges, and the SAME address appeared twice in the build log. It still
+;; did not reproduce, and it failed in a way worth recording:
+;;
+;;   the op log came out BYTE-IDENTICAL on pre-R3 (f9dc70e~1) and R3
+;;   — same 36 creates / 30 set-attrs / 33 appends / 6 inserts on both.
+;;
+;; Identical logs mean the fixture never exercises the staging-vs-direct-write
+;; distinction at all: every tree it builds eventually commits, so where the
+;; cache write happens cannot matter. The harness itself CAN discriminate the
+;; two versions — `superseded_run_test` fails 3/3 on pre-R3 and passes on R3 —
+;; so this is the fixture's shape, not a limitation of the runner.
+;;
+;; THE HARNESS CANNOT ANSWER "WHAT IS ON SCREEN". `MockDischarge/remove-child!`
+;; is INDEX-addressed and `child-index-of` returns nil (documented in the mock:
+;; it has no DOM), so a removal cannot be attributed to a node. Replaying the op
+;; log into a tree and counting nodes reachable from the root — the harness
+;; equivalent of `querySelectorAll`, and the metric the browser used — reports
+;; ZERO live containers for a clean, fully-drained expand that unquestionably
+;; renders. Any duplication metric built on this log is unsound in BOTH
+;; directions; op counts are the only trustworthy readout, and they cannot
+;; express "9 became 15".
+;;
+;; So a faithful final-state harness (jsdom-backed, asserting on a real tree)
+;; is not an optional nicety for this bug — it is a PREREQUISITE for acceptance.
+;; Candidate still untried under the current harness:
+;;   - driving through the real render effect rather than a mock discharge
+;;
+;; Until then, `toggled-*` acceptance for the repeat case does NOT exist, and
+;; any claim that a fix is a "strict improvement" rests on the unit property
+;; above plus a browser check — not on this suite.

--- a/test/org/replikativ/spindel/dom/superseded_run_test.clj
+++ b/test/org/replikativ/spindel/dom/superseded_run_test.clj
@@ -13,10 +13,11 @@
    the DOM never gained, so the NEXT transition removed the wrong index — a
    live sibling.
 
-   The fix: `build-element`/`ifor-each` STAGE their reconciliations
-   (`[:dom/pending]`), and `cache/commit-pending!` promotes them only for
-   addresses present in a vdom tree that actually reached the DOM
-   (initial-mount!, update-render!'s two branches, discharge-all!)."
+   HISTORY: the first fix STAGED build-time reconciliations and promoted
+   them at commit (R3 v1). That design was later replaced by commit-time
+   reconciliation (dom/commit): builds are pure and the diff runs at the
+   commit point, which makes abandonment free by construction — these
+   tests now guard that property rather than the staging mechanism."
   (:refer-clojure :exclude [await])
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [org.replikativ.spindel.dom.elements :as el]


### PR DESCRIPTION
## The bug

A **fully settled** collapse duplicates the list: 6 sections become 12, and the items container is never removed. No race, no in-flight toggling required.

```
mount            6 sections, 0 containers   ok
settled expand   6 sections, 1 container    ok
settled collapse 12 sections, 1 container   BROKEN
```

**Not an R3 regression.** The failure is byte-identical on `f9dc70e~1`, so 0.1.37 and 0.1.38 both carry it. It is a candidate explanation for duplications seen before R3 existed.

## Root cause

`flush-pending-evictions!` protects an unmounted address when a live element re-claims it, comparing against `*rendered-addrs*`. That set holds only addresses that appear **on a vnode** — and an `ifor-each` call site appears on none, because `flatten-slot` splices the fragment's items into `:children` and drops the fragment. So a fragment could never be found live, and was structurally exempt from the entire check.

Since the call-site address is *stable across re-renders*, a superseded parent's slot cache still names the fragment the **current** parent renders. Evicting that dead parent cascaded into the live fragment's keyed cache. Traced with probes:

```
[frag]  my-addr :el-2662818d  n 6  prev 6     <- expand, correct
[flush] addr :el-12707852 live? false -> frags [:el-2662818d]   <- dead parent, LIVE fragment
[frag]  my-addr :el-2662818d  n 6  prev 0     <- collapse: baseline gone, all 6 re-added
```

## The fix

`commit-pending!` already solved this on the staging side, closing over `keyed-frag-addrs` transitively for exactly this reason. This mirrors it for eviction:

- `live-keyed-closure` extends the live set over **committed** slots (commit runs before flush at every call site, so they are promoted by then)
- `evict-cache!` takes that set, so the cascade cannot take a live fragment down with a dead parent

The leak the cascade exists to prevent is unaffected — a genuinely dead fragment is not in the closure and is still evicted (`test-ifor-each-keyed-cache-is-evicted-on-unmount` passes).

## Testing

New jsdom-backed tests asserting `querySelectorAll` counts — the same measurement taken in Chrome.

The existing JVM op-log harness **cannot express this bug**: `MockDischarge/remove-child!` is index-addressed and `child-index-of` returns nil, so replaying the log reports *zero* live nodes for a state that unquestionably renders. The first test therefore proves the harness before the rest are trusted.

- JVM **920 green**
- CLJS **411 green**
- Pre-existing flake seen on this suite, unrelated and present without this change: `fork-ctx-pubsub-bus-built-outside` (1 in 4 baseline runs)

## Second commit fails CI — deliberately

`de56653` adds a test for a **separate, unfixed** defect found while diagnosing this one: a parent whose child is an awaited `ifor-each` fragment is re-minted on every re-render (new address, subtree rebuilt), violating R1.

The two passing identity tests isolate the trigger: `track -> await -> element` preserves node identity, so neither the await nor the track is at fault alone — it is the fragment child. Address is `content-hash[source-loc, parent-addr, slot-index]`, all stable here, so the cause is likelier the chain-head cursor forked for fragment items. Engine-level, deserves its own change.

It is a separate commit so it can be dropped if you want a green merge first.