### PR TITLE
feat: make world fork settlement affine

### DIFF
--- a/src/org/replikativ/spindel/distributed/workspace_peer_sync.cljc
+++ b/src/org/replikativ/spindel/distributed/workspace_peer_sync.cljc
@@ -280,7 +280,7 @@
    collects per-system `ygg/conflicts` between the parent + fork snapshot-ids; if
    any system conflicts (or a detector throws — counted as indeterminate) it aborts
    WITHOUT merging and returns `{:merged {} :conflicts {sid [...]}}`. Mirrors
-   `yggdrasil.cljc/merge-to-parent!` for the branch (rather than overlay) case.
+   `yggdrasil.cljc/merge-fork!` for the branch (rather than overlay) case.
 
    DI: `system-lookup` (system-id -> local base ygg-system); `checkout-fn`
    (sys branch -> branch-scoped system, default `ygg/checkout`); `snapshot-id-fn`

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -411,7 +411,8 @@
   - Fork-local state (continuations, engine queue/timers) doesn't fall back
   - Bindings are merged (child overrides parent)
   - Process-id auto-increments for Elle compatibility"
-  [parent-ctx & {:keys [state-updates bindings metadata process-id mode snapshots convergent-fork]
+  [parent-ctx & {:keys [state-updates bindings metadata process-id mode snapshots convergent-fork
+                        forkable-signals]
                  :or {state-updates {}
                       bindings {}
                       metadata nil
@@ -478,7 +479,14 @@
         ;; parent. `:snapshots` (per-id) picks a SNAPSHOT fork (pin a fixed value)
         ;; over the default OVERLAY fork (from current head, `mode` :following→
         ;; :frozen). Pure signals aren't in the set and fall through unchanged.
-        forkable-ids (rtp/get-state parent-ctx [:forkable-signals])
+        ;; A higher-level bridge may attenuate the fork to an explicit subset of
+        ;; forkable signals. `nil` preserves the historical "all registered"
+        ;; behavior; an explicit empty set means none. The bridge must also hide
+        ;; excluded addressing entries from the child so an unforked mutable
+        ;; value cannot be reached accidentally through a shared reference.
+        forkable-ids (if (nil? forkable-signals)
+                       (rtp/get-state parent-ctx [:forkable-signals])
+                       forkable-signals)
         forked-nodes (when (seq forkable-ids)
                        (persistent!
                         (reduce
@@ -1139,4 +1147,3 @@
     (advance-time! ctx 1000)  ; Jump to t=1000ms"
   [ctx target-ms]
   (delayed/advance-virtual-time! ctx target-ms))
-

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -20,8 +20,8 @@
      SNAPSHOT fork that pins a fixed snapshot-id (`fork-context … :snapshots`).
    - context-diff / context-conflicts: per-system delta of a fork vs its
      parent, using each system's own merge-base.
-   - merge-to-parent! / discard-from-parent!: parent-controlled merge-down /
-     discard of the fork's per-system overlays.
+   - merge-fork! / discard-fork!: affine parent-controlled settlement of the
+     fork's per-system overlays. The ForkHandle is the only settlement authority.
 
    ASYNC+SYNC (portability, Design B): the engine stays synchronous and every
    fn that drives a DURABLE yggdrasil op (`fork!`, merge/discard/diff/conflicts)
@@ -43,11 +43,11 @@
      (ygg/system \"dvergr-db\")   ; => the db system (canonical accessor)
 
      ;; Fork overlays every ygg-signal (git/datahike → branched fork worktree/conn)
-     (let [child-ctx (ctx/fork-context parent-ctx)]
-       (ec/with-context child-ctx
+     (let [fork (ygg/fork!)]
+       (ec/with-context (:child-ctx fork)
          @ygit  ; => git system on the forked overlay branch (automatic!)
          (d/transact! @@ydb [{:foo/bar 1}]))
-       (ygg/merge-to-parent! child-ctx))            ; merge each overlay down"
+       (ygg/merge-fork! fork))                       ; merge each overlay down"
   (:require [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.engine.protocols :as rtp]
             [org.replikativ.spindel.engine.context :as ctx]
@@ -61,7 +61,6 @@
             [yggdrasil.types :as ygt]
             [yggdrasil.convergent :as yc]
             [yggdrasil.convergent.overlay :as ovl]
-            [clojure.string :as str]
             [is.simm.partial-cps.async :as pcps]
             #?(:clj  [is.simm.partial-cps.async :refer [async await]]
                :cljs [is.simm.partial-cps.async :refer [await]])
@@ -126,17 +125,6 @@
   [sys]
   (and (satisfies? yc/PConvergent sys)
        (boolean (:branchable (caps sys)))))
-
-(defn- fork-branch-name?
-  "True if `b` is a fork branch (engine fork-ids are `:fork-<uuid>` keywords)."
-  [b]
-  (and b (str/starts-with? (name b) "fork-")))
-
-(defn- managed-fork-branch-name?
-  "True when `b` is a private branch owned by a ForkHandle lifecycle."
-  [b]
-  (and b (or (str/starts-with? (name b) "fork-")
-             (str/starts-with? (name b) "snap-"))))
 
 (defn- branch-fork
   "BRANCH fork (the DEFAULT for convergent systems): a REAL branched system as the
@@ -511,7 +499,11 @@
         (throw (authority-error fork-handle state))
 
         (= :open (:status state))
-        (let [next-state (assoc state :status :settling :operation operation)]
+        (let [next-state (-> state
+                             (assoc :status :settling
+                                    :operation operation
+                                    :phase :preflight)
+                             (dissoc :last-operation :last-error))]
           (if (compare-and-set! authority state next-state)
             {:execute? true}
             (recur)))
@@ -529,9 +521,20 @@
            (if (and (= (:token fork-handle) (:token state))
                     (= :settling (:status state))
                     (= operation (:operation state)))
-             (assoc state :status (terminal-status operation) :result result)
+             (-> state
+                 (assoc :status (terminal-status operation) :result result)
+                 (dissoc :phase :last-operation :last-error))
              state)))
   result)
+
+(defn- mark-settlement-mutating! [fork-handle operation]
+  (swap! (:authority fork-handle)
+         (fn [state]
+           (if (and (= (:token fork-handle) (:token state))
+                    (= :settling (:status state))
+                    (= operation (:operation state)))
+             (assoc state :phase :mutating)
+             state))))
 
 (defn- fail-settlement! [fork-handle operation error]
   (swap! (:authority fork-handle)
@@ -539,40 +542,135 @@
            (if (and (= (:token fork-handle) (:token state))
                     (= :settling (:status state))
                     (= operation (:operation state)))
-             ;; A failed attempt does not consume affine authority. Dvergr keeps
-             ;; automatic merge failures for review, where the same owner must be
-             ;; able to retry or discard. A later durable per-system journal makes
-             ;; retry after a mid-settlement process crash recoverable as well.
-             (-> state
-                 (assoc :status :open
-                        :last-operation operation
-                        :last-error error)
-                 (update :settlement-attempts (fnil inc 0))
-                 (dissoc :operation))
+             ;; Read-only preflight failures leave the capability retryable. Once
+             ;; any substrate may have changed, reopening would falsely advertise
+             ;; a pristine world and permit destructive double settlement.
+             (if (= :preflight (:phase state))
+               (-> state
+                   (assoc :status :open
+                          :last-operation operation
+                          :last-error error)
+                   (update :settlement-attempts (fnil inc 0))
+                   (dissoc :operation :phase))
+               (-> state
+                   (assoc :status :incomplete
+                          :last-operation operation
+                          :last-error error)
+                   (update :settlement-attempts (fnil inc 0))))
              state)))
   error)
 
-(defn- settle-fork! [fork-handle operation f]
+(defn- complete-callback! [fork-handle]
+  (swap! (:authority fork-handle)
+         #(-> % (assoc :callback-status :completed) (dissoc :callback-error))))
+
+(defn- fail-callback! [fork-handle error]
+  ;; Settlement is already terminal: callback failure must never resurrect the
+  ;; consumed world. Keep a portable diagnostic so an owner can repair the
+  ;; post-commit integration without retrying substrate settlement.
+  (swap! (:authority fork-handle)
+         #(assoc % :callback-status :failed :callback-error (ex-message error)))
+  error)
+
+(defn- run-post-commit! [fork-handle callback payload]
+  (when callback
+    (try
+      (callback payload)
+      (complete-callback! fork-handle)
+      (catch #?(:clj Throwable :cljs :default) error
+        (fail-callback! fork-handle error)
+        (throw error)))))
+
+(defn- memoized-cps
+  "Return a single-execution partial-CPS expression. Every invocation observes
+   the same resolution; callers that invoke it while running are joined rather
+   than executing its body again."
+  [start]
+  (let [state (atom {:status :idle :waiters []})]
+    (fn [resolve reject]
+      (let [launch? (volatile! false)
+            snapshot
+            (swap! state
+                   (fn [s]
+                     (case (:status s)
+                       :idle (do (vreset! launch? true)
+                                 {:status :running :waiters [[resolve reject]]})
+                       :running (update s :waiters conj [resolve reject])
+                       s)))]
+        (cond
+          @launch?
+          (letfn [(settle! [status value]
+                    (let [waiters (volatile! nil)]
+                      (swap! state
+                             (fn [s]
+                               (vreset! waiters (:waiters s))
+                               (assoc s
+                                      :status status
+                                      (if (= :resolved status) :value :error) value
+                                      :waiters [])))
+                      (doseq [[res rej] @waiters]
+                        ((if (= :resolved status) res rej) value))))]
+            (try
+              (start #(settle! :resolved %)
+                     #(settle! :rejected %))
+              (catch #?(:clj Throwable :cljs :default) error
+                (settle! :rejected error))))
+
+          (= :resolved (:status snapshot)) (resolve (:value snapshot))
+          (= :rejected (:status snapshot)) (reject (:error snapshot))
+          :else nil)))))
+
+(defn- settle-sync!
+  [fork-handle operation operation-f result-f callback]
   (let [{:keys [execute? result]} (claim-settlement! fork-handle operation)]
     (if-not execute?
       result
-      (try
-        (let [x (f)]
-          ;; Durable Yggdrasil ops are values on the JVM and partial-CPS thunks on
-          ;; cljs. Attach the authority transition without changing either public
-          ;; execution shape.
-          (if (fn? x)
-            (fn [resolve reject]
-              (x (fn [value]
-                   (complete-settlement! fork-handle operation value)
-                   (resolve value))
-                 (fn [error]
-                   (fail-settlement! fork-handle operation error)
-                   (reject error))))
-            (complete-settlement! fork-handle operation x)))
-        (catch #?(:clj Throwable :cljs :default) error
-          (fail-settlement! fork-handle operation error)
-          (throw error))))))
+      (let [payload (try
+                      (operation-f)
+                      (catch #?(:clj Throwable :cljs :default) error
+                        (fail-settlement! fork-handle operation error)
+                        (throw error)))
+            result (result-f payload)]
+        (complete-settlement! fork-handle operation result)
+        (run-post-commit! fork-handle callback payload)
+        result))))
+
+(defn- settle-async!
+  [fork-handle operation operation-f result-f callback]
+  ;; Claim authority only when the CPS expression is actually executed. Merely
+  ;; constructing an awaitable must not strand the fork in :settling.
+  (memoized-cps
+   (fn [resolve reject]
+     (try
+       (let [{:keys [execute? result]} (claim-settlement! fork-handle operation)]
+         (if-not execute?
+           (resolve result)
+           (letfn [(succeed! [payload]
+                     (let [result (result-f payload)]
+                       (complete-settlement! fork-handle operation result)
+                       (try
+                         (run-post-commit! fork-handle callback payload)
+                         (resolve result)
+                         (catch #?(:clj Throwable :cljs :default) error
+                           (reject error)))))
+                   (fail! [error]
+                     (fail-settlement! fork-handle operation error)
+                     (reject error))]
+             (try
+               (let [x (operation-f)]
+                 (if (fn? x)
+                   (x succeed! fail!)
+                   (succeed! x)))
+               (catch #?(:clj Throwable :cljs :default) error
+                 (fail! error))))))
+       (catch #?(:clj Throwable :cljs :default) error
+         (reject error))))))
+
+(defn- settle-fork!
+  [fork-handle operation opts operation-f result-f callback]
+  (if (:sync? (merge yc/default-opts opts))
+    (settle-sync! fork-handle operation operation-f result-f callback)
+    (settle-async! fork-handle operation operation-f result-f callback)))
 
 (defn fork!
   "Create a forked execution context with every ygg-signal overlaid (or snapshot-
@@ -583,6 +681,8 @@
      :snapshots {system-id -> snapshot-id} — pin those systems at fixed values
      :systems   :all (default) | :none | #{system-id ...} — systems visible and
        forked in the child. Excluded systems are hidden, never shared writable.
+     :rights    {system-id :write} — optional explicit grants. Other rights are
+       rejected until the substrate can enforce them rather than merely label them.
      :purpose   portable descriptor tag such as :run/:particle/:proposal
      :owner     initial affine settlement owner (default parent context fork-id)
      :convergent-fork :branch (default) | :overlay — a CONVERGENT CRDT forks as a
@@ -622,6 +722,19 @@
                                              {:type ::unknown-fork-systems
                                               :systems (vec unknown)
                                               :registered (vec (keys parent-reg))})))
+            rights (or (:rights opts) {})
+            unknown-rights (seq (remove selected-ids (keys rights)))
+            _known-rights (when unknown-rights
+                            (throw (ex-info "Fork rights name systems outside the selected world"
+                                            {:type ::unknown-fork-rights
+                                             :systems (vec unknown-rights)
+                                             :selected (vec selected-ids)})))
+            unsupported-rights (seq (remove (fn [[_ right]] (= :write right)) rights))
+            _enforced-rights (when unsupported-rights
+                               (throw (ex-info "Only :write fork rights are currently enforceable"
+                                               {:type ::unsupported-fork-rights
+                                                :rights (into {} unsupported-rights)
+                                                :supported #{:write}})))
             snapshot-ids (set (keys (:snapshots opts)))
             _included-snapshots (when-let [excluded (seq (remove selected-ids snapshot-ids))]
                                   (throw (ex-info "Snapshot policy names systems excluded from the fork"
@@ -629,6 +742,22 @@
                                                    :systems (vec excluded)})))
             selected-reg (select-keys parent-reg selected-ids)
             selected-signal-ids (into #{} (map (comp :id val)) selected-reg)
+            excluded-signal-ids (into #{}
+                                      (keep (fn [[sid sig-ref]]
+                                              (when-not (contains? selected-ids sid)
+                                                (:id sig-ref))))
+                                      parent-reg)
+            ;; A registry-only filter is insufficient: a retained raw SignalRef
+            ;; otherwise falls through the context overlay to the parent's mutable
+            ;; system. Seat nil-valued child-local nodes for every excluded signal,
+            ;; preserving the parent while making the retained capability inert.
+            attenuated-nodes
+            (into {}
+                  (keep (fn [sig-id]
+                          (when-let [pnode (rtp/get-state parent-ctx [:nodes sig-id])]
+                            [sig-id (nodes/->signal-node nil nil nil false #{}
+                                                         (inc (or (:generation pnode) 0)))])))
+                  excluded-signal-ids)
            ;; translate :snapshots from SYSTEM-id keys (what callers know) to the
            ;; SIGNAL-id keys fork-context forks by.
             snaps  (when-let [s (:snapshots opts)]
@@ -636,9 +765,10 @@
                                       (when-let [sr (get selected-reg sid)]
                                         [(:id sr) snap])))
                            s))
-            state-updates (merge (:state-updates opts)
-                                 {registry-key selected-reg
-                                  :forkable-signals selected-signal-ids})
+            state-updates (-> (or (:state-updates opts) {})
+                              (assoc registry-key selected-reg
+                                     :forkable-signals selected-signal-ids)
+                              (update :nodes #(merge (or % {}) attenuated-nodes)))
             fopts  (cond-> (-> opts
                                (dissoc :systems :purpose :owner :rights)
                                (assoc :state-updates state-updates
@@ -660,7 +790,7 @@
           (when ps
             (let [[_sid sig-ref cval _psys] (first ps)]
               (when (and (convergent-branchable? cval)
-                         (not (fork-branch-name? (ygg/current-branch cval))))
+                         (not= fork-id (ygg/current-branch cval)))
                 (let [_        (await (ygg/branch! cval fork-id (ygg/current-branch cval) popts))
                       branched (await (ygg/checkout cval fork-id popts))]
                   (set-node-value! child-ctx sig-ref branched))))
@@ -683,12 +813,12 @@
                                  (ygg/current-branch csys))
                         kind (cond snapshot? :snapshot
                                    (ovl/overlay? cval) :overlay
-                                   (managed-fork-branch-name? branch) :branch
+                                   (= fork-id branch) :branch
                                    (= cval psys) :shared
                                    :else :forked)
-                        entry {:base-snapshot (if (ovl/overlay? cval)
-                                                (ygg/base-ref cval)
-                                                parent-head)
+                        entry {:base-snapshot (cond snapshot? (get-in opts [:snapshots sid])
+                                                    (ovl/overlay? cval) (ygg/base-ref cval)
+                                                    :else parent-head)
                                :head child-head
                                :branch branch
                                :mode (cond (ovl/overlay? cval) (:mode cval)
@@ -807,8 +937,17 @@
 ;; Merge / Discard (Parent-Controlled)
 ;; =============================================================================
 
-(defn merge-to-parent!
-  "Merge a forked context's per-system overlays into its parent.
+(defn- managed-branch?
+  "True only when this handle's creation descriptor names the branch currently
+   held by `cval`. Prefixes are not authority: user-created fork-/snap- branches
+   must never be settled accidentally."
+  [fork-handle sid cval]
+  (let [{:keys [kind branch]} (get-in (:descriptor fork-handle) [:fork/systems sid])]
+    (and (contains? #{:branch :snapshot} kind)
+         (= branch (ygg/current-branch cval)))))
+
+(defn- merge-fork-context!
+  "Merge a ForkHandle's per-system overlays into its parent.
 
    Algorithm:
      1. Pre-check conflicts (unless :strategy or :force given); abort untouched
@@ -821,201 +960,208 @@
    unchanged and re-throws with diagnostics (git/datahike have no cross-store
    2PC; the conflict pre-check makes mid-merge failure unlikely).
 
-   Args:
-     child-ctx - Child ExecutionContext to merge from
-     opts      - {:strategy … :force true :message … :on-merge (fn [m])}
-
-   Returns: {:merged [sys-id …] :child-only [sys-id …]} or nil if no parent."
-  ([child-ctx] (merge-to-parent! child-ctx {}))
-  ([child-ctx opts]
-   (convey-context
-    (async+sync
-     (:sync? (merge yc/default-opts opts))
-     (async
-      (when-let [parent-ctx (:parent-ctx child-ctx)]
-        (let [pairs (shared-pairs child-ctx parent-ctx)]
+   Internal substrate operation. Public callers must settle through
+   `merge-fork!`, which owns the affine lifecycle and post-commit callback."
+  [fork-handle opts]
+  (let [child-ctx (:child-ctx fork-handle)]
+    (convey-context
+     (async+sync
+      (:sync? (merge yc/default-opts opts))
+      (async
+       (when-let [parent-ctx (:parent-ctx child-ctx)]
+         (let [pairs (shared-pairs child-ctx parent-ctx)
+               co (child-only child-ctx parent-ctx)]
          ;; 1. conflict pre-check (FAIL-SAFE: a throwing detector counts as an
          ;; indeterminate conflict so the gate aborts rather than blind-merges).
          ;; `snapshot-id`/`conflicts` are `await`ed ONLY when a continuation (a fn):
          ;; default-opts `snapshot-id` is a plain value on the JVM but a CPS on cljs;
          ;; `conflicts` is `[]` for conflict-free convergent CRDTs, CPS for versioned.
-          (when-not (or (:strategy opts) (:force opts))
-            (let [confs (loop [ps (seq pairs) acc []]
-                          (if ps
-                            (let [[sid _ cval psys] (first ps)
-                                  fsys (ys/effective-system cval)
-                                  more (if (satisfies? ygg/Mergeable fsys)
-                                         (try
-                                           (let [ps1  (let [v (ygg/snapshot-id psys)] (if (fn? v) (await v) v))
-                                                 fs1  (let [v (ygg/snapshot-id fsys)] (if (fn? v) (await v) v))
-                                                 pres (ygg/conflicts psys ps1 fs1)
-                                                 cs   (if (fn? pres) (await pres) pres)]
-                                             (mapv #(assoc % :system sid) cs))
-                                           (catch #?(:clj Throwable :cljs :default) e
-                                             [{:system sid :indeterminate? true
-                                               :error (ex-message e)}]))
-                                         [])]
-                              (recur (next ps) (into acc more)))
-                            acc))]
-              (when (seq confs)
-                (throw (ex-info "context merge has conflicts; aborting (pass :strategy or :force)"
-                                {:conflicts (vec confs)})))))
+           (when-not (or (:strategy opts) (:force opts))
+             (let [confs (loop [ps (seq pairs) acc []]
+                           (if ps
+                             (let [[sid _ cval psys] (first ps)
+                                   fsys (ys/effective-system cval)
+                                   more (if (satisfies? ygg/Mergeable fsys)
+                                          (try
+                                            (let [ps1  (let [v (ygg/snapshot-id psys)] (if (fn? v) (await v) v))
+                                                  fs1  (let [v (ygg/snapshot-id fsys)] (if (fn? v) (await v) v))
+                                                  pres (ygg/conflicts psys ps1 fs1)
+                                                  cs   (if (fn? pres) (await pres) pres)]
+                                              (mapv #(assoc % :system sid) cs))
+                                            (catch #?(:clj Throwable :cljs :default) e
+                                              [{:system sid :indeterminate? true
+                                                :error (ex-message e)}]))
+                                          [])]
+                               (recur (next ps) (into acc more)))
+                             acc))]
+               (when (seq confs)
+                 (throw (ex-info "context merge has conflicts; aborting (pass :strategy or :force)"
+                                 {:conflicts (vec confs)})))))
          ;; 2. merge each overlay down, repoint the parent ygg-signal, discard.
          ;; ROLLBACK SEMANTICS PRESERVED: each merged value is COMPUTED first, and the
          ;; parent ygg-signal is repointed only AFTER; a throwing/rejecting durable op
          ;; leaves that system's parent untouched and propagates (git/datahike have no
          ;; cross-store 2PC — the pre-check makes mid-merge failure unlikely).
-          (let [merged (loop [ps (seq pairs) acc []]
-                         (if ps
-                           (let [[sid sig-ref cval psys] (first ps)
-                                 acc* (cond
+           (when (or (seq pairs) (seq co))
+             (mark-settlement-mutating! fork-handle :merge))
+           (let [merged (loop [ps (seq pairs) acc []]
+                          (if ps
+                            (let [[sid sig-ref cval psys] (first ps)
+                                  acc* (cond
                                        ;; OVERLAY fork (convergent :overlay opt + datahike/git): join back.
-                                        (ovl/overlay? cval)
-                                        (let [m (await (ygg/merge-down! cval opts))]
-                                          (set-node-value! parent-ctx sig-ref m)
-                                          (ygg/discard! cval)
-                                          (conj acc sid))
+                                         (ovl/overlay? cval)
+                                         (let [m (await (ygg/merge-down! cval opts))]
+                                           (set-node-value! parent-ctx sig-ref m)
+                                           (ygg/discard! cval)
+                                           (conj acc sid))
 
                                        ;; Managed BRANCH fork: `cval` is a real system on a private
                                        ;; `:fork-<uuid>` or `:snap-<uuid>` branch.
                                        ;; Check out the parent branch (loads its LIVE head for durable stores),
                                        ;; `merge!` the fork branch in, drop the fork branch. Await each (can't
                                        ;; thread-first through CPS on cljs); `mopts` threads `:sync?`.
-                                        (and (satisfies? ygg/Branchable cval)
-                                             (satisfies? ygg/Mergeable cval)
-                                             (managed-fork-branch-name? (ygg/current-branch cval)))
-                                        (let [mopts   (merge yc/default-opts opts)
-                                              fbranch (ygg/current-branch cval)
-                                              pbranch (ygg/current-branch psys)
-                                              co      (await (ygg/checkout cval pbranch mopts))
-                                              mg      (await (ygg/merge! co fbranch mopts))
-                                              m       (await (ygg/delete-branch! mg fbranch mopts))]
-                                          (set-node-value! parent-ctx sig-ref m)
-                                          (conj acc sid))
+                                         (and (satisfies? ygg/Branchable cval)
+                                              (satisfies? ygg/Mergeable cval)
+                                              (managed-branch? fork-handle sid cval))
+                                         (let [mopts   (merge yc/default-opts opts)
+                                               fbranch (ygg/current-branch cval)
+                                               pbranch (ygg/current-branch psys)
+                                               co      (await (ygg/checkout cval pbranch mopts))
+                                               mg      (await (ygg/merge! co fbranch mopts))
+                                               m       (await (ygg/delete-branch! mg fbranch mopts))]
+                                           (set-node-value! parent-ctx sig-ref m)
+                                           (conj acc sid))
 
-                                        :else acc)]
-                             (recur (next ps) acc*))
-                           acc))
-               ;; 3. carry child-only systems into the parent registry + nodes.
-                co (child-only child-ctx parent-ctx)]
-            (doseq [[sid sig-ref] co]
-              (rtp/swap-state! parent-ctx [registry-key] #(assoc (or % {}) sid sig-ref))
-              (rtp/swap-state! parent-ctx [:forkable-signals] #(conj (or % #{}) (:id sig-ref)))
-              (set-node-value! parent-ctx sig-ref (node-value child-ctx sig-ref)))
-            (when-let [cb (:on-merge opts)]
-              (cb {:merged merged :child-only (vec (keys co))
-                   :parent-ctx parent-ctx :child-ctx child-ctx}))
-            {:merged merged :child-only (vec (keys co))}))))))))
+                                         :else acc)]
+                              (recur (next ps) acc*))
+                            acc))]
+            ;; 3. carry child-only systems into the parent registry + nodes.
+             (doseq [[sid sig-ref] co]
+               (rtp/swap-state! parent-ctx [registry-key] #(assoc (or % {}) sid sig-ref))
+               (rtp/swap-state! parent-ctx [:forkable-signals] #(conj (or % #{}) (:id sig-ref)))
+               (set-node-value! parent-ctx sig-ref (node-value child-ctx sig-ref)))
+             {:merged merged :child-only (vec (keys co))
+              :parent-ctx parent-ctx :child-ctx child-ctx}))))))))
 
-(defn discard-from-parent!
-  "Discard a forked context's per-system overlays without merging — `discard!`
+(defn- discard-fork-context!
+  "Discard a ForkHandle's per-system overlays without merging — `discard!`
    each shared overlay (deleting git worktrees / fork branches). Fork-ONLY
    systems have no shared overlay; the `:on-discard` callback receives them so
    an external owner can clean up (delete the store, drop a deferred grant).
 
-   Args:
-     child-ctx - Child ExecutionContext to discard
-     opts      - {:on-discard (fn [{:keys [child-only child-ctx]}])}
-
-   Returns: nil"
-  ([child-ctx] (discard-from-parent! child-ctx {}))
-  ([child-ctx opts]
-   (convey-context
-    (async+sync
-     (:sync? (merge yc/default-opts opts))
-     (async
-      (when-let [parent-ctx (:parent-ctx child-ctx)]
+   Internal substrate operation. Public callers must settle through
+   `discard-fork!`."
+  [fork-handle opts]
+  (let [child-ctx (:child-ctx fork-handle)]
+    (convey-context
+     (async+sync
+      (:sync? (merge yc/default-opts opts))
+      (async
+       (when-let [parent-ctx (:parent-ctx child-ctx)]
+         (let [pairs (shared-pairs child-ctx parent-ctx)
+               co (child-only child-ctx parent-ctx)]
+           (when (seq pairs)
+             (mark-settlement-mutating! fork-handle :discard))
        ;; `discard!` on an overlay is a synchronous no-op (returns nil); `delete-branch!`
        ;; is async — await it. Loop (not doseq) so the await threads on cljs.
-        (loop [ps (seq (shared-pairs child-ctx parent-ctx))]
-          (when ps
-            (let [[_ _ cval _] (first ps)]
-              (cond
-                (ovl/overlay? cval) (ygg/discard! cval)
+           (loop [ps (seq pairs)]
+             (when ps
+               (let [[sid _ cval _] (first ps)]
+                 (cond
+                   (ovl/overlay? cval) (ygg/discard! cval)
                ;; Managed branch fork: drop the private branch (its nodes GC later).
-                (and (satisfies? ygg/Branchable cval)
-                     (managed-fork-branch-name? (ygg/current-branch cval)))
-                (await (ygg/delete-branch! cval (ygg/current-branch cval) (merge yc/default-opts opts)))))
-            (recur (next ps))))
-        (when-let [cb (:on-discard opts)]
-          (let [co (child-only child-ctx parent-ctx)]
-            (cb {:child-only (vec (keys co))
-                 :child-only-systems (into {} (keep (fn [[sid sr]]
-                                                      (when-let [s (ys/effective-system (node-value child-ctx sr))]
-                                                        [sid s])))
-                                           co)
-                 :child-ctx child-ctx}))))
-      nil)))))
-
-;; ForkHandle variants (delegate to the ctx-based ops)
+                   (and (satisfies? ygg/Branchable cval)
+                        (managed-branch? fork-handle sid cval))
+                   (await (ygg/delete-branch! cval (ygg/current-branch cval) (merge yc/default-opts opts)))))
+               (recur (next ps))))
+           {:child-only (vec (keys co))
+            :child-only-systems (into {} (keep (fn [[sid sr]]
+                                                 (when-let [s (ys/effective-system (node-value child-ctx sr))]
+                                                   [sid s])))
+                                      co)
+            :child-ctx child-ctx})))))))
 
 (defn merge-fork!
   "Merge an OPEN fork's overlays to its parent exactly once. Repeating the same
    successful operation returns its cached result; discard/transfer afterwards
-   fails without touching the substrate."
+   fails without touching the substrate. `:on-merge`, when supplied, runs once
+   after terminal settlement; its failure is reported as `:callback-status
+   :failed` and never reopens the already-mutated world."
   ([fork-handle] (merge-fork! fork-handle {}))
   ([fork-handle opts]
-   (settle-fork! fork-handle :merge
-                 #(merge-to-parent! (:child-ctx fork-handle) opts))))
+   (settle-fork! fork-handle :merge opts
+                 #(merge-fork-context! fork-handle (dissoc opts :on-merge))
+                 #(select-keys % [:merged :child-only])
+                 (:on-merge opts))))
 
 (defn discard-fork!
   "Discard an OPEN fork exactly once. Repeating the same successful operation is
-   idempotent and returns the cached result."
+   idempotent and returns the cached result. `:on-discard` has the same
+   post-commit, single-execution semantics as `:on-merge`."
   ([fork-handle] (discard-fork! fork-handle {}))
   ([fork-handle opts]
-   (settle-fork! fork-handle :discard
-                 #(discard-from-parent! (:child-ctx fork-handle) opts))))
+   (settle-fork! fork-handle :discard opts
+                 #(discard-fork-context! fork-handle (dissoc opts :on-discard))
+                 (constantly nil)
+                 (:on-discard opts))))
 
 ;; =============================================================================
 ;; Merge From Parent (Parent → Child sync)
 ;; =============================================================================
 
-(defn merge-from-parent!
+(defn- merge-fork-context-from-parent!
   "Merge the parent's current state INTO a child context (inverse of
-   merge-to-parent!) — for long-lived agent forks that need to stay in sync.
+   merge-fork!) — for long-lived agent forks that need to stay in sync.
    Per shared system, merge the parent's branch into the fork's writable system
    and repoint the fork's ygg-signal. Called from within / on the child context.
 
    Args:
-     child-ctx - The child ExecutionContext to update
-     opts      - Optional merge opts {:strategy … :message …}
+     fork-handle - The open fork to update
+     opts        - Optional merge opts {:strategy … :message …}
 
    Returns: nil"
-  ([child-ctx] (merge-from-parent! child-ctx {}))
-  ([child-ctx opts]
-   (convey-context
-    (async+sync
-     (:sync? (merge yc/default-opts opts))
-     (async
-      (when-let [parent-ctx (:parent-ctx child-ctx)]
+  ([fork-handle] (merge-fork-context-from-parent! fork-handle {}))
+  ([fork-handle opts]
+   (let [child-ctx (:child-ctx fork-handle)]
+     (convey-context
+      (async+sync
+       (:sync? (merge yc/default-opts opts))
+       (async
+      ;; In the CPS mode this check runs when the awaitable executes, so an
+      ;; authority transfer between construction and execution invalidates it.
+        (ensure-open-authority! fork-handle)
+        (when-let [parent-ctx (:parent-ctx child-ctx)]
        ;; Loop (not doseq) so `checkout`/`merge!` await-thread on cljs.
-        (loop [ps (seq (shared-pairs child-ctx parent-ctx))]
-          (when ps
-            (let [[_ sig-ref cval psys] (first ps)
-                  fsys (ys/effective-system cval)]
-              (when (and (satisfies? ygg/Branchable fsys)
-                         (satisfies? ygg/Mergeable fsys))
-                (let [cbranch (ygg/current-branch fsys)
-                      pbranch (ygg/current-branch psys)
+          (loop [ps (seq (filter (fn [[sid _ _ _]]
+                                   (not= :shared (get-in (:descriptor fork-handle)
+                                                         [:fork/systems sid :kind])))
+                                 (shared-pairs child-ctx parent-ctx)))]
+            (when ps
+              (let [[_ sig-ref cval psys] (first ps)
+                    fsys (ys/effective-system cval)]
+                (when (and (satisfies? ygg/Branchable fsys)
+                           (satisfies? ygg/Mergeable fsys))
+                  (let [cbranch (ygg/current-branch fsys)
+                        pbranch (ygg/current-branch psys)
                      ;; thread :sync? — `opts` is a merge-opts map without it; else the
                      ;; JVM async branch seats a CPS continuation (the finding-#3 twin).
-                      mopts   (merge yc/default-opts {:message (str "Merge from " (name pbranch))} opts)
-                      co      (await (ygg/checkout fsys cbranch mopts))
-                      m       (await (ygg/merge! co pbranch mopts))]
+                        mopts   (merge yc/default-opts {:message (str "Merge from " (name pbranch))} opts)
+                        co      (await (ygg/checkout fsys cbranch mopts))
+                        m       (await (ygg/merge! co pbranch mopts))]
                  ;; repoint: if cval is an overlay, update its writable system in
                  ;; place; else repoint the node. (both sync)
-                  (if (ovl/overlay? cval)
-                    (ovl/reseat-overlay! cval m)
-                    (set-node-value! child-ctx sig-ref m)))))
-            (recur (next ps)))))
-      nil)))))
+                    (if (ovl/overlay? cval)
+                      (ovl/reseat-overlay! cval m)
+                      (set-node-value! child-ctx sig-ref m)))))
+              (recur (next ps)))))
+        nil))))))
 
 (defn merge-fork-from-parent!
-  "Merge parent's current state into a fork (ForkHandle variant)."
+  "Merge the parent's current state into an OPEN fork. The ForkHandle is the
+   authority for both settlement directions; raw child contexts cannot bypass it."
   ([fork-handle] (merge-fork-from-parent! fork-handle {}))
   ([fork-handle opts]
-   (ensure-open-authority! fork-handle)
-   (merge-from-parent! (:child-ctx fork-handle) opts)))
+   (merge-fork-context-from-parent! fork-handle opts)))
 
 ;; =============================================================================
 ;; Accessors

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -107,11 +107,9 @@
    natively; a convergent system without a branch map falls back to the system
    unchanged (snapshot fork targets versioned systems for now).
 
-   Returns a plain branched SYSTEM (not an Overlay) — pinned at a PAST value, it
-   is for reproduce/replay/experiment, where you read or run in isolation and
-   drop the `snap-<fork>` branch rather than merge it back. So a snapshot fork
-   is NOT auto-managed by merge-to-parent! / discard-from-parent! (which act on
-   overlays); lifecycle cleanup of snapshot forks is a follow-up."
+   Returns a plain branched SYSTEM (not an Overlay) — pinned at a PAST value.
+   Its `snap-<fork>` branch is managed by the same ForkHandle lifecycle as a
+   regular branch fork: merge explicitly to adopt it, or discard to clean it up."
   [sys fork-id snap-id]
   (if (satisfies? ygg/Branchable sys)
     (let [new-branch (keyword (str "snap-" (name fork-id)))]
@@ -133,6 +131,12 @@
   "True if `b` is a fork branch (engine fork-ids are `:fork-<uuid>` keywords)."
   [b]
   (and b (str/starts-with? (name b) "fork-")))
+
+(defn- managed-fork-branch-name?
+  "True when `b` is a private branch owned by a ForkHandle lifecycle."
+  [b]
+  (and b (or (str/starts-with? (name b) "fork-")
+             (str/starts-with? (name b) "snap-"))))
 
 (defn- branch-fork
   "BRANCH fork (the DEFAULT for convergent systems): a REAL branched system as the
@@ -403,15 +407,172 @@
     x))
 
 ;; =============================================================================
-;; Fork Handle (explicit control)
+;; Fork Handle (explicit affine control)
 ;; =============================================================================
 
-(defrecord ForkHandle [child-ctx parent-ctx fork-id])
+(defrecord ForkHandle [child-ctx parent-ctx fork-id descriptor authority token])
 
 (defn fork-handle?
   "Returns true if x is a ForkHandle."
   [x]
   (instance? ForkHandle x))
+
+(defn fork-descriptor
+  "Portable creation-time description of `fork-handle` plus its current owner and
+   settlement status. The descriptor contains only data; live contexts, callbacks,
+   errors, and the affine authority token never cross this boundary.
+
+   For Snapshotable systems, per-system `:head` is the head observed immediately
+   after fork creation. A durable branch remains the live locator after it
+   advances; a later settlement journal/export API will checkpoint terminal
+   heads for restart recovery. Non-forkable compatibility systems are reported
+   honestly as `:kind :shared` rather than pretending they were isolated."
+  [fork-handle]
+  (let [{:keys [status owner operation]} @(:authority fork-handle)]
+    (cond-> (assoc (:descriptor fork-handle)
+                   :fork/owner owner
+                   :fork/status status)
+      operation (assoc :fork/operation operation))))
+
+(defn fork-disposition
+  "Process-local lifecycle view of a ForkHandle, without its authority token."
+  [fork-handle]
+  (dissoc @(:authority fork-handle) :token :error :last-error))
+
+(defn open-fork?
+  "True when this exact handle still owns the open settlement capability. A
+   transferred handle is stale even though the adopted handle remains open."
+  [fork-handle]
+  (let [{:keys [status token]} @(:authority fork-handle)]
+    (and (= :open status) (= token (:token fork-handle)))))
+
+(defn- authority-error [fork-handle state]
+  (if (not= (:token fork-handle) (:token state))
+    (ex-info "ForkHandle settlement authority was transferred"
+             {:type ::stale-fork-handle
+              :fork-id (:fork-id fork-handle)
+              :owner (:owner state)
+              :status (:status state)})
+    (ex-info "ForkHandle is not open"
+             {:type ::fork-not-open
+              :fork-id (:fork-id fork-handle)
+              :owner (:owner state)
+              :status (:status state)
+              :operation (:operation state)})))
+
+(defn- ensure-open-authority! [fork-handle]
+  (let [state @(:authority fork-handle)]
+    (when-not (and (= :open (:status state))
+                   (= (:token fork-handle) (:token state)))
+      (throw (authority-error fork-handle state))))
+  fork-handle)
+
+(defn transfer-fork!
+  "Transfer an OPEN fork's affine settlement authority to `new-owner`.
+
+   Returns a new ForkHandle over the same child/parent world. The old handle is
+   immediately stale and can no longer merge, discard, transfer, or advance from
+   its parent. No substrate state is copied and no branch is created. This is the
+   primitive a durable proposal/room adoption layer uses after it has persisted
+   ownership and arranged GC retention."
+  [fork-handle new-owner]
+  (when (nil? new-owner)
+    (throw (ex-info "Fork owner cannot be nil"
+                    {:type ::invalid-fork-owner
+                     :fork-id (:fork-id fork-handle)})))
+  (loop []
+    (let [authority (:authority fork-handle)
+          state @authority]
+      (when-not (and (= :open (:status state))
+                     (= (:token fork-handle) (:token state)))
+        (throw (authority-error fork-handle state)))
+      (let [new-token (random-uuid)
+            next-state (assoc state :owner new-owner :token new-token)]
+        (if (compare-and-set! authority state next-state)
+          (assoc fork-handle
+                 :token new-token
+                 :descriptor (assoc (:descriptor fork-handle) :fork/owner new-owner))
+          (recur))))))
+
+(defn- terminal-status [operation]
+  (case operation
+    :merge :merged
+    :discard :discarded
+    (throw (ex-info "Unknown fork settlement operation"
+                    {:type ::invalid-settlement-operation
+                     :operation operation}))))
+
+(defn- claim-settlement! [fork-handle operation]
+  (loop []
+    (let [authority (:authority fork-handle)
+          state @authority]
+      (cond
+        (not= (:token fork-handle) (:token state))
+        (throw (authority-error fork-handle state))
+
+        (= :open (:status state))
+        (let [next-state (assoc state :status :settling :operation operation)]
+          (if (compare-and-set! authority state next-state)
+            {:execute? true}
+            (recur)))
+
+        (and (= (terminal-status operation) (:status state))
+             (= operation (:operation state)))
+        {:execute? false :result (:result state)}
+
+        :else
+        (throw (authority-error fork-handle state))))))
+
+(defn- complete-settlement! [fork-handle operation result]
+  (swap! (:authority fork-handle)
+         (fn [state]
+           (if (and (= (:token fork-handle) (:token state))
+                    (= :settling (:status state))
+                    (= operation (:operation state)))
+             (assoc state :status (terminal-status operation) :result result)
+             state)))
+  result)
+
+(defn- fail-settlement! [fork-handle operation error]
+  (swap! (:authority fork-handle)
+         (fn [state]
+           (if (and (= (:token fork-handle) (:token state))
+                    (= :settling (:status state))
+                    (= operation (:operation state)))
+             ;; A failed attempt does not consume affine authority. Dvergr keeps
+             ;; automatic merge failures for review, where the same owner must be
+             ;; able to retry or discard. A later durable per-system journal makes
+             ;; retry after a mid-settlement process crash recoverable as well.
+             (-> state
+                 (assoc :status :open
+                        :last-operation operation
+                        :last-error error)
+                 (update :settlement-attempts (fnil inc 0))
+                 (dissoc :operation))
+             state)))
+  error)
+
+(defn- settle-fork! [fork-handle operation f]
+  (let [{:keys [execute? result]} (claim-settlement! fork-handle operation)]
+    (if-not execute?
+      result
+      (try
+        (let [x (f)]
+          ;; Durable Yggdrasil ops are values on the JVM and partial-CPS thunks on
+          ;; cljs. Attach the authority transition without changing either public
+          ;; execution shape.
+          (if (fn? x)
+            (fn [resolve reject]
+              (x (fn [value]
+                   (complete-settlement! fork-handle operation value)
+                   (resolve value))
+                 (fn [error]
+                   (fail-settlement! fork-handle operation error)
+                   (reject error))))
+            (complete-settlement! fork-handle operation x)))
+        (catch #?(:clj Throwable :cljs :default) error
+          (fail-settlement! fork-handle operation error)
+          (throw error))))))
 
 (defn fork!
   "Create a forked execution context with every ygg-signal overlaid (or snapshot-
@@ -420,6 +581,10 @@
    opts (optional): forwarded to `ctx/fork-context` —
      :mode      :following (default) | :frozen — overlay fork relation to parent
      :snapshots {system-id -> snapshot-id} — pin those systems at fixed values
+     :systems   :all (default) | :none | #{system-id ...} — systems visible and
+       forked in the child. Excluded systems are hidden, never shared writable.
+     :purpose   portable descriptor tag such as :run/:particle/:proposal
+     :owner     initial affine settlement owner (default parent context fork-id)
      :convergent-fork :branch (default) | :overlay — a CONVERGENT CRDT forks as a
        real yggdrasil BRANCH by default (the natural CRDT API works in the fork: read
        `@ref`, write `g/conj`, `merge-fork!` folds back). `:overlay` forces the live-
@@ -442,17 +607,47 @@
      (:sync? (merge yc/default-opts opts))
      (async
       (let [parent-ctx (ec/current-execution-context)
+            parent-reg (registry parent-ctx)
+            systems-opt (get opts :systems :all)
+            selected-ids (cond
+                           (= :all systems-opt) (set (keys parent-reg))
+                           (= :none systems-opt) #{}
+                           (set? systems-opt) systems-opt
+                           :else (throw (ex-info "Invalid :systems fork policy"
+                                                 {:type ::invalid-systems-policy
+                                                  :systems systems-opt})))
+            unknown (seq (remove #(contains? parent-reg %) selected-ids))
+            _known-systems (when unknown
+                             (throw (ex-info "Fork policy names unregistered systems"
+                                             {:type ::unknown-fork-systems
+                                              :systems (vec unknown)
+                                              :registered (vec (keys parent-reg))})))
+            snapshot-ids (set (keys (:snapshots opts)))
+            _included-snapshots (when-let [excluded (seq (remove selected-ids snapshot-ids))]
+                                  (throw (ex-info "Snapshot policy names systems excluded from the fork"
+                                                  {:type ::excluded-snapshot-systems
+                                                   :systems (vec excluded)})))
+            selected-reg (select-keys parent-reg selected-ids)
+            selected-signal-ids (into #{} (map (comp :id val)) selected-reg)
            ;; translate :snapshots from SYSTEM-id keys (what callers know) to the
            ;; SIGNAL-id keys fork-context forks by.
             snaps  (when-let [s (:snapshots opts)]
                      (into {} (keep (fn [[sid snap]]
-                                      (when-let [sr (get (registry parent-ctx) sid)]
+                                      (when-let [sr (get selected-reg sid)]
                                         [(:id sr) snap])))
                            s))
-            fopts  (cond-> opts snaps (assoc :snapshots snaps))
+            state-updates (merge (:state-updates opts)
+                                 {registry-key selected-reg
+                                  :forkable-signals selected-signal-ids})
+            fopts  (cond-> (-> opts
+                               (dissoc :systems :purpose :owner :rights)
+                               (assoc :state-updates state-updates
+                                      :forkable-signals selected-signal-ids))
+                     snaps (assoc :snapshots snaps))
             child-ctx  (apply ctx/fork-context parent-ctx (mapcat identity fopts))
             fork-id    (:fork-id child-ctx)
-            popts  (merge yc/default-opts opts)]
+            popts  (merge yc/default-opts opts)
+            owner  (or (:owner opts) (:fork-id parent-ctx))]
        ;; POST-PASS (Design B async lift): the engine's `fork-context`/`fork-value`
        ;; hook is SYNCHRONOUS, so a convergent BRANCH fork — durable `branch!`/`checkout`
        ;; that only yield a value synchronously on the JVM — is done here, AWAITED, over
@@ -470,7 +665,49 @@
                       branched (await (ygg/checkout cval fork-id popts))]
                   (set-node-value! child-ctx sig-ref branched))))
             (recur (next ps))))
-        (->ForkHandle child-ctx parent-ctx fork-id)))))))
+        ;; Capture the actual granted per-system fork shape, not merely the
+        ;; requested policy. Versioned systems may degrade :following to :frozen.
+        (let [systems
+              (loop [ps (seq (shared-pairs child-ctx parent-ctx)) acc {}]
+                (if ps
+                  (let [[sid _ cval psys] (first ps)
+                        csys (ys/effective-system cval)
+                        pv (when (satisfies? ygg/Snapshotable psys)
+                             (ygg/snapshot-id psys))
+                        cv (when (satisfies? ygg/Snapshotable csys)
+                             (ygg/snapshot-id csys))
+                        parent-head (if (fn? pv) (await pv) pv)
+                        child-head (if (fn? cv) (await cv) cv)
+                        snapshot? (contains? snapshot-ids sid)
+                        branch (when (satisfies? ygg/Branchable csys)
+                                 (ygg/current-branch csys))
+                        kind (cond snapshot? :snapshot
+                                   (ovl/overlay? cval) :overlay
+                                   (managed-fork-branch-name? branch) :branch
+                                   (= cval psys) :shared
+                                   :else :forked)
+                        entry {:base-snapshot (if (ovl/overlay? cval)
+                                                (ygg/base-ref cval)
+                                                parent-head)
+                               :head child-head
+                               :branch branch
+                               :mode (cond (ovl/overlay? cval) (:mode cval)
+                                           (= :shared kind) :shared
+                                           :else :frozen)
+                               :kind kind
+                               :rights (if (= :shared kind)
+                                         :shared
+                                         (get-in opts [:rights sid] :write))}]
+                    (recur (next ps) (assoc acc sid entry)))
+                  acc))
+              descriptor {:fork/id fork-id
+                          :fork/parent (:fork-id parent-ctx)
+                          :fork/purpose (or (:purpose opts) :unspecified)
+                          :fork/owner owner
+                          :fork/systems systems}
+              token (random-uuid)
+              authority (atom {:status :open :owner owner :token token})]
+          (->ForkHandle child-ctx parent-ctx fork-id descriptor authority token))))))))
 
 ;; `with-fork` is a JVM-only convenience macro. On cljs use the engine form it
 ;; expands to directly: `(ec/with-context (:child-ctx fork) …)`.
@@ -639,12 +876,14 @@
                                           (ygg/discard! cval)
                                           (conj acc sid))
 
-                                       ;; BRANCH-forked convergent: `cval` is a real system on `:fork-<uuid>`.
+                                       ;; Managed BRANCH fork: `cval` is a real system on a private
+                                       ;; `:fork-<uuid>` or `:snap-<uuid>` branch.
                                        ;; Check out the parent branch (loads its LIVE head for durable stores),
                                        ;; `merge!` the fork branch in, drop the fork branch. Await each (can't
                                        ;; thread-first through CPS on cljs); `mopts` threads `:sync?`.
-                                        (and (satisfies? yc/PConvergent cval)
-                                             (fork-branch-name? (ygg/current-branch cval)))
+                                        (and (satisfies? ygg/Branchable cval)
+                                             (satisfies? ygg/Mergeable cval)
+                                             (managed-fork-branch-name? (ygg/current-branch cval)))
                                         (let [mopts   (merge yc/default-opts opts)
                                               fbranch (ygg/current-branch cval)
                                               pbranch (ygg/current-branch psys)
@@ -693,9 +932,9 @@
             (let [[_ _ cval _] (first ps)]
               (cond
                 (ovl/overlay? cval) (ygg/discard! cval)
-               ;; branch-forked convergent: drop the fork branch (its nodes GC later).
-                (and (satisfies? yc/PConvergent cval)
-                     (fork-branch-name? (ygg/current-branch cval)))
+               ;; Managed branch fork: drop the private branch (its nodes GC later).
+                (and (satisfies? ygg/Branchable cval)
+                     (managed-fork-branch-name? (ygg/current-branch cval)))
                 (await (ygg/delete-branch! cval (ygg/current-branch cval) (merge yc/default-opts opts)))))
             (recur (next ps))))
         (when-let [cb (:on-discard opts)]
@@ -711,14 +950,21 @@
 ;; ForkHandle variants (delegate to the ctx-based ops)
 
 (defn merge-fork!
-  "Merge fork's overlays to parent (ForkHandle variant of merge-to-parent!)."
+  "Merge an OPEN fork's overlays to its parent exactly once. Repeating the same
+   successful operation returns its cached result; discard/transfer afterwards
+   fails without touching the substrate."
   ([fork-handle] (merge-fork! fork-handle {}))
-  ([fork-handle opts] (merge-to-parent! (:child-ctx fork-handle) opts)))
+  ([fork-handle opts]
+   (settle-fork! fork-handle :merge
+                 #(merge-to-parent! (:child-ctx fork-handle) opts))))
 
 (defn discard-fork!
-  "Discard fork's overlays (ForkHandle variant of discard-from-parent!)."
+  "Discard an OPEN fork exactly once. Repeating the same successful operation is
+   idempotent and returns the cached result."
   ([fork-handle] (discard-fork! fork-handle {}))
-  ([fork-handle opts] (discard-from-parent! (:child-ctx fork-handle) opts)))
+  ([fork-handle opts]
+   (settle-fork! fork-handle :discard
+                 #(discard-from-parent! (:child-ctx fork-handle) opts))))
 
 ;; =============================================================================
 ;; Merge From Parent (Parent → Child sync)
@@ -768,6 +1014,7 @@
   "Merge parent's current state into a fork (ForkHandle variant)."
   ([fork-handle] (merge-fork-from-parent! fork-handle {}))
   ([fork-handle opts]
+   (ensure-open-authority! fork-handle)
    (merge-from-parent! (:child-ctx fork-handle) opts)))
 
 ;; =============================================================================

--- a/test/org/replikativ/spindel/distributed/composite_join_test.clj
+++ b/test/org/replikativ/spindel/distributed/composite_join_test.clj
@@ -3,7 +3,7 @@
    their per-system ygg-signal VALUES — no parent, no new interface, no privileged
    workspace. Each registered system is a convergent value (PConvergent); merging
    two peers is `(-join (system a) (system b))` per system, seated back into both
-   contexts' ygg-signals. `merge-to-parent!` not involved."
+   contexts' ygg-signals. Hierarchical fork settlement is not involved."
   (:require [clojure.test :refer [deftest testing is]]
             [org.replikativ.spindel.engine.context :as ctx]
             [org.replikativ.spindel.engine.core :as ec]

--- a/test/org/replikativ/spindel/ygg_bridge_portable_test.cljc
+++ b/test/org/replikativ/spindel/ygg_bridge_portable_test.cljc
@@ -10,7 +10,7 @@
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.yggdrasil :as ygg]
             [org.replikativ.spindel.test-helpers :as th]
-            [org.replikativ.spindel.test-async :refer [deftest-async <?]]
+            [org.replikativ.spindel.test-async :refer [deftest-async <? sync?]]
             [yggdrasil.protocols :as yp])
   #?(:cljs (:require-macros [org.replikativ.spindel.test-helpers]
                             [org.replikativ.spindel.test-async :refer [deftest-async <?]])))
@@ -51,3 +51,21 @@
           (is (true? (ygg/unregister! "kb")))
           (is (nil? (ygg/system "kb")))
           (is (= {} (ygg/registered-systems))))))))
+
+(deftest-async settlement-cps-is-lazy-single-execution-and-replayable
+  (th/with-ctx [ctx]
+    (let [fork (<? (ygg/fork! {:systems :none :sync? sync?}))
+          callbacks (atom 0)
+          settlement (ygg/discard-fork! fork {:sync? sync?
+                                              :on-discard (fn [_] (swap! callbacks inc))})]
+      #?(:cljs
+         (is (ygg/open-fork? fork)
+             "constructing the CPS expression does not consume settlement authority"))
+      (is (nil? (<? settlement)))
+      (is (nil? (<? settlement))
+          "invoking the same CPS expression again replays its result")
+      (is (= 1 @callbacks)
+          "the settlement body and callback execute exactly once")
+      (is (nil? (<? (ygg/discard-fork! fork {:sync? sync?})))
+          "a later idempotent call preserves the asynchronous return shape")
+      (is (= :discarded (:status (ygg/fork-disposition fork)))))))

--- a/test/org/replikativ/spindel/ygg_bridge_portable_test.cljc
+++ b/test/org/replikativ/spindel/ygg_bridge_portable_test.cljc
@@ -38,7 +38,11 @@
         (let [fork (<? (ygg/fork!))]
           (is (ygg/fork-handle? fork))
           (is (some? (:child-ctx fork)))
-          (is (some? (:fork-id fork)))))
+          (is (some? (:fork-id fork)))
+          (is (= :shared (get-in (ygg/fork-descriptor fork)
+                                 [:fork/systems "kb" :kind]))
+              "the descriptor does not claim an identity-forked system is isolated")
+          (<? (ygg/discard-fork! fork))))
       ;; post-await: the with-ctx binding has exited across the fork! await (partial-cps
       ;; hands a thunk to its trampoline, so `binding` does not convey), so RE-BIND the
       ;; context for these context-reading ops.

--- a/test/org/replikativ/spindel/yggdrasil_test.clj
+++ b/test/org/replikativ/spindel/yggdrasil_test.clj
@@ -19,6 +19,19 @@
 (def ^:dynamic *test-repo-path* nil)
 (def ^:dynamic *test-git-system* nil)
 
+(defrecord ThrowingOverlay [parent local-writes mode]
+  ygg-proto/Overlayable
+  (advance! [this] this)
+  (advance! [this _] this)
+  (peek-parent [_] parent)
+  (peek-parent [_ _] parent)
+  (base-ref [_] (ygg-proto/snapshot-id parent))
+  (overlay-writes [_] @local-writes)
+  (merge-down! [_] (throw (ex-info "mutation probe" {})))
+  (merge-down! [_ _] (throw (ex-info "mutation probe" {})))
+  (discard! [_] parent)
+  (discard! [_ _] parent))
+
 (defn create-temp-repo
   "Create a temporary git repository for testing."
   []
@@ -294,6 +307,9 @@
           ;; snapshot-fork pinned at state-1
           (let [fork-handle (ygg/fork! {:snapshots {sid snap1}})
                 branch-name (atom nil)]
+            (is (= snap1 (get-in (ygg/fork-descriptor fork-handle)
+                                 [:fork/systems sid :base-snapshot]))
+                "descriptor records the requested historical base, not the live parent head")
             (ygg/with-fork fork-handle
               (let [branch (name (ygg-proto/current-branch @yref))
                     wt     (str (:worktrees-dir @yref) "/" branch)]
@@ -388,24 +404,60 @@
         (is (nil? (ygg/discard-fork! adopted)))
         (is (= :discarded (:status (ygg/fork-disposition adopted))))))))
 
-(deftest test-failed-settlement-attempt-remains-retryable
-  (testing "failure records an attempt without consuming merge/discard authority"
+(deftest test-post-commit-callback-failure-does-not-reopen-settlement
+  (testing "callback failure reports an integration error after the substrate is terminal"
     (th/with-ctx [ctx]
-      (let [fork-handle (ygg/fork! {:systems :none})]
+      (let [yref (ygg/register! *test-git-system*)
+            fork-handle (ygg/fork!)
+            branch-name (atom nil)]
+        (ygg/with-fork fork-handle
+          (let [branch (name (ygg-proto/current-branch @yref))
+                wt (str (:worktrees-dir @yref) "/" branch)]
+            (reset! branch-name (keyword branch))
+            (spit (str wt "/callback-failure.txt") "merged once")
+            (sh "git" "add" "callback-failure.txt" :dir wt)
+            (sh "git" "commit" "-m" "callback failure regression" :dir wt)))
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"injected"
                               (ygg/merge-fork! fork-handle
                                                {:on-merge
                                                 (fn [_]
                                                   (throw (ex-info "injected" {})))})))
-        (is (ygg/open-fork? fork-handle))
-        (is (= {:status :open
-                :owner (:fork-id ctx)
-                :last-operation :merge
-                :settlement-attempts 1}
-               (ygg/fork-disposition fork-handle)))
-        (is (= {:merged [] :child-only []}
+        (is (not (ygg/open-fork? fork-handle)))
+        (is (= :merged (:status (ygg/fork-disposition fork-handle))))
+        (is (= :failed (:callback-status (ygg/fork-disposition fork-handle))))
+        (is (= "injected" (:callback-error (ygg/fork-disposition fork-handle))))
+        (is (.exists (io/file (str (:repo-path @yref) "/callback-failure.txt"))))
+        (is (not (contains? (ygg-proto/branches @yref) @branch-name)))
+        (is (= {:merged [(ygg-proto/system-id @yref)] :child-only []}
                (ygg/merge-fork! fork-handle)))
-        (is (= :merged (:status (ygg/fork-disposition fork-handle))))))))
+        (is (= :failed (:callback-status (ygg/fork-disposition fork-handle))))))))
+
+(deftest test-mutation-failure-does-not-reopen-settlement
+  (testing "a failure after entering the mutation phase requires repair"
+    (th/with-ctx [ctx]
+      (ygg/register! *test-git-system*)
+      (let [sid (ygg-proto/system-id *test-git-system*)
+            parent-system (ygg/system sid)
+            mutation-fork (ygg/fork!)]
+        (ygg/with-fork mutation-fork
+          (reset! (ygg/system-signal sid)
+                  (->ThrowingOverlay parent-system (atom parent-system) :frozen)))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"mutation probe"
+                              (ygg/merge-fork! mutation-fork {:force true})))
+        (is (not (ygg/open-fork? mutation-fork)))
+        (is (= :incomplete (:status (ygg/fork-disposition mutation-fork))))
+        (is (= :mutating (:phase (ygg/fork-disposition mutation-fork))))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not open"
+                              (ygg/discard-fork! mutation-fork)))))))
+
+(deftest test-fork-rights-reject-unenforceable-labels
+  (testing "descriptors never claim rights the runtime does not enforce"
+    (th/with-ctx [ctx]
+      (let [yref (ygg/register! *test-git-system*)
+            sid (ygg-proto/system-id @yref)]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"currently enforceable"
+                              (ygg/fork! {:systems #{sid}
+                                          :rights {sid :read}})))))))
 
 (deftest test-fork-system-selection-hides-unselected-systems
   (testing "only selected registered systems are visible and forked in the child"
@@ -417,6 +469,8 @@
           (let [included (ygg/register! *test-git-system*)
                 excluded (ygg/register! second-system)
                 included-id (ygg-proto/system-id *test-git-system*)
+                excluded-id (ygg-proto/system-id second-system)
+                raw-excluded (ygg/system-signal excluded-id)
                 fork-handle (ygg/fork! {:systems #{included-id}
                                         :purpose :selected-test})
                 descriptor (ygg/fork-descriptor fork-handle)]
@@ -425,7 +479,13 @@
             (ygg/with-fork fork-handle
               (is (some? @included))
               (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not found"
-                                    @excluded)))
+                                    @excluded))
+              (is (nil? @raw-excluded)
+                  "a retained raw SignalRef is tombstoned instead of falling through")
+              (reset! raw-excluded :child-local)
+              (is (= :child-local @raw-excluded)))
+            (is (identical? second-system @raw-excluded)
+                "writes through the retained ref remain child-local")
             (ygg/discard-fork! fork-handle)))
         (finally
           (ctx/stop-context! ctx)
@@ -458,11 +518,10 @@
 ;; =============================================================================
 
 (deftest test-merge-from-parent
-  (testing "merge-from-parent! pulls parent changes into child"
+  (testing "merge-fork-from-parent! pulls parent changes into child"
     (th/with-ctx [ctx]
       (let [yref (ygg/register! *test-git-system*)
-            fork-handle (ygg/fork!)
-            child-ctx (:child-ctx fork-handle)]
+            fork-handle (ygg/fork!)]
 
         ;; Make a change in the parent (simulates another agent's merged work)
         (let [repo-path (:repo-path @yref)
@@ -480,7 +539,7 @@
                 "Child does NOT have parent's file before merge")))
 
         ;; Merge: pull parent's changes into child
-        (ygg/merge-from-parent! child-ctx)
+        (ygg/merge-fork-from-parent! fork-handle)
 
         ;; After merge, child SHOULD have the parent file
         (ygg/with-fork fork-handle
@@ -493,11 +552,10 @@
         (ygg/discard-fork! fork-handle)))))
 
 (deftest test-merge-from-parent-preserves-child-work
-  (testing "merge-from-parent! preserves child's own changes"
+  (testing "merge-fork-from-parent! preserves child's own changes"
     (th/with-ctx [ctx]
       (let [yref (ygg/register! *test-git-system*)
-            fork-handle (ygg/fork!)
-            child-ctx (:child-ctx fork-handle)]
+            fork-handle (ygg/fork!)]
 
         ;; Make a change in the fork first
         (ygg/with-fork fork-handle
@@ -517,7 +575,7 @@
           (sh "git" "commit" "-m" "Parent update" :dir repo-path))
 
         ;; Merge from parent
-        (ygg/merge-from-parent! child-ctx)
+        (ygg/merge-fork-from-parent! fork-handle)
 
         ;; After merge, child should have BOTH files
         (ygg/with-fork fork-handle
@@ -636,20 +694,19 @@
         (ygg/discard-fork! fork-handle)))))
 
 (deftest test-workspace-merge-transactional
-  (testing "merge-to-parent! returns :merged and lands the fork's change"
+  (testing "merge-fork! returns :merged and lands the fork's change"
     (th/with-ctx [ctx]
       (let [yref (ygg/register! *test-git-system*)
             sid  (ygg-proto/system-id *test-git-system*)
-            fork-handle (ygg/fork!)
-            child-ctx (:child-ctx fork-handle)]
+            fork-handle (ygg/fork!)]
         (ygg/with-fork fork-handle
           (let [branch-name (name (ygg-proto/current-branch @yref))
                 wt-path (str (:worktrees-dir @yref) "/" branch-name)]
             (spit (str wt-path "/ws-merge.txt") "merge me")
             (sh "git" "add" "ws-merge.txt" :dir wt-path)
             (sh "git" "commit" "-m" "ws merge commit" :dir wt-path)))
-        (let [result (ygg/merge-to-parent! child-ctx)]
+        (let [result (ygg/merge-fork! fork-handle)]
           (is (contains? (set (:merged result)) sid)
-              "merge-to-parent! reports the merged sub-system")
+              "merge-fork! reports the merged sub-system")
           (is (.exists (io/file (str (:repo-path @yref) "/ws-merge.txt")))
               "fork's file landed in the parent"))))))

--- a/test/org/replikativ/spindel/yggdrasil_test.clj
+++ b/test/org/replikativ/spindel/yggdrasil_test.clj
@@ -292,16 +292,52 @@
           (sh "git" "add" "v2.txt" :dir repo)
           (sh "git" "commit" "-m" "v2" :dir repo)
           ;; snapshot-fork pinned at state-1
-          (let [fork-handle (ygg/fork! {:snapshots {sid snap1}})]
+          (let [fork-handle (ygg/fork! {:snapshots {sid snap1}})
+                branch-name (atom nil)]
             (ygg/with-fork fork-handle
               (let [branch (name (ygg-proto/current-branch @yref))
                     wt     (str (:worktrees-dir @yref) "/" branch)]
+                (reset! branch-name branch)
                 (is (clojure.string/starts-with? branch "snap-")
                     "snapshot fork is on a snap-<fork> branch")
                 (is (.exists (io/file (str wt "/v1.txt")))
                     "the pinned state-1 file is present in the fork")
                 (is (not (.exists (io/file (str wt "/v2.txt"))))
-                    "the parent's later state-2 is NOT present (frozen at the snapshot)")))))))))
+                    "the parent's later state-2 is NOT present (frozen at the snapshot)")))
+            (ygg/discard-fork! fork-handle)
+            (is (not (contains? (ygg-proto/branches @yref) (keyword @branch-name)))
+                "discard cleans up the managed snapshot branch")))))))
+
+(deftest test-snapshot-fork-can-be-adopted
+  (testing "an explicitly merged snapshot experiment joins into the live parent"
+    (th/with-ctx [ctx]
+      (let [yref (ygg/register! *test-git-system*)
+            sid  (ygg-proto/system-id *test-git-system*)
+            repo (:repo-path @yref)]
+        (spit (str repo "/base.txt") "base")
+        (sh "git" "add" "base.txt" :dir repo)
+        (sh "git" "commit" "-m" "base" :dir repo)
+        (let [base (ygg-proto/snapshot-id @yref)]
+          (spit (str repo "/parent.txt") "parent")
+          (sh "git" "add" "parent.txt" :dir repo)
+          (sh "git" "commit" "-m" "parent advance" :dir repo)
+          (let [fork-handle (ygg/fork! {:snapshots {sid base}})
+                branch-name (atom nil)]
+            (ygg/with-fork fork-handle
+              (let [branch (name (ygg-proto/current-branch @yref))
+                    wt     (str (:worktrees-dir @yref) "/" branch)]
+                (reset! branch-name branch)
+                (spit (str wt "/experiment.txt") "adopt me")
+                (sh "git" "add" "experiment.txt" :dir wt)
+                (sh "git" "commit" "-m" "snapshot experiment" :dir wt)))
+            (ygg/merge-fork! fork-handle)
+            (is (.exists (io/file (str repo "/parent.txt")))
+                "the live parent's own advance remains")
+            (is (.exists (io/file (str repo "/experiment.txt")))
+                "the experiment was adopted")
+            (is (not (contains? (ygg-proto/branches @yref) (keyword @branch-name)))
+                "merge cleans up the managed snapshot branch")
+            (is (= :merged (:status (ygg/fork-disposition fork-handle))))))))))
 
 ;; =============================================================================
 ;; ForkHandle Tests
@@ -320,7 +356,102 @@
             "ForkHandle has parent-ctx")
         (is (:fork-id fork-handle)
             "ForkHandle has fork-id")
+        (is (= :open (:fork/status (ygg/fork-descriptor fork-handle))))
         (ygg/discard-fork! fork-handle)))))
+
+(deftest test-fork-handle-settles-exactly-once
+  (testing "the same settlement is idempotent and a competing settlement is refused"
+    (th/with-ctx [ctx]
+      (let [fork-handle (ygg/fork! {:systems :none :purpose :test})]
+        (is (ygg/open-fork? fork-handle))
+        (is (nil? (ygg/discard-fork! fork-handle)))
+        (is (nil? (ygg/discard-fork! fork-handle))
+            "the second discard returns the cached result")
+        (is (= {:status :discarded
+                :owner (:fork-id ctx)
+                :operation :discard
+                :result nil}
+               (ygg/fork-disposition fork-handle)))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not open"
+                              (ygg/merge-fork! fork-handle)))))))
+
+(deftest test-fork-authority-transfer-is-affine
+  (testing "transfer invalidates the old handle and gives the adopter one authority"
+    (th/with-ctx [ctx]
+      (let [original (ygg/fork! {:systems :none :owner :run})
+            adopted  (ygg/transfer-fork! original :proposal)]
+        (is (not (ygg/open-fork? original)))
+        (is (ygg/open-fork? adopted))
+        (is (= :proposal (:fork/owner (ygg/fork-descriptor adopted))))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"transferred"
+                              (ygg/discard-fork! original)))
+        (is (nil? (ygg/discard-fork! adopted)))
+        (is (= :discarded (:status (ygg/fork-disposition adopted))))))))
+
+(deftest test-failed-settlement-attempt-remains-retryable
+  (testing "failure records an attempt without consuming merge/discard authority"
+    (th/with-ctx [ctx]
+      (let [fork-handle (ygg/fork! {:systems :none})]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"injected"
+                              (ygg/merge-fork! fork-handle
+                                               {:on-merge
+                                                (fn [_]
+                                                  (throw (ex-info "injected" {})))})))
+        (is (ygg/open-fork? fork-handle))
+        (is (= {:status :open
+                :owner (:fork-id ctx)
+                :last-operation :merge
+                :settlement-attempts 1}
+               (ygg/fork-disposition fork-handle)))
+        (is (= {:merged [] :child-only []}
+               (ygg/merge-fork! fork-handle)))
+        (is (= :merged (:status (ygg/fork-disposition fork-handle))))))))
+
+(deftest test-fork-system-selection-hides-unselected-systems
+  (testing "only selected registered systems are visible and forked in the child"
+    (let [ctx (ctx/create-execution-context)
+          second-repo-path (create-temp-repo)
+          second-system (git-adapter/create second-repo-path {:system-name "excluded"})]
+      (try
+        (binding [ec/*execution-context* ctx]
+          (let [included (ygg/register! *test-git-system*)
+                excluded (ygg/register! second-system)
+                included-id (ygg-proto/system-id *test-git-system*)
+                fork-handle (ygg/fork! {:systems #{included-id}
+                                        :purpose :selected-test})
+                descriptor (ygg/fork-descriptor fork-handle)]
+            (is (= #{included-id} (set (keys (:fork/systems descriptor))))
+                "the portable descriptor records the selected world")
+            (ygg/with-fork fork-handle
+              (is (some? @included))
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not found"
+                                    @excluded)))
+            (ygg/discard-fork! fork-handle)))
+        (finally
+          (ctx/stop-context! ctx)
+          (cleanup-temp-repo second-repo-path))))))
+
+(deftest test-nested-merge-targets-immediate-parent
+  (testing "an inner merge changes its outer fork but not the root"
+    (th/with-ctx [ctx]
+      (let [yref (ygg/register! *test-git-system*)
+            outer (ygg/fork!)]
+        (ygg/with-fork outer
+          (let [inner (ygg/fork!)]
+            (ygg/with-fork inner
+              (let [branch-name (name (ygg-proto/current-branch @yref))
+                    wt-path (str (:worktrees-dir @yref) "/" branch-name)]
+                (spit (str wt-path "/nested.txt") "nested")
+                (sh "git" "add" "nested.txt" :dir wt-path)
+                (sh "git" "commit" "-m" "nested" :dir wt-path)))
+            (ygg/merge-fork! inner)
+            (let [outer-branch (name (ygg-proto/current-branch @yref))
+                  outer-path (str (:worktrees-dir @yref) "/" outer-branch)]
+              (is (.exists (io/file (str outer-path "/nested.txt")))
+                  "inner contribution landed in the immediate parent"))))
+        (is (not (.exists (io/file (str (:repo-path @yref) "/nested.txt"))))
+            "inner contribution did not skip the outer fork and reach root")
+        (ygg/discard-fork! outer)))))
 
 ;; =============================================================================
 ;; Merge From Parent Tests


### PR DESCRIPTION
## Summary

- make ForkHandle the canonical exactly-once merge/discard authority, with affine ownership transfer
- expose portable fork descriptors and explicit selected-system/snapshot policies
- manage snapshot branches through the same merge/discard lifecycle and preserve nested parent targeting
- keep failed settlement attempts retryable for retained review worlds
- attenuate excluded systems instead of sharing writable references; report legacy identity-forked systems honestly as shared

## Verification

- clojure -M:format
- clojure -M:test — 934 tests, 3213 assertions
- npx shadow-cljs compile test — 413 tests, 1558 assertions
- dependent Dvergr focused suite — 33 tests, 168 assertions
- dependent Dvergr full suite — 518 tests, 2152 assertions
- dependent Dvergr harness uberjar build and --help smoke test

## Follow-ups

Durable per-system settlement journaling and inference particle isolation remain separate passes. This PR establishes the single live capability and portable descriptor they build on.