### PR TITLE
fix: consume cancellation subscriptions atomically

### DIFF
--- a/src/org/replikativ/spindel/effects/await.cljc
+++ b/src/org/replikativ/spindel/effects/await.cljc
@@ -461,7 +461,10 @@
                          (rtp/swap-state! ctx [:engine/cancelled-tokens]
                                           (fn [s] (conj (or s #{}) cancel-token))))
               :resolve-fn wrapped-resolve
-              :reject-fn wrapped-reject
+              ;; Engine cancellation first arms cancel-token and then resumes
+              ;; the body through this raw reject continuation so finally/catch
+              ;; still run. The external resource alone receives wrapped-reject.
+              :reject-fn reject
               ;; on-resume is required for the cont protocol but
               ;; never fires for external-await conts — the engine
               ;; doesn't dispatch on :external-await events.

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -251,7 +251,7 @@
                               :track-subscriptions {} ; Comonadic track continuations (per spin)
                               :await-conts {}        ; Monadic await continuations (per spin)
                               :subscriptions {}      ; Event subscriptions (reverse index of the continuation tables)
-                              :engine/resuming-conts #{} ; Completion claims currently advancing CPS slices
+                              :engine/retired-conts {} ; Exact edges consumed by valid continuation retirement
                               :atoms {}              ; Fork-safe execution context atoms
                               ;; Engine state
                               :engine/pending []
@@ -521,7 +521,7 @@
                                   {:track-subscriptions (or parent-track-subscriptions {}) ; ← Copy parent's track conts!
                                    :await-conts (or parent-await-conts {})                 ; ← Copy parent's await conts!
                                    :subscriptions (or parent-subscriptions {})             ; ← Copy their reverse index!
-                                   :engine/resuming-conts #{} ; in-flight execution is not inherited
+                                   :engine/retired-conts {} ; retirement history is world-local
                                    :engine/pending [] ; ← NO inherited events; see the claim-undo below
                                    :engine/draining? false
                                    :engine/delayed-spins (sorted-map)

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -251,6 +251,7 @@
                               :track-subscriptions {} ; Comonadic track continuations (per spin)
                               :await-conts {}        ; Monadic await continuations (per spin)
                               :subscriptions {}      ; Event subscriptions (reverse index of the continuation tables)
+                              :engine/resuming-conts #{} ; Completion claims currently advancing CPS slices
                               :atoms {}              ; Fork-safe execution context atoms
                               ;; Engine state
                               :engine/pending []
@@ -428,6 +429,11 @@
         ;; parent fallback).
         parent-track-subscriptions (rtp/get-state parent-ctx [:track-subscriptions])
         parent-await-conts (rtp/get-state parent-ctx [:await-conts])
+        ;; Continuations and their reverse index form one graph snapshot. If
+        ;; :subscriptions falls through to the live parent while the cont tables
+        ;; are copied, a fork can observe a post-fork edge whose continuation it
+        ;; can never resume.
+        parent-subscriptions (rtp/get-state parent-ctx [:subscriptions])
 
         ;; The fork inherits NONE of the parent's un-drained events —
         ;; an event is delivered in exactly one world (the parent's).
@@ -514,6 +520,8 @@
         fork-local-state (cond-> (merge
                                   {:track-subscriptions (or parent-track-subscriptions {}) ; ← Copy parent's track conts!
                                    :await-conts (or parent-await-conts {})                 ; ← Copy parent's await conts!
+                                   :subscriptions (or parent-subscriptions {})             ; ← Copy their reverse index!
+                                   :engine/resuming-conts #{} ; in-flight execution is not inherited
                                    :engine/pending [] ; ← NO inherited events; see the claim-undo below
                                    :engine/draining? false
                                    :engine/delayed-spins (sorted-map)

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -120,6 +120,8 @@
     (simple/add-continuation! this spin-id cont))
   (remove-continuation! [this spin-id cont-id]
     (simple/remove-continuation! this spin-id cont-id))
+  (remove-continuation! [this spin-id cont-id opts]
+    (simple/remove-continuation! this spin-id cont-id opts))
   (earliest-continuation [this spin-id signal-id]
     (simple/earliest-continuation this spin-id signal-id))
   (resume-continuation! [this spin-id cont resume-fn]

--- a/src/org/replikativ/spindel/engine/core.cljc
+++ b/src/org/replikativ/spindel/engine/core.cljc
@@ -239,9 +239,13 @@
         cont-with-bindings (assoc cont :bindings captured-bindings)]
     (rtp/add-continuation! ctx spin-id cont-with-bindings)))
 
-(defn ^:no-doc continuation-remove! [spin-id cont-id]
-  (let [ctx (current-execution-context)]
-    (rtp/remove-continuation! ctx spin-id cont-id)))
+(defn ^:no-doc continuation-remove!
+  ([spin-id cont-id]
+   (let [ctx (current-execution-context)]
+     (rtp/remove-continuation! ctx spin-id cont-id)))
+  ([spin-id cont-id opts]
+   (let [ctx (current-execution-context)]
+     (rtp/remove-continuation! ctx spin-id cont-id opts))))
 
 (defn ^:no-doc continuation-earliest [spin-id signal-id]
   (let [ctx (current-execution-context)]
@@ -386,4 +390,3 @@
   (fn [event]
     (binding [*execution-context* ctx]
       (handler-fn event))))
-

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -1044,7 +1044,18 @@
               ;; days of debugging as an unexplained hang. Known cause:
               ;; a fork's [:await-conts] snapshot (context.cljc fork-context)
               ;; not containing a cont the parent registered post-fork.
-              (when (and (nil? cont) (not already-resumed?))
+              ;; Cancellation removes the cont and reverse subscription in one
+              ;; transaction. `cont-ids` was read earlier, so re-check the
+              ;; reverse edge before diagnosing a missing cont: its deliberate
+              ;; removal may have won between those reads.
+              (when (and (nil? cont)
+                         (not already-resumed?)
+                         (contains? (or (rtp/get-state
+                                         context
+                                         [:subscriptions [:spin/complete tid]
+                                          parent-id])
+                                        #{})
+                                    cont-id))
                 (log/warn :engine/spin-completion-cont-missing
                           {:parent-id parent-id :cont-id cont-id :child-id tid
                            :fork-id (:fork-id context)}))
@@ -2562,48 +2573,57 @@
     (get-in new-state [store-key spin-id cont-id])))
 
 (defn remove-continuation!
-  "Remove a continuation from a spin.
+  "Atomically remove and return a continuation from a spin.
 
   TRANSACTIONAL: All state changes happen atomically in a single swap-state! to
-  ensure context consistency for snapshotting.
+  ensure context consistency for snapshotting. Exactly one concurrent caller
+  receives the removed continuation. With `{:cancel? true}`, an external-await
+  cancellation token is armed in the same transaction as removal.
 
   Args:
     context - context record (implements PState protocol)
     spin-id - ID of spin that owns the continuation
     cont-id - ID of continuation to remove
 
-  Returns: true"
-  [context spin-id cont-id]
-  (rtp/swap-state! context []
-                   (fn [rt-state]
-                     (let [;; cont-id alone doesn't carry the kind — look it
-                           ;; up to find which structure it lives in.
-                           cont (or (get-in rt-state [:track-subscriptions spin-id cont-id])
-                                    (get-in rt-state [:await-conts spin-id cont-id]))
-                           store-key (when cont (cont-store-key cont))
-                           event-key (:event-key cont)]
-                       (cond-> rt-state
-            ;; Remove continuation from its kind-routed structure.
-                         store-key
-                         (update-in [store-key spin-id] dissoc cont-id)
-
-            ;; Unregister subscription and clean up empty entries
-                         true
-                         (update :subscriptions
-                                 (fn [subs]
-                                   (let [spin-subs (get-in subs [event-key spin-id])
-                                         spin-subs' (disj (or spin-subs #{}) cont-id)]
-                                     (if (seq spin-subs')
-                          ;; Still have subscriptions for this spin
-                                       (assoc-in subs [event-key spin-id] spin-subs')
-                          ;; No more subscriptions for this spin
-                                       (let [event-subs (dissoc (get subs event-key) spin-id)]
-                                         (if (seq event-subs)
-                              ;; Still have other spins subscribed to this event
-                                           (assoc subs event-key event-subs)
-                              ;; No more spins subscribed to this event
-                                           (dissoc subs event-key)))))))))))
-  true)
+  Returns: the removed continuation, or nil."
+  ([context spin-id cont-id]
+   (remove-continuation! context spin-id cont-id nil))
+  ([context spin-id cont-id {:keys [cancel?]}]
+   (let [removed (volatile! nil)]
+     (rtp/swap-state! context []
+                      (fn [rt-state]
+                        (if-let [cont (or (get-in rt-state
+                                                  [:track-subscriptions spin-id cont-id])
+                                          (get-in rt-state
+                                                  [:await-conts spin-id cont-id]))]
+                          (let [store-key (cont-store-key cont)
+                                event-key (:event-key cont)
+                                spin-subs (get-in rt-state
+                                                  [:subscriptions event-key spin-id])
+                                spin-subs' (disj (or spin-subs #{}) cont-id)
+                                state' (-> rt-state
+                                           (update-in [store-key spin-id] dissoc cont-id)
+                                           (update :subscriptions
+                                                   (fn [subs]
+                                                     (if (seq spin-subs')
+                                                       (assoc-in subs
+                                                                 [event-key spin-id]
+                                                                 spin-subs')
+                                                       (let [event-subs
+                                                             (dissoc (get subs event-key)
+                                                                     spin-id)]
+                                                         (if (seq event-subs)
+                                                           (assoc subs event-key event-subs)
+                                                           (dissoc subs event-key)))))))]
+                            (vreset! removed cont)
+                            (cond-> state'
+                              (and cancel? (:cancel-token cont))
+                              (update-in [:engine/cancelled-tokens]
+                                         (fn [tokens]
+                                           (conj (or tokens #{})
+                                                 (:cancel-token cont))))))
+                          rt-state)))
+     @removed)))
 
 (defn earliest-continuation
   "Get the earliest continuation for a spin subscribed to a signal or

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -143,7 +143,6 @@
 (declare restore-slice-state!)
 (declare claim-continuation-for-resume!)
 (declare release-reactive-resume!)
-(declare release-continuation-resume!)
 (declare remove-continuation!)
 
 (defn- cont-by-cancel-token
@@ -876,6 +875,13 @@
                              (update state :subscriptions dissoc event-key)))))))
   nil)
 
+(defn- legitimately-retired-edge?
+  "True only when this exact continuation/event edge was validly consumed."
+  [context event-key spin-id cont-id]
+  (= event-key
+     (rtp/get-state context
+                    [:engine/retired-conts [spin-id cont-id]])))
+
 (defn process-event!
   "Process a single event.
 
@@ -1067,13 +1073,12 @@
                   cont (when-not already-resumed?
                          (claim-continuation-for-resume!
                           context parent-id cont-id))]
-              ;; A missing cont is a dropped wakeup only when its parent is
-              ;; provably stranded: live/running, no cached result, no concurrent
-              ;; resume owner, and no other continuation to express progress. A
-              ;; terminal parent or one that advanced to its next await can race
-              ;; an event already in flight. Converge that obsolete reverse edge
-              ;; quietly. Always prune it so repeated completion events cannot
-              ;; amplify one stale edge indefinitely.
+              ;; A missing cont is benign only with exact retirement evidence
+              ;; for this [parent cont-id] and event edge. This distinguishes a
+              ;; body that legitimately advanced/cancelled from a multi-await
+              ;; parent whose one missing branch can still strand the join.
+              ;; Always prune the stale reverse edge so repeated completion
+              ;; events cannot amplify it indefinitely.
               (when (and (nil? cont)
                          (not already-resumed?)
                          (contains? (or (rtp/get-state
@@ -1082,23 +1087,13 @@
                                           parent-id])
                                         #{})
                                     cont-id))
-                (let [parent-node (rtp/get-state context [:nodes parent-id])
-                      remaining-conts (spin-continuations
-                                       (rtp/get-state context []) parent-id)
-                      resume-in-flight? (contains?
-                                         (or (rtp/get-state
-                                              context [:engine/resuming-conts])
-                                             #{})
-                                         [parent-id cont-id])
-                      stranded? (and parent-node
-                                     (:running? parent-node)
-                                     (not (:completed? parent-node))
-                                     (nil? (nodes/get-value parent-node))
-                                     (not resume-in-flight?)
-                                     (empty? remaining-conts))]
+                (let [event-key [:spin/complete tid]
+                      legitimately-retired?
+                      (legitimately-retired-edge?
+                       context event-key parent-id cont-id)]
                   (prune-completion-subscription!
-                   context [:spin/complete tid] parent-id cont-id)
-                  (when stranded?
+                   context event-key parent-id cont-id)
+                  (when-not legitimately-retired?
                     (log/warn :engine/spin-completion-cont-missing
                               {:parent-id parent-id :cont-id cont-id :child-id tid
                                :fork-id (:fork-id context)}))))
@@ -1146,11 +1141,9 @@
                                 pcps-async/*in-trampoline* false]
                         (when-let [rj (:reject-fn cont)] (rj e)))
                       (catch #?(:clj Throwable :cljs :default) _ nil))
-                    (remove-continuation! context parent-id cont-id))
-                  (finally
-                    (release-continuation-resume! context parent-id cont-id))))))))
+                    (remove-continuation! context parent-id cont-id))))))))
 
-      ;; Propagate dirty flag through await dependency graph
+;; Propagate dirty flag through await dependency graph
       (propagate-await-dirty! context tid)
       nil)
 
@@ -1730,6 +1723,12 @@
             ;; Clear continuations (both kinds) + transient tracking.
                            (update :track-subscriptions dissoc spin-id)
                            (update :await-conts dissoc spin-id)
+                           (update :engine/retired-conts
+                                   (fn [retired]
+                                     (into {}
+                                           (remove (fn [[[owner-id _] _]]
+                                                     (= owner-id spin-id)))
+                                           retired)))
                            (update :spin-tracking dissoc spin-id)
 
             ;; Clean up subscriptions (remove spin-id from all event keys,
@@ -1788,6 +1787,12 @@
             ;; 5. Remove continuations (both kinds)
                            (update :track-subscriptions dissoc spin-id)
                            (update :await-conts dissoc spin-id)
+                           (update :engine/retired-conts
+                                   (fn [retired]
+                                     (into {}
+                                           (remove (fn [[[owner-id _] _]]
+                                                     (= owner-id spin-id)))
+                                           retired)))
             ;; 6. Remove pending callbacks
                            (update :pending-callbacks dissoc spin-id)
             ;; 7. Remove tracking data
@@ -2623,6 +2628,8 @@
                                                     rt-state spin-id cont-id displaced false)
                                                    rt-state)]
                                        (-> state
+                                           (update :engine/retired-conts
+                                                   dissoc [spin-id cont-id])
                                            (assoc-in [store-key spin-id cont-id] cont')
                                            (update-in [:subscriptions event-key spin-id]
                                                       (fn [s] (conj (or s #{}) cont-id)))))))]
@@ -2645,6 +2652,7 @@
         spin-subs' (disj (or spin-subs #{}) cont-id)
         state' (-> rt-state
                    (update-in [store-key spin-id] dissoc cont-id)
+                   (assoc-in [:engine/retired-conts [spin-id cont-id]] event-key)
                    (update :subscriptions
                            (fn [subs]
                              (if (seq spin-subs')
@@ -2672,38 +2680,24 @@
                      (fn [rt-state]
                        (vreset! claimed nil)
                        (if-let [cont (continuation-at rt-state spin-id cont-id)]
-                         (let [next-state
-                               (cond
-                                 (and (= :await-reactive (:kind cont))
-                                      (not (resume-claimed-key cont)))
-                                 (do
-                                   (vreset! claimed cont)
-                                   (assoc-in rt-state
-                                             [:await-conts spin-id cont-id resume-claimed-key]
-                                             true))
+                         (cond
+                           (and (= :await-reactive (:kind cont))
+                                (not (resume-claimed-key cont)))
+                           (do
+                             (vreset! claimed cont)
+                             (assoc-in rt-state
+                                       [:await-conts spin-id cont-id resume-claimed-key]
+                                       true))
 
-                                 (= :await-reactive (:kind cont))
-                                 rt-state
+                           (= :await-reactive (:kind cont))
+                           rt-state
 
-                                 :else
-                                 (do
-                                   (vreset! claimed cont)
-                                   (detach-continuation rt-state spin-id cont-id cont false)))]
-                           (if @claimed
-                             (update next-state :engine/resuming-conts
-                                     (fn [claims]
-                                       (conj (or claims #{}) [spin-id cont-id])))
-                             next-state))
+                           :else
+                           (do
+                             (vreset! claimed cont)
+                             (detach-continuation rt-state spin-id cont-id cont false)))
                          rt-state)))
     @claimed))
-
-(defn release-continuation-resume!
-  "Release transient ownership of a continuation's CPS resume slice."
-  [context spin-id cont-id]
-  (rtp/swap-state! context [:engine/resuming-conts]
-                   (fn [claims]
-                     (disj (or claims #{}) [spin-id cont-id])))
-  nil)
 
 (defn release-reactive-resume!
   "Release a reactive continuation's in-flight completion claim when it still

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -141,6 +141,9 @@
 (declare clear-all-await-continuations!)
 (declare cache-result!)
 (declare restore-slice-state!)
+(declare claim-continuation-for-resume!)
+(declare release-reactive-resume!)
+(declare remove-continuation!)
 
 (defn- cont-by-cancel-token
   "The `:external-await` cont in `[:await-conts spin-id]` carrying
@@ -151,6 +154,8 @@
   (when (and spin-id cancel-token)
     (first (filter #(= (:cancel-token %) cancel-token)
                    (vals (rtp/get-state context [:await-conts spin-id]))))))
+
+(def ^:private resume-claimed-key ::resume-claimed?)
 
 (defn- slice-context
   "The context a one-shot waiter's slice must resume in: the cont's
@@ -1031,13 +1036,17 @@
             ;; construction — track conts subscribe to [:signal _]. Read
             ;; :await-conts directly: an await resume cannot reach a
             ;; track cont, and the structural split enforces that.
-            (let [cont (rtp/get-state context
-                                      [:await-conts parent-id cont-id])
-                  ;; Generation-based deduplication via batch state (not dynamic bindings)
+            (let [;; Generation-based deduplication via batch state (not dynamic bindings)
                   generation (when batch (:generation batch))
                   dedup-key [parent-id tid generation]
                   already-resumed? (when (and generation batch)
-                                     (contains? @(:resumed-conts batch) dedup-key))]
+                                     (contains? @(:resumed-conts batch) dedup-key))
+                  ;; Completion and external cancellation arbitrate through one
+                  ;; state claim. One-shot awaits are consumed; reactive awaits
+                  ;; retain their graph edge with an in-flight marker.
+                  cont (when-not already-resumed?
+                         (claim-continuation-for-resume!
+                          context parent-id cont-id))]
               ;; A completion whose subscription exists but whose cont entry is
               ;; MISSING is a dropped wakeup — the parent spin will never
               ;; resume. This must be loud, not a silent skip: it has cost
@@ -1059,7 +1068,7 @@
                 (log/warn :engine/spin-completion-cont-missing
                           {:parent-id parent-id :cont-id cont-id :child-id tid
                            :fork-id (:fork-id context)}))
-              (when (and cont (not already-resumed?))
+              (when cont
                 ;; Mark [parent child generation] as resumed
                 (when (and generation batch)
                   (swap! (:resumed-conts batch) conj dedup-key))
@@ -1087,6 +1096,8 @@
                 ;; backstop but should no longer fire for resume throws.
                 (try
                   (resume-body! context parent-id cont :await)
+                  (when (= :await-reactive (:kind cont))
+                    (release-reactive-resume! context parent-id cont-id))
                   (catch #?(:clj Throwable :cljs :default) e
                     #?(:clj (when (instance? InterruptedException e)
                               (.interrupt (Thread/currentThread))))
@@ -1101,8 +1112,7 @@
                                 pcps-async/*in-trampoline* false]
                         (when-let [rj (:reject-fn cont)] (rj e)))
                       (catch #?(:clj Throwable :cljs :default) _ nil))
-                    (rtp/swap-state! context [:await-conts parent-id]
-                                     (fn [m] (dissoc m cont-id))))))))))
+                    (remove-continuation! context parent-id cont-id))))))))
 
       ;; Propagate dirty flag through await dependency graph
       (propagate-await-dirty! context tid)
@@ -1206,8 +1216,11 @@
             cancelled-tokens (rtp/get-state context [:engine/cancelled-tokens])
             cancelled? (or (and spin-id (ec/spin-is-cancelled? spin-id))
                            (and cancel-token cancelled-tokens
-                                (contains? cancelled-tokens cancel-token)))]
-        (if cancelled?
+                                (contains? cancelled-tokens cancel-token)))
+            cont (cont-by-cancel-token context spin-id cancel-token)
+            claimed (when (and (not cancelled?) cont)
+                      (remove-continuation! context spin-id (:id cont)))]
+        (if (or cancelled? (and cont (nil? claimed)))
           (do
             ;; Self-cleaning: consuming the cancelled waiter's token (same
             ;; contract as the pop-time skip in post-inline!).
@@ -1229,7 +1242,9 @@
           ;; drain's. `slice-context` restores the owning cont's
           ;; `:slice-state` (bindings + chain-head + dep tracking); the
           ;; re-binding is what the resumed body code actually reads.
-          (let [rctx (slice-context context spin-id cancel-token)]
+          (let [rctx (if (:slice-state claimed)
+                       (restore-slice-state! context spin-id claimed)
+                       context)]
             (binding [ec/*execution-context* rctx]
               (guarded-resume! rctx site spin-id cancel-token resolve value))
             nil))))
@@ -2572,6 +2587,74 @@
     (when-let [c! @displaced-cancel] (c! context))
     (get-in new-state [store-key spin-id cont-id])))
 
+(defn- continuation-at [rt-state spin-id cont-id]
+  (or (get-in rt-state [:track-subscriptions spin-id cont-id])
+      (get-in rt-state [:await-conts spin-id cont-id])))
+
+(defn- detach-continuation
+  "Pure removal of `cont` and its reverse subscription from runtime state."
+  [rt-state spin-id cont-id cont cancel?]
+  (let [store-key (cont-store-key cont)
+        event-key (:event-key cont)
+        spin-subs (get-in rt-state [:subscriptions event-key spin-id])
+        spin-subs' (disj (or spin-subs #{}) cont-id)
+        state' (-> rt-state
+                   (update-in [store-key spin-id] dissoc cont-id)
+                   (update :subscriptions
+                           (fn [subs]
+                             (if (seq spin-subs')
+                               (assoc-in subs [event-key spin-id] spin-subs')
+                               (let [event-subs (dissoc (get subs event-key)
+                                                        spin-id)]
+                                 (if (seq event-subs)
+                                   (assoc subs event-key event-subs)
+                                   (dissoc subs event-key)))))))]
+    (cond-> state'
+      (and cancel? (:cancel-token cont))
+      (update-in [:engine/cancelled-tokens]
+                 (fn [tokens]
+                   (conj (or tokens #{}) (:cancel-token cont)))))))
+
+(defn claim-continuation-for-resume!
+  "Atomically arbitrate completion against cancellation.
+
+  One-shot/external awaits are detached and returned to exactly one caller.
+  Reactive awaits remain registered but are marked in-flight so cancellation
+  can remove the future graph edge without invoking the same CPS slice."
+  [context spin-id cont-id]
+  (let [claimed (volatile! nil)]
+    (rtp/swap-state! context []
+                     (fn [rt-state]
+                       (vreset! claimed nil)
+                       (if-let [cont (continuation-at rt-state spin-id cont-id)]
+                         (cond
+                           (and (= :await-reactive (:kind cont))
+                                (not (resume-claimed-key cont)))
+                           (do
+                             (vreset! claimed cont)
+                             (assoc-in rt-state
+                                       [:await-conts spin-id cont-id resume-claimed-key]
+                                       true))
+
+                           (= :await-reactive (:kind cont))
+                           rt-state
+
+                           :else
+                           (do
+                             (vreset! claimed cont)
+                             (detach-continuation rt-state spin-id cont-id cont false)))
+                         rt-state)))
+    @claimed))
+
+(defn release-reactive-resume!
+  "Release a reactive continuation's in-flight completion claim when it still
+  exists. Cancellation may have removed it while the resumed slice ran."
+  [context spin-id cont-id]
+  (rtp/swap-state! context [:await-conts spin-id cont-id]
+                   (fn [cont]
+                     (when cont (dissoc cont resume-claimed-key))))
+  nil)
+
 (defn remove-continuation!
   "Atomically remove and return a continuation from a spin.
 
@@ -2592,36 +2675,21 @@
    (let [removed (volatile! nil)]
      (rtp/swap-state! context []
                       (fn [rt-state]
-                        (if-let [cont (or (get-in rt-state
-                                                  [:track-subscriptions spin-id cont-id])
-                                          (get-in rt-state
-                                                  [:await-conts spin-id cont-id]))]
-                          (let [store-key (cont-store-key cont)
-                                event-key (:event-key cont)
-                                spin-subs (get-in rt-state
-                                                  [:subscriptions event-key spin-id])
-                                spin-subs' (disj (or spin-subs #{}) cont-id)
-                                state' (-> rt-state
-                                           (update-in [store-key spin-id] dissoc cont-id)
-                                           (update :subscriptions
-                                                   (fn [subs]
-                                                     (if (seq spin-subs')
-                                                       (assoc-in subs
-                                                                 [event-key spin-id]
-                                                                 spin-subs')
-                                                       (let [event-subs
-                                                             (dissoc (get subs event-key)
-                                                                     spin-id)]
-                                                         (if (seq event-subs)
-                                                           (assoc subs event-key event-subs)
-                                                           (dissoc subs event-key)))))))]
-                            (vreset! removed cont)
-                            (cond-> state'
-                              (and cancel? (:cancel-token cont))
-                              (update-in [:engine/cancelled-tokens]
-                                         (fn [tokens]
-                                           (conj (or tokens #{})
-                                                 (:cancel-token cont))))))
+                        ;; swap!/overlay transactions may retry. Clear an earlier
+                        ;; failed attempt's capture before inspecting this attempt.
+                        (vreset! removed nil)
+                        (if-let [cont (continuation-at rt-state spin-id cont-id)]
+                          (do
+                            ;; A completion that already linearized on this
+                            ;; reactive cont owns its current CPS invocation.
+                            ;; Cancellation removes future reactivity but marks
+                            ;; the descriptor so the canceller does not reject
+                            ;; the same slice concurrently.
+                            (vreset! removed
+                                     (cond-> cont
+                                       (resume-claimed-key cont)
+                                       (assoc ::resume-in-flight? true)))
+                            (detach-continuation rt-state spin-id cont-id cont cancel?))
                           rt-state)))
      @removed)))
 

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -866,13 +866,33 @@
                    (fn [state]
                      (let [spin-subs (get-in state [:subscriptions event-key spin-id])
                            spin-subs' (disj (or spin-subs #{}) cont-id)]
-                       (if (seq spin-subs')
-                         (assoc-in state [:subscriptions event-key spin-id] spin-subs')
-                         (let [event-subs (dissoc (get-in state [:subscriptions event-key])
-                                                  spin-id)]
-                           (if (seq event-subs)
-                             (assoc-in state [:subscriptions event-key] event-subs)
-                             (update state :subscriptions dissoc event-key)))))))
+                       (->
+                        (if (seq spin-subs')
+                          (assoc-in state [:subscriptions event-key spin-id] spin-subs')
+                          (let [event-subs (dissoc (get-in state [:subscriptions event-key])
+                                                   spin-id)]
+                            (if (seq event-subs)
+                              (assoc-in state [:subscriptions event-key] event-subs)
+                              (update state :subscriptions dissoc event-key))))
+                        (update :engine/retired-conts
+                                dissoc [spin-id cont-id])))))
+  nil)
+
+(defn- sweep-retired-continuations!
+  "Retain retirement evidence only for completion events still pending."
+  [context]
+  (let [pending-event-keys
+        (into #{}
+              (keep (fn [event]
+                      (when (= :spin-completion (:type event))
+                        [:spin/complete (:id event)])))
+              (rtp/get-state context [:engine/pending]))]
+    (rtp/swap-state! context [:engine/retired-conts]
+                     (fn [retired]
+                       (into {}
+                             (filter (fn [[_ edge]]
+                                       (contains? pending-event-keys edge)))
+                             retired))))
   nil)
 
 (defn- legitimately-retired-edge?
@@ -1415,11 +1435,14 @@
                                         (catch #?(:clj Throwable :cljs :default) _))))
 
                                   nil)))
+                            (sweep-retired-continuations! context)
                             (swap! event-count inc)
                             (recur))
                           ;; Queue empty — drain complete.
                           (do
                             (log/trace :engine/drain-complete {:events-processed @event-count})
+                            (rtp/swap-state! context [:engine/retired-conts]
+                                             (constantly {}))
                             @event-count))))))
                 (finally
                   ;; Always release draining lock.

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -143,6 +143,7 @@
 (declare restore-slice-state!)
 (declare claim-continuation-for-resume!)
 (declare release-reactive-resume!)
+(declare release-continuation-resume!)
 (declare remove-continuation!)
 
 (defn- cont-by-cancel-token
@@ -659,6 +660,8 @@
   (merge (get-in state [:track-subscriptions spin-id])
          (get-in state [:await-conts spin-id])))
 
+(declare detach-continuation)
+
 (defn- truncate-stale-conts!
   "Drop a spin's continuations whose `:order` is strictly greater than the
   resumed continuation's, then re-track the signal deps of the conts whose
@@ -682,8 +685,7 @@
         skipped-signal-ids (->> (vals all-conts)
                                 (filter #(< (:order %) cont-order))
                                 (keep :signal-id))
-        cancelled-conts (filter #(> (:order %) cont-order) (vals all-conts))
-        keep-kept (fn [conts] (into {} (filter (fn [[_k v]] (<= (:order v) cont-order)) conts)))]
+        cancelled-conts (filter #(> (:order %) cont-order) (vals all-conts))]
     ;; Fire cancellation hooks BEFORE state mutation so orphaned closures
     ;; observe cancellation the moment the external resource calls them.
     ;; Pass the current context — under Option A (state-backed cancel
@@ -694,9 +696,11 @@
       (when-let [cancel! (:cancel! c)] (cancel! context)))
     (rtp/swap-state! context []
                      (fn [state]
-                       (-> state
-                           (update-in [:track-subscriptions spin-id] keep-kept)
-                           (update-in [:await-conts spin-id] keep-kept))))
+                       (reduce (fn [next-state stale]
+                                 (detach-continuation
+                                  next-state spin-id (:id stale) stale false))
+                               state
+                               cancelled-conts)))
     (doseq [skipped-sid skipped-signal-ids]
       (track-signal-dep! context spin-id skipped-sid))))
 
@@ -855,6 +859,22 @@
               (if (seq grandparents)
                 (recur (first grandparents) (conj visited current))
                 current))))))))
+
+(defn- prune-completion-subscription!
+  "Remove a reverse completion edge whose continuation no longer exists."
+  [context event-key spin-id cont-id]
+  (rtp/swap-state! context []
+                   (fn [state]
+                     (let [spin-subs (get-in state [:subscriptions event-key spin-id])
+                           spin-subs' (disj (or spin-subs #{}) cont-id)]
+                       (if (seq spin-subs')
+                         (assoc-in state [:subscriptions event-key spin-id] spin-subs')
+                         (let [event-subs (dissoc (get-in state [:subscriptions event-key])
+                                                  spin-id)]
+                           (if (seq event-subs)
+                             (assoc-in state [:subscriptions event-key] event-subs)
+                             (update state :subscriptions dissoc event-key)))))))
+  nil)
 
 (defn process-event!
   "Process a single event.
@@ -1047,16 +1067,13 @@
                   cont (when-not already-resumed?
                          (claim-continuation-for-resume!
                           context parent-id cont-id))]
-              ;; A completion whose subscription exists but whose cont entry is
-              ;; MISSING is a dropped wakeup — the parent spin will never
-              ;; resume. This must be loud, not a silent skip: it has cost
-              ;; days of debugging as an unexplained hang. Known cause:
-              ;; a fork's [:await-conts] snapshot (context.cljc fork-context)
-              ;; not containing a cont the parent registered post-fork.
-              ;; Cancellation removes the cont and reverse subscription in one
-              ;; transaction. `cont-ids` was read earlier, so re-check the
-              ;; reverse edge before diagnosing a missing cont: its deliberate
-              ;; removal may have won between those reads.
+              ;; A missing cont is a dropped wakeup only when its parent is
+              ;; provably stranded: live/running, no cached result, no concurrent
+              ;; resume owner, and no other continuation to express progress. A
+              ;; terminal parent or one that advanced to its next await can race
+              ;; an event already in flight. Converge that obsolete reverse edge
+              ;; quietly. Always prune it so repeated completion events cannot
+              ;; amplify one stale edge indefinitely.
               (when (and (nil? cont)
                          (not already-resumed?)
                          (contains? (or (rtp/get-state
@@ -1065,9 +1082,26 @@
                                           parent-id])
                                         #{})
                                     cont-id))
-                (log/warn :engine/spin-completion-cont-missing
-                          {:parent-id parent-id :cont-id cont-id :child-id tid
-                           :fork-id (:fork-id context)}))
+                (let [parent-node (rtp/get-state context [:nodes parent-id])
+                      remaining-conts (spin-continuations
+                                       (rtp/get-state context []) parent-id)
+                      resume-in-flight? (contains?
+                                         (or (rtp/get-state
+                                              context [:engine/resuming-conts])
+                                             #{})
+                                         [parent-id cont-id])
+                      stranded? (and parent-node
+                                     (:running? parent-node)
+                                     (not (:completed? parent-node))
+                                     (nil? (nodes/get-value parent-node))
+                                     (not resume-in-flight?)
+                                     (empty? remaining-conts))]
+                  (prune-completion-subscription!
+                   context [:spin/complete tid] parent-id cont-id)
+                  (when stranded?
+                    (log/warn :engine/spin-completion-cont-missing
+                              {:parent-id parent-id :cont-id cont-id :child-id tid
+                               :fork-id (:fork-id context)}))))
               (when cont
                 ;; Mark [parent child generation] as resumed
                 (when (and generation batch)
@@ -1112,7 +1146,9 @@
                                 pcps-async/*in-trampoline* false]
                         (when-let [rj (:reject-fn cont)] (rj e)))
                       (catch #?(:clj Throwable :cljs :default) _ nil))
-                    (remove-continuation! context parent-id cont-id))))))))
+                    (remove-continuation! context parent-id cont-id))
+                  (finally
+                    (release-continuation-resume! context parent-id cont-id))))))))
 
       ;; Propagate dirty flag through await dependency graph
       (propagate-await-dirty! context tid)
@@ -2568,6 +2604,7 @@
         store-key (cont-store-key cont)
         new-state (rtp/swap-state! context []
                                    (fn [rt-state]
+                                     (reset! displaced-cancel nil)
                                      (let [track-conts (get-in rt-state [:track-subscriptions spin-id])
                                            await-conts (get-in rt-state [:await-conts spin-id])
                                            order (inc (+ (count track-conts) (count await-conts)))
@@ -2576,8 +2613,16 @@
                                            _     (when-let [c! (:cancel! displaced)]
                                                    (reset! displaced-cancel c!))
                                            cont' (-> cont (assoc :id cont-id :order order))
-                                           event-key (:event-key cont')]
-                                       (-> rt-state
+                                           event-key (:event-key cont')
+                                           ;; A deterministic source-location ID may be
+                                           ;; reused when a body advances to a different
+                                           ;; child. Remove both halves of the old graph
+                                           ;; edge before attaching the replacement.
+                                           state (if displaced
+                                                   (detach-continuation
+                                                    rt-state spin-id cont-id displaced false)
+                                                   rt-state)]
+                                       (-> state
                                            (assoc-in [store-key spin-id cont-id] cont')
                                            (update-in [:subscriptions event-key spin-id]
                                                       (fn [s] (conj (or s #{}) cont-id)))))))]
@@ -2627,32 +2672,48 @@
                      (fn [rt-state]
                        (vreset! claimed nil)
                        (if-let [cont (continuation-at rt-state spin-id cont-id)]
-                         (cond
-                           (and (= :await-reactive (:kind cont))
-                                (not (resume-claimed-key cont)))
-                           (do
-                             (vreset! claimed cont)
-                             (assoc-in rt-state
-                                       [:await-conts spin-id cont-id resume-claimed-key]
-                                       true))
+                         (let [next-state
+                               (cond
+                                 (and (= :await-reactive (:kind cont))
+                                      (not (resume-claimed-key cont)))
+                                 (do
+                                   (vreset! claimed cont)
+                                   (assoc-in rt-state
+                                             [:await-conts spin-id cont-id resume-claimed-key]
+                                             true))
 
-                           (= :await-reactive (:kind cont))
-                           rt-state
+                                 (= :await-reactive (:kind cont))
+                                 rt-state
 
-                           :else
-                           (do
-                             (vreset! claimed cont)
-                             (detach-continuation rt-state spin-id cont-id cont false)))
+                                 :else
+                                 (do
+                                   (vreset! claimed cont)
+                                   (detach-continuation rt-state spin-id cont-id cont false)))]
+                           (if @claimed
+                             (update next-state :engine/resuming-conts
+                                     (fn [claims]
+                                       (conj (or claims #{}) [spin-id cont-id])))
+                             next-state))
                          rt-state)))
     @claimed))
+
+(defn release-continuation-resume!
+  "Release transient ownership of a continuation's CPS resume slice."
+  [context spin-id cont-id]
+  (rtp/swap-state! context [:engine/resuming-conts]
+                   (fn [claims]
+                     (disj (or claims #{}) [spin-id cont-id])))
+  nil)
 
 (defn release-reactive-resume!
   "Release a reactive continuation's in-flight completion claim when it still
   exists. Cancellation may have removed it while the resumed slice ran."
   [context spin-id cont-id]
-  (rtp/swap-state! context [:await-conts spin-id cont-id]
-                   (fn [cont]
-                     (when cont (dissoc cont resume-claimed-key))))
+  (rtp/swap-state! context [:await-conts spin-id]
+                   (fn [conts]
+                     (if (contains? conts cont-id)
+                       (update conts cont-id dissoc resume-claimed-key)
+                       conts)))
   nil)
 
 (defn remove-continuation!

--- a/src/org/replikativ/spindel/engine/protocols.cljc
+++ b/src/org/replikativ/spindel/engine/protocols.cljc
@@ -65,7 +65,10 @@
   (add-continuation! [ctx spin-id cont]
     "Attach a continuation descriptor to spin-id.")
   (remove-continuation! [ctx spin-id cont-id]
-    "Detach continuation by id.")
+    [ctx spin-id cont-id opts]
+    "Atomically detach and return a continuation by id, or nil when already
+     absent. With `{:cancel? true}`, arm a state-backed external-await token in
+     the same transaction so external delivery cannot race cancellation.")
   (earliest-continuation [ctx spin-id signal-id]
     "Return earliest applicable continuation descriptor for (spin-id, signal-id), or nil.")
   (resume-continuation! [ctx spin-id cont resume-fn]

--- a/src/org/replikativ/spindel/engine/state_backend.cljc
+++ b/src/org/replikativ/spindel/engine/state_backend.cljc
@@ -122,6 +122,20 @@
    (some #(= deleted (get-in overlay (subvec (vec path) 0 %)))
          (range 1 (inc (count path))))))
 
+(defn- revive-deleted-path
+  "Replace tombstoned prefixes so a nested update can safely descend.
+
+  Strict ancestors become maps; a tombstone at the target becomes nil so the
+  caller's update function observes the same value as backend-read."
+  [overlay path]
+  (reduce (fn [state depth]
+            (let [prefix (subvec (vec path) 0 depth)]
+              (if (= deleted (get-in state prefix))
+                (assoc-in state prefix (when (< depth (count path)) {}))
+                state)))
+          overlay
+          (range 1 (inc (count path)))))
+
 (defn- merged-overlay-state
   "Materialize the shallow entity-level overlay view, applying tombstones."
   [parent-state overlay local-paths]
@@ -315,7 +329,9 @@
           ;; Fork-local path (no parent fallback by design) or root
           ;; backend (no parent): direct write.
           (get-in
-           (swap! overlay-atom update-in path f)
+           (swap! overlay-atom
+                  (fn [ov]
+                    (update-in (revive-deleted-path ov path) path f)))
            path)))))
 
   (backend-write-2! [_ path-a path-b f2]

--- a/src/org/replikativ/spindel/engine/state_backend.cljc
+++ b/src/org/replikativ/spindel/engine/state_backend.cljc
@@ -94,12 +94,14 @@
 
   Fork-local state:
   - :track-subscriptions / :await-conts - Continuations specific to this fork
+  - :subscriptions - Reverse index for those continuations; it must share their
+    snapshot boundary or a fork can observe a parent registration without the
+    matching continuation
   - :engine/* - Engine execution state (pending queue, draining flag, timers)
 
   Shared state (falls back to parent):
   - :nodes - Signal and spin nodes (shared observer graph for reactive invalidation)
   - :spin-tracking - Dependency tracking (transient accumulator)
-  - :subscriptions - Event subscriptions
   - :atoms - Runtime atoms
 
   :listeners is fork-local AND deliberately NOT copied into a fork by
@@ -107,7 +109,8 @@
   This is load-bearing: a listener is side-effecting egress (publish/notify), so a
   fork must not inherit-then-fire the parent's listener on a fork-private mutation
   (that would leak speculative state). A fork that wants to egress adds its own."
-  #{:track-subscriptions :await-conts :engine/pending :engine/draining?
+  #{:track-subscriptions :await-conts :subscriptions :engine/resuming-conts
+    :engine/pending :engine/draining?
     :engine/delayed-spins :engine/timer-handles :listeners})
 
 (def ^:private deleted ::deleted)
@@ -182,6 +185,8 @@
         (swap! overlay-atom
                (fn [ov]
                  (let [parent-state (when parent-backend
+                                      ;; Recursively materialized by the
+                                      ;; overlay backend implementation.
                                       (backend-deref parent-backend))
                        merged (merged-overlay-state parent-state ov)
                        new-state (f merged)
@@ -320,7 +325,12 @@
                                   (vec (take 2 path)) ;; entity-level CoW
                                   path)]
                   (if (not= ::not-found (get-in ov seed-path ::not-found))
-                    ov
+                    (if (= deleted (get-in ov seed-path))
+                      ;; A whole-state transaction removed this entity.
+                      ;; Revive an empty fork-local entity before assoc-in
+                      ;; descends through the tombstone.
+                      (assoc-in ov seed-path {})
+                      ov)
                     (if-some [parent-val (backend-read parent-backend seed-path)]
                       (assoc-in ov seed-path parent-val)
                       ov)))))]
@@ -337,9 +347,13 @@
     nil)
 
   (backend-deref [_]
-    ;; Return overlay only (not merged with parent)
-    ;; This is intentional - deref shows what's in this layer
-    @overlay-atom)
+    ;; The protocol promises the entire state for inspection and snapshots.
+    ;; Materialize recursively so nested overlays include inherited entities
+    ;; and every ancestor's tombstones. Diagnostics that need only this sparse
+    ;; layer can inspect :overlay-atom directly.
+    (merged-overlay-state
+     (when parent-backend (backend-deref parent-backend))
+     @overlay-atom))
 
   (backend-type [_]
     :overlay))

--- a/src/org/replikativ/spindel/engine/state_backend.cljc
+++ b/src/org/replikativ/spindel/engine/state_backend.cljc
@@ -6,7 +6,8 @@
   - RefBackend: STM transactional state (ref-based, JVM only)
   - ImmutableBackend: Readonly snapshots (serializable)
   - OverlayBackend: Fork with delta storage (memory efficient)"
-  (:require [incognito.edn :refer [read-string-safe]]))
+  (:require [clojure.set :as set]
+            [incognito.edn :refer [read-string-safe]]))
 
 ;; =============================================================================
 ;; Protocol
@@ -109,6 +110,38 @@
   #{:track-subscriptions :await-conts :engine/pending :engine/draining?
     :engine/delayed-spins :engine/timer-handles :listeners})
 
+(def ^:private deleted ::deleted)
+
+(defn- deleted-ancestor?
+  "True when an overlay path or one of its prefixes is an explicit tombstone."
+  [overlay path]
+  (boolean
+   (some #(= deleted (get-in overlay (subvec (vec path) 0 %)))
+         (range 1 (inc (count path))))))
+
+(defn- merged-overlay-state
+  "Materialize the shallow entity-level overlay view, applying tombstones."
+  [parent-state overlay]
+  (reduce-kv
+   (fn [state top-key overlay-value]
+     (cond
+       (= deleted overlay-value)
+       (dissoc state top-key)
+
+       (and (map? (get state top-key)) (map? overlay-value))
+       (assoc state top-key
+              (reduce-kv (fn [entities entity-id entity-value]
+                           (if (= deleted entity-value)
+                             (dissoc entities entity-id)
+                             (assoc entities entity-id entity-value)))
+                         (or (get state top-key) {})
+                         overlay-value))
+
+       :else
+       (assoc state top-key overlay-value)))
+   (or parent-state {})
+   overlay))
+
 (defn fork-local-path?
   "Check if path is fork-local (should not fall back to parent).
 
@@ -127,59 +160,69 @@
       ;; Fork-local: overlay only, no parent fallback
       (get-in @overlay-atom path)
       ;; Shared state: check overlay, fall back to parent
-      (let [overlay-val (get-in @overlay-atom path ::not-found)]
-        (if (not= overlay-val ::not-found)
-          overlay-val
-          (when parent-backend
-            (backend-read parent-backend path))))))
+      (let [overlay @overlay-atom
+            overlay-val (get-in overlay path ::not-found)]
+        (cond
+          (deleted-ancestor? overlay path) nil
+          (not= overlay-val ::not-found) overlay-val
+          parent-backend (backend-read parent-backend path)
+          :else nil))))
 
   (backend-write! [this path f]
     ;; All writes go to overlay
     ;; CRITICAL: For shared state, use copy-on-write at entity level (e.g., full node)
     (if (empty? path)
       ;; Empty path = full state transaction
-      ;; Detect changes at ENTITY level (depth 2) to preserve sparse overlay
-      (let [parent-state (when parent-backend (backend-deref parent-backend))
-            overlay-state @overlay-atom
-            ;; Deep merge: overlay entities override parent entities
-            merged (merge-with (fn [parent-val overlay-val]
-                                 (if (and (map? parent-val) (map? overlay-val))
-                                   (merge parent-val overlay-val)
-                                   overlay-val))
-                               parent-state
-                               overlay-state)
-            ;; Apply function to merged view
-            new-state (f merged)
-            ;; Find changed ENTITIES (depth 2: [:nodes spin-1], [:signals sig-1])
-            ;; not just changed top-level keys (depth 1: :nodes, :signals)
-            changed-entities (reduce
-                              (fn [acc top-key]
-                                (let [old-map (get merged top-key)
-                                      new-map (get new-state top-key)]
-                                  (if (and (map? old-map) (map? new-map))
-                                    ;; Both are maps - check entity-level changes
-                                    (reduce (fn [acc2 entity-id]
-                                              (let [old-entity (get old-map entity-id)
-                                                    new-entity (get new-map entity-id)]
-                                                (if (not= old-entity new-entity)
-                                                  (conj acc2 [[top-key entity-id] new-entity])
-                                                  acc2)))
-                                            acc
-                                            (keys new-map))
-                                    ;; Not entity maps - write whole top-level value if changed
-                                    (if (not= old-map new-map)
-                                      (conj acc [[top-key] new-map])
-                                      acc))))
-                              []
-                              (keys new-state))]
-        ;; Write only changed entities to overlay (preserves sparseness!)
+      ;; Apply `f` INSIDE the overlay CAS. The prior implementation computed
+      ;; from @overlay-atom before swap!, so two whole-state transactions could
+      ;; both claim the same continuation. Removed inherited entities are
+      ;; written as nil tombstones; omission would fall through to the parent
+      ;; backend and resurrect the removed subscription/continuation.
+      (let [committed (volatile! nil)]
         (swap! overlay-atom
                (fn [ov]
-                 (reduce (fn [acc [path val]]
-                           (assoc-in acc path val))
-                         ov
-                         changed-entities)))
-        new-state)
+                 (let [parent-state (when parent-backend
+                                      (backend-deref parent-backend))
+                       merged (merged-overlay-state parent-state ov)
+                       new-state (f merged)
+                       top-keys (set/union (set (keys merged))
+                                           (set (keys new-state)))
+                       changes
+                       (reduce
+                        (fn [acc top-key]
+                          (let [old-value (get merged top-key)
+                                new-value (get new-state top-key)]
+                            (if (and (map? old-value) (map? new-value))
+                              (reduce
+                               (fn [acc' entity-id]
+                                 (let [old-entity (get old-value entity-id)
+                                       present? (contains? new-value entity-id)
+                                       new-entity (when present?
+                                                    (get new-value entity-id))]
+                                   (if (= old-entity new-entity)
+                                     acc'
+                                     (conj acc'
+                                           [[top-key entity-id]
+                                            (if present? new-entity deleted)]))))
+                               acc
+                               (set/union (set (keys old-value))
+                                          (set (keys new-value))))
+                              (if (= old-value new-value)
+                                acc
+                                (conj acc [[top-key]
+                                           (if (contains? new-state top-key)
+                                             new-value
+                                             deleted)])))))
+                        []
+                        top-keys)]
+                   ;; Reset on every retry; only the invocation whose CAS commits
+                   ;; determines the auxiliary return value.
+                   (vreset! committed new-state)
+                   (reduce (fn [next-ov [changed-path value]]
+                             (assoc-in next-ov changed-path value))
+                           ov
+                           changes))))
+        @committed)
 
       ;; Non-empty path
       ;; CRITICAL: All writes must be atomic (f runs inside swap!) to prevent
@@ -204,7 +247,9 @@
                                                      (get-in ov entity-path ::not-found))
                         ;; If entity not in overlay, copy from parent first
                             ov (if entity-in-overlay?
-                                 ov
+                                 (if (= deleted (get-in ov entity-path))
+                                   (assoc-in ov entity-path {})
+                                   ov)
                                  (if-let [parent-entity (when parent-backend
                                                           (backend-read parent-backend entity-path))]
                                    (assoc-in ov entity-path parent-entity)
@@ -247,7 +292,10 @@
                                (if-some [parent-val (backend-read parent-backend path)]
                                  (assoc-in ov path parent-val)
                                  ov))]
-                      (assoc-in ov path (f (get-in ov path))))))
+                      (assoc-in ov path
+                                (f (if (= deleted (get-in ov path))
+                                     nil
+                                     (get-in ov path)))))))
            path)
 
           :else
@@ -279,7 +327,10 @@
       (swap! overlay-atom
              (fn [ov]
                (let [ov (-> ov (seed path-a) (seed path-b))
-                     [a' b'] (f2 (get-in ov path-a) (get-in ov path-b))]
+                     read-local (fn [path]
+                                  (when-not (deleted-ancestor? ov path)
+                                    (get-in ov path)))
+                     [a' b'] (f2 (read-local path-a) (read-local path-b))]
                  (-> ov
                      (assoc-in path-a a')
                      (assoc-in path-b b'))))))

--- a/src/org/replikativ/spindel/engine/state_backend.cljc
+++ b/src/org/replikativ/spindel/engine/state_backend.cljc
@@ -109,7 +109,7 @@
   This is load-bearing: a listener is side-effecting egress (publish/notify), so a
   fork must not inherit-then-fire the parent's listener on a fork-private mutation
   (that would leak speculative state). A fork that wants to egress adds its own."
-  #{:track-subscriptions :await-conts :subscriptions :engine/resuming-conts
+  #{:track-subscriptions :await-conts :subscriptions :engine/retired-conts
     :engine/pending :engine/draining?
     :engine/delayed-spins :engine/timer-handles :listeners})
 
@@ -124,25 +124,31 @@
 
 (defn- merged-overlay-state
   "Materialize the shallow entity-level overlay view, applying tombstones."
-  [parent-state overlay]
+  [parent-state overlay local-paths]
   (reduce-kv
    (fn [state top-key overlay-value]
      (cond
        (= deleted overlay-value)
        (dissoc state top-key)
 
-       (and (map? (get state top-key)) (map? overlay-value))
+       (map? overlay-value)
        (assoc state top-key
               (reduce-kv (fn [entities entity-id entity-value]
                            (if (= deleted entity-value)
                              (dissoc entities entity-id)
                              (assoc entities entity-id entity-value)))
-                         (or (get state top-key) {})
+                         (if (map? (get state top-key))
+                           (get state top-key)
+                           {})
                          overlay-value))
 
        :else
        (assoc state top-key overlay-value)))
-   (or parent-state {})
+   ;; Fork-local top-level keys are authoritative in this layer. They were
+   ;; copied explicitly at fork creation (or initialized empty) and must never
+   ;; re-import values the parent registered afterward during a whole-state
+   ;; transaction.
+   (apply dissoc (or parent-state {}) local-paths)
    overlay))
 
 (defn fork-local-path?
@@ -161,7 +167,9 @@
     ;; Special handling for fork-local state (don't fall back to parent)
     (if (and (seq path) (fork-local-path? (first path) local-paths))
       ;; Fork-local: overlay only, no parent fallback
-      (get-in @overlay-atom path)
+      (let [overlay @overlay-atom]
+        (when-not (deleted-ancestor? overlay path)
+          (get-in overlay path)))
       ;; Shared state: check overlay, fall back to parent
       (let [overlay @overlay-atom
             overlay-val (get-in overlay path ::not-found)]
@@ -188,7 +196,7 @@
                                       ;; Recursively materialized by the
                                       ;; overlay backend implementation.
                                       (backend-deref parent-backend))
-                       merged (merged-overlay-state parent-state ov)
+                       merged (merged-overlay-state parent-state ov local-paths)
                        new-state (f merged)
                        top-keys (set/union (set (keys merged))
                                            (set (keys new-state)))
@@ -353,7 +361,8 @@
     ;; layer can inspect :overlay-atom directly.
     (merged-overlay-state
      (when parent-backend (backend-deref parent-backend))
-     @overlay-atom))
+     @overlay-atom
+     local-paths))
 
   (backend-type [_]
     :overlay))

--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -656,44 +656,41 @@
     ;; runs (and the parked continuation + external reader leak). Actively unwind it
     ;; by delivering the cancellation into its parked await continuation — the
     ;; structured-concurrency contract (`finally`/`ensure` runs on cancel).
-    (doseq [[cont-id cont] conts]
-      ;; Consume the parked continuation and its reverse subscription as one
-      ;; state transition before resuming user cleanup or cancelling children.
-      ;; A child completion can be enqueued synchronously by either action.  If
-      ;; only the cont is dissociated afterwards, that completion observes a
-      ;; stale [:subscriptions [:spin/complete child]] entry and reports a
-      ;; missing continuation even though cancellation intentionally spent it.
-      (ec/continuation-remove! sid cont-id)
-      (case (:kind cont)
+    (doseq [cont-id (keys conts)]
+      ;; Atomically claim the parked continuation, remove its reverse
+      ;; subscription, and arm an external cancellation token before resuming
+      ;; user cleanup or cancelling children. Only the winning concurrent
+      ;; canceller receives `cont`; all others skip it.
+      (when-let [cont (ec/continuation-remove! sid cont-id {:cancel? true})]
+        (case (:kind cont)
         ;; Parked on a Deferred / Mailbox / async-thunk: invoking the cont's reject
         ;; continuation resumes the body into its reject path so catch/finally run.
         ;; Then arm the external-resource cancellation gate (so a later delivery on
         ;; the abandoned reader is a no-op) and drop the now-spent cont.
-        :external-await
-        (do (try
-              (binding [ec/*execution-context* ctx
-                        ec/*spin-id*          sid
-                        pcps-async/*in-trampoline* false]
-                (when-let [rj (:reject-fn cont)] (rj err)))
-              (catch #?(:clj Throwable :cljs :default) _ nil))
-            (when-let [c! (:cancel! cont)]
-              (try (c! ctx) (catch #?(:clj Throwable :cljs :default) _ nil))))
+          :external-await
+          (do (try
+                (binding [ec/*execution-context* ctx
+                          ec/*spin-id*          sid
+                          pcps-async/*in-trampoline* false]
+                  (when-let [rj (:reject-fn cont)] (rj err)))
+                (catch #?(:clj Throwable :cljs :default) _ nil))
+              nil)
         ;; Parked awaiting a child spin (incl. a reactive aseq/PSpin): resume THIS
         ;; parent into reject directly — the cont's :reject-fn is the parent body's
         ;; raw reject continuation, so invoking it unwinds the parent's try/finally
         ;; without depending on the child driving a :spin-completion resume (which a
         ;; reactive await won't, on cancel). Then cascade-cancel the awaited child so
         ;; it terminates too, and drop the spent cont.
-        (:await-once :await-reactive)
-        (do (try
-              (binding [ec/*execution-context* ctx
-                        ec/*spin-id*          sid
-                        pcps-async/*in-trampoline* false]
-                (when-let [rj (:reject-fn cont)] (rj err)))
-              (catch #?(:clj Throwable :cljs :default) _ nil))
-            (when-let [child (:awaited-spin cont)]
-              (cancel-spin! child)))
-        nil))
+          (:await-once :await-reactive)
+          (do (try
+                (binding [ec/*execution-context* ctx
+                          ec/*spin-id*          sid
+                          pcps-async/*in-trampoline* false]
+                  (when-let [rj (:reject-fn cont)] (rj err)))
+                (catch #?(:clj Throwable :cljs :default) _ nil))
+              (when-let [child (:awaited-spin cont)]
+                (cancel-spin! child)))
+          nil)))
     ;; (3) Cascade into combinator-owned children. A fan-out combinator
     ;; (`race`/`parallel`) starts its children via manual `make-spin` callbacks,
     ;; so during the initial fan-out window they are held outside the await-cont

--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -662,35 +662,43 @@
       ;; user cleanup or cancelling children. Only the winning concurrent
       ;; canceller receives `cont`; all others skip it.
       (when-let [cont (ec/continuation-remove! sid cont-id {:cancel? true})]
-        (case (:kind cont)
+        (if (::simple/resume-in-flight? cont)
+          ;; Completion linearized first and owns this reactive CPS slice.
+          ;; Remove its future graph edge, but do not reject the same slice.
+          ;; Cooperative cancellation is already cached on the parent and will
+          ;; be observed at its next await point.
+          (when-let [child (:awaited-spin cont)]
+            (when (nil? (ec/spin-current-result (spin-id child)))
+              (cancel-spin! child)))
+          (case (:kind cont)
         ;; Parked on a Deferred / Mailbox / async-thunk: invoking the cont's reject
         ;; continuation resumes the body into its reject path so catch/finally run.
         ;; Then arm the external-resource cancellation gate (so a later delivery on
         ;; the abandoned reader is a no-op) and drop the now-spent cont.
-          :external-await
-          (do (try
-                (binding [ec/*execution-context* ctx
-                          ec/*spin-id*          sid
-                          pcps-async/*in-trampoline* false]
-                  (when-let [rj (:reject-fn cont)] (rj err)))
-                (catch #?(:clj Throwable :cljs :default) _ nil))
-              nil)
+            :external-await
+            (do (try
+                  (binding [ec/*execution-context* ctx
+                            ec/*spin-id*          sid
+                            pcps-async/*in-trampoline* false]
+                    (when-let [rj (:reject-fn cont)] (rj err)))
+                  (catch #?(:clj Throwable :cljs :default) _ nil))
+                nil)
         ;; Parked awaiting a child spin (incl. a reactive aseq/PSpin): resume THIS
         ;; parent into reject directly — the cont's :reject-fn is the parent body's
         ;; raw reject continuation, so invoking it unwinds the parent's try/finally
         ;; without depending on the child driving a :spin-completion resume (which a
         ;; reactive await won't, on cancel). Then cascade-cancel the awaited child so
         ;; it terminates too, and drop the spent cont.
-          (:await-once :await-reactive)
-          (do (try
-                (binding [ec/*execution-context* ctx
-                          ec/*spin-id*          sid
-                          pcps-async/*in-trampoline* false]
-                  (when-let [rj (:reject-fn cont)] (rj err)))
-                (catch #?(:clj Throwable :cljs :default) _ nil))
-              (when-let [child (:awaited-spin cont)]
-                (cancel-spin! child)))
-          nil)))
+            (:await-once :await-reactive)
+            (do (try
+                  (binding [ec/*execution-context* ctx
+                            ec/*spin-id*          sid
+                            pcps-async/*in-trampoline* false]
+                    (when-let [rj (:reject-fn cont)] (rj err)))
+                  (catch #?(:clj Throwable :cljs :default) _ nil))
+                (when-let [child (:awaited-spin cont)]
+                  (cancel-spin! child)))
+            nil))))
     ;; (3) Cascade into combinator-owned children. A fan-out combinator
     ;; (`race`/`parallel`) starts its children via manual `make-spin` callbacks,
     ;; so during the initial fan-out window they are held outside the await-cont

--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -657,6 +657,13 @@
     ;; by delivering the cancellation into its parked await continuation — the
     ;; structured-concurrency contract (`finally`/`ensure` runs on cancel).
     (doseq [[cont-id cont] conts]
+      ;; Consume the parked continuation and its reverse subscription as one
+      ;; state transition before resuming user cleanup or cancelling children.
+      ;; A child completion can be enqueued synchronously by either action.  If
+      ;; only the cont is dissociated afterwards, that completion observes a
+      ;; stale [:subscriptions [:spin/complete child]] entry and reports a
+      ;; missing continuation even though cancellation intentionally spent it.
+      (ec/continuation-remove! sid cont-id)
       (case (:kind cont)
         ;; Parked on a Deferred / Mailbox / async-thunk: invoking the cont's reject
         ;; continuation resumes the body into its reject path so catch/finally run.
@@ -670,8 +677,7 @@
                 (when-let [rj (:reject-fn cont)] (rj err)))
               (catch #?(:clj Throwable :cljs :default) _ nil))
             (when-let [c! (:cancel! cont)]
-              (try (c! ctx) (catch #?(:clj Throwable :cljs :default) _ nil)))
-            (ec/swap-state! [:await-conts sid] (fn [m] (dissoc m cont-id))))
+              (try (c! ctx) (catch #?(:clj Throwable :cljs :default) _ nil))))
         ;; Parked awaiting a child spin (incl. a reactive aseq/PSpin): resume THIS
         ;; parent into reject directly — the cont's :reject-fn is the parent body's
         ;; raw reject continuation, so invoking it unwinds the parent's try/finally
@@ -686,8 +692,7 @@
                 (when-let [rj (:reject-fn cont)] (rj err)))
               (catch #?(:clj Throwable :cljs :default) _ nil))
             (when-let [child (:awaited-spin cont)]
-              (cancel-spin! child))
-            (ec/swap-state! [:await-conts sid] (fn [m] (dissoc m cont-id))))
+              (cancel-spin! child)))
         nil))
     ;; (3) Cascade into combinator-owned children. A fan-out combinator
     ;; (`race`/`parallel`) starts its children via manual `make-spin` callbacks,

--- a/test/org/replikativ/spindel/engine/cont_cancellation_test.cljc
+++ b/test/org/replikativ/spindel/engine/cont_cancellation_test.cljc
@@ -503,3 +503,68 @@
                    "cancellation atomically removes the await cont and its reverse index")))
            (finally
              (ctx/close-context! execution-ctx)))))))
+
+#?(:clj
+   (deftest external-await-is-gated-before-cancellation-cleanup
+     (testing "a finally block that synchronously delivers the abandoned resource
+            cannot resume the post-await slice during cancellation"
+       (let [execution-ctx (ctx/create-execution-context)]
+         (try
+           (binding [ec/*execution-context* execution-ctx]
+             (let [gate (sync/deferred)
+                   after-await (atom 0)
+                   cleanups (atom 0)
+                   worker (spin
+                           (try
+                             (await gate)
+                             (swap! after-await inc)
+                             (finally
+                               (swap! cleanups inc)
+                               (sync/deliver! gate :delivered-by-cleanup))))]
+               (sp/spawn! worker)
+               (Thread/sleep 80)
+               (spin-core/cancel-spin! worker)
+               (simple/await-drain-complete! execution-ctx :timeout-ms 2000)
+               (is (= 1 @cleanups) "the raw reject continuation runs finally once")
+               (is (zero? @after-await)
+                   "the atomically armed external gate rejects synchronous delivery")))
+           (finally
+             (ctx/close-context! execution-ctx)))))))
+
+#?(:clj
+   (deftest concurrent-cancellers-claim-a-parked-continuation-once
+     (testing "two cancellers racing on one parent run each cleanup and child
+            cascade at most once"
+       (let [execution-ctx (ctx/create-execution-context)]
+         (try
+           (binding [ec/*execution-context* execution-ctx]
+             (let [gate (sync/deferred)
+                   parent-cleanups (atom 0)
+                   child-cleanups (atom 0)
+                   child (spin
+                          (try
+                            (await gate)
+                            (finally (swap! child-cleanups inc))))
+                   parent (spin
+                           (try
+                             (await child)
+                             (finally (swap! parent-cleanups inc))))
+                   start (promise)]
+               (sp/spawn! parent)
+               (Thread/sleep 80)
+               (let [cancel (fn []
+                              (future
+                                @start
+                                (binding [ec/*execution-context* execution-ctx]
+                                  (spin-core/cancel-spin! parent))))
+                     a (cancel)
+                     b (cancel)]
+                 (deliver start true)
+                 @a
+                 @b)
+               (simple/await-drain-complete! execution-ctx :timeout-ms 2000)
+               (is (= 1 @parent-cleanups) "one canceller claimed the parent cont")
+               (is (= 1 @child-cleanups) "the child cancellation cascade ran once")
+               (is (empty? (stale-spin-completion-subscriptions execution-ctx)))))
+           (finally
+             (ctx/close-context! execution-ctx)))))))

--- a/test/org/replikativ/spindel/engine/cont_cancellation_test.cljc
+++ b/test/org/replikativ/spindel/engine/cont_cancellation_test.cljc
@@ -36,6 +36,18 @@
             [is.simm.partial-cps.sequence :refer [anext]]
             [org.replikativ.spindel.core :as sp]))
 
+(defn- stale-spin-completion-subscriptions
+  "Reverse subscription entries whose owning await continuation is gone."
+  [context]
+  (let [state (rtp/get-state context [])]
+    (vec
+     (for [[[event-type child-id] parents] (:subscriptions state)
+           :when (= :spin/complete event-type)
+           [parent-id cont-ids] parents
+           cont-id cont-ids
+           :when (nil? (get-in state [:await-conts parent-id cont-id]))]
+       {:child-id child-id :parent-id parent-id :cont-id cont-id}))))
+
 #?(:clj
    (deftest no-double-side-effect-after-track-resume-mid-deferred-await
      (testing "When a parent body's track-cont is resumed mid `(await deferred)`,
@@ -473,3 +485,21 @@
            (let [res (ec/get-state [:nodes (spin-core/spin-id winner) :result])]
              (is (or (nil? res) (= :ok (:variant res)))
                  "winner child's cached result was not overwritten by a stray cancel")))))))
+
+#?(:clj
+   (deftest race-cancellation-consumes-continuation-and-reverse-subscription
+     (testing "a race loser cancelled while awaiting a child leaves no reverse
+            subscription pointing at its intentionally consumed continuation"
+       (let [execution-ctx (ctx/create-execution-context)]
+         (try
+           (binding [ec/*execution-context* execution-ctx]
+             (let [fast (spin (await (comb/sleep 10 :fast)))
+                   slow (spin (await (comb/sleep 5000 :slow)))
+                   root (spin (await (comb/race fast slow)))]
+               (is (= :fast (deref root 2000 ::timeout)))
+               (simple/await-drain-complete! execution-ctx :timeout-ms 2000)
+               (is (spin-core/spin-cancelled? slow))
+               (is (empty? (stale-spin-completion-subscriptions execution-ctx))
+                   "cancellation atomically removes the await cont and its reverse index")))
+           (finally
+             (ctx/close-context! execution-ctx)))))))

--- a/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
+++ b/test/org/replikativ/spindel/engine/lost_wakeup_test.cljc
@@ -276,7 +276,27 @@
          (is (= [:w] (:waiters (backend/backend-read parent [:atoms :mbx :value])))
              "parent's copy is untouched (fork diverged)")
          (is (= [{:ev 1}] (backend/backend-read fork [:engine/pending]))
-             "fork-local pending written directly — parent's queue not read")))))
+             "fork-local pending written directly — parent's queue not read")))
+     (testing "OverlayBackend: two-path handoff revives an entity tombstone"
+       (let [parent (backend/create-atom-backend
+                     {:atoms {:mbx {:value {:queue []}}}
+                      :engine/pending []})
+             fork (backend/create-overlay-backend parent)]
+         ;; Whole-state cleanup creates an explicit entity tombstone so the
+         ;; inherited mailbox cannot fall through from the parent.
+         (backend/backend-write! fork [] #(update % :atoms dissoc :mbx))
+         (is (nil? (backend/backend-read fork [:atoms :mbx])))
+         (backend/backend-write-2! fork [:atoms :mbx :value] [:engine/pending]
+                                   (fn [_ pending]
+                                     [{:queue [:late]}
+                                      (conj (vec pending) {:ev :late})]))
+         (is (= {:queue [:late]}
+                (backend/backend-read fork [:atoms :mbx :value])))
+         (is (= [{:ev :late}]
+                (backend/backend-read fork [:engine/pending])))
+         (is (= {:queue []}
+                (backend/backend-read parent [:atoms :mbx :value]))
+             "revival remains isolated from the parent")))))
 
 ;; -----------------------------------------------------------------------------
 ;; 4c. Forkability: in-flight data-bearing events are inherited by forks

--- a/test/org/replikativ/spindel/runtime_protocols_test.clj
+++ b/test/org/replikativ/spindel/runtime_protocols_test.clj
@@ -343,6 +343,41 @@
         (finally
           (ctx/close-context! context))))))
 
+(deftest retirement-evidence-is-bounded-by-pending-completions
+  (testing "fresh continuation IDs do not accumulate as historical state"
+    (let [context (ctx/create-execution-context)
+          spin-id :long-lived-await-loop
+          sweep! (ns-resolve 'org.replikativ.spindel.engine.impl.simple
+                             'sweep-retired-continuations!)]
+      (try
+        (dotimes [i 200]
+          (let [cont-id (keyword (str "fresh-cont-" i))
+                child-id (keyword (str "fresh-child-" i))]
+            (rtp/add-continuation!
+             context spin-id
+             {:id cont-id
+              :event-key [:spin/complete child-id]
+              :kind :await-once
+              :on-resume identity
+              :resolve-fn identity
+              :reject-fn identity})
+            (is (some? (simple/claim-continuation-for-resume!
+                        context spin-id cont-id)))))
+        (is (= 200 (count (rtp/get-state context [:engine/retired-conts]))))
+        (rtp/swap-state! context [:engine/pending]
+                         (constantly [{:type :spin-completion
+                                       :id :fresh-child-199}]))
+        (sweep! context)
+        (is (= {[spin-id :fresh-cont-199]
+                [:spin/complete :fresh-child-199]}
+               (rtp/get-state context [:engine/retired-conts]))
+            "only evidence relevant to queued work survives the sweep")
+        (rtp/swap-state! context [:engine/pending] (constantly []))
+        (sweep! context)
+        (is (empty? (rtp/get-state context [:engine/retired-conts])))
+        (finally
+          (ctx/close-context! context))))))
+
 (deftest truncating-stale-continuations-detaches-reverse-edges
   (testing "reactive resume truncates both halves of every later await edge"
     (let [context (ctx/create-execution-context)
@@ -505,6 +540,13 @@
                 (is (nil? (simple/process-event!
                            fork-2 {:type :spin-completion :id child-b}))
                     "late completion treats the fork-local tombstone as absent")
+                (rtp/swap-state! fork-2 [:await-conts spin-id]
+                                 (fn [conts]
+                                   (assoc (or conts {}) :revived {:kind :await-once})))
+                (is (= :await-once
+                       (rtp/get-state
+                        fork-2 [:await-conts spin-id :revived :kind]))
+                    "a fork-local write can revive a tombstoned entity")
                 (is (nil? (rtp/get-state
                            fork-2 [:await-conts spin-id :nested-cont-a]))
                     "the parent fork's tombstone remains materialized")

--- a/test/org/replikativ/spindel/runtime_protocols_test.clj
+++ b/test/org/replikativ/spindel/runtime_protocols_test.clj
@@ -293,13 +293,53 @@
         (is (= :new-child
                (-> (rtp/get-state context [:await-conts spin-id cont-id])
                    :event-key second)))
+        (is (nil? (rtp/get-state
+                   context [:engine/retired-conts [spin-id cont-id]]))
+            "re-attaching a deterministic ID clears its old retirement")
         (is (some? (simple/claim-continuation-for-resume!
                     context spin-id cont-id)))
-        (is (contains? (rtp/get-state context [:engine/resuming-conts])
-                       [spin-id cont-id]))
-        (simple/release-continuation-resume! context spin-id cont-id)
-        (is (not (contains? (rtp/get-state context [:engine/resuming-conts])
-                            [spin-id cont-id])))
+        (is (= [:spin/complete :new-child]
+               (rtp/get-state
+                context [:engine/retired-conts [spin-id cont-id]]))
+            "a consumed edge carries explicit retirement evidence")
+        (finally
+          (ctx/close-context! context))))))
+
+(deftest retirement-evidence-distinguishes-missing-parallel-branch
+  (testing "a live sibling continuation does not excuse an unretired missing edge"
+    (let [context (ctx/create-execution-context)
+          spin-id :parallel-parent
+          missing-id :missing-branch
+          sibling-id :live-sibling
+          missing-event [:spin/complete :missing-child]
+          classifier (ns-resolve 'org.replikativ.spindel.engine.impl.simple
+                                 'legitimately-retired-edge?)]
+      (try
+        (rtp/add-continuation!
+         context spin-id
+         {:id sibling-id
+          :event-key [:spin/complete :sibling-child]
+          :kind :await-reactive
+          :on-resume identity
+          :resolve-fn identity
+          :reject-fn identity})
+        (rtp/swap-state! context [:subscriptions missing-event spin-id]
+                         (constantly #{missing-id}))
+        (is (false? (classifier context missing-event spin-id missing-id))
+            "unrelated progress cannot hide a genuinely missing branch")
+
+        (rtp/add-continuation!
+         context spin-id
+         {:id missing-id
+          :event-key missing-event
+          :kind :await-once
+          :on-resume identity
+          :resolve-fn identity
+          :reject-fn identity})
+        (is (some? (simple/claim-continuation-for-resume!
+                    context spin-id missing-id)))
+        (is (true? (classifier context missing-event spin-id missing-id))
+            "an exact completion claim records benign advancement")
         (finally
           (ctx/close-context! context))))))
 
@@ -424,6 +464,9 @@
                          fork [:subscriptions [:spin/complete child-id] spin-id])
                         #{}))
             "the reverse index shares the continuation snapshot boundary")
+        (is (nil? (simple/claim-continuation-for-resume!
+                   fork spin-id cont-id))
+            "a whole-state claim cannot re-import the parent's continuation")
         (finally
           (ctx/close-context! fork)
           (ctx/close-context! parent))))))
@@ -459,6 +502,9 @@
                                   spin-id])
                                 #{}))
                     "the removed edge cannot fall through either overlay")
+                (is (nil? (simple/process-event!
+                           fork-2 {:type :spin-completion :id child-b}))
+                    "late completion treats the fork-local tombstone as absent")
                 (is (nil? (rtp/get-state
                            fork-2 [:await-conts spin-id :nested-cont-a]))
                     "the parent fork's tombstone remains materialized")

--- a/test/org/replikativ/spindel/runtime_protocols_test.clj
+++ b/test/org/replikativ/spindel/runtime_protocols_test.clj
@@ -256,8 +256,11 @@
           (let [stored (ec/get-state [:track-subscriptions spin-id (:id added-cont)])]
             (is (some? stored)))
 
-          ;; Remove continuation
-          (rtp/remove-continuation! ctx spin-id (:id added-cont))
+          ;; Remove continuation. Exactly one caller claims the descriptor.
+          (is (= (:id added-cont)
+                 (:id (rtp/remove-continuation! ctx spin-id (:id added-cont)))))
+          (is (nil? (rtp/remove-continuation! ctx spin-id (:id added-cont)))
+              "a spent continuation cannot be claimed twice")
 
           ;; Verify removed
           (is (nil? (ec/get-state [:track-subscriptions spin-id (:id added-cont)]))))))))

--- a/test/org/replikativ/spindel/runtime_protocols_test.clj
+++ b/test/org/replikativ/spindel/runtime_protocols_test.clj
@@ -265,6 +265,51 @@
           ;; Verify removed
           (is (nil? (ec/get-state [:track-subscriptions spin-id (:id added-cont)]))))))))
 
+(deftest fork-overlay-continuation-claim-has-one-winner
+  (testing "completion and cancellation atomically arbitrate in a fork overlay"
+    (let [parent (ctx/create-execution-context)]
+      (try
+        ;; Register before forking: await conts are copied into the fork while
+        ;; reverse subscriptions initially fall through to the parent backend.
+        (dotimes [i 100]
+          (let [spin-id (keyword (str "fork-claim-spin-" i))
+                child-id (keyword (str "fork-claim-child-" i))
+                cont-id (keyword (str "fork-claim-cont-" i))
+                cont {:id cont-id
+                      :event-key [:spin/complete child-id]
+                      :kind :await-once
+                      :on-resume identity
+                      :resolve-fn identity
+                      :reject-fn identity}]
+            (rtp/add-continuation! parent spin-id cont)))
+        (let [fork (ctx/fork-context parent)]
+          (try
+            (dotimes [i 100]
+              (let [spin-id (keyword (str "fork-claim-spin-" i))
+                    child-id (keyword (str "fork-claim-child-" i))
+                    cont-id (keyword (str "fork-claim-cont-" i))
+                    start (promise)
+                    completion (future
+                                 @start
+                                 (simple/claim-continuation-for-resume!
+                                  fork spin-id cont-id))
+                    cancellation (future
+                                   @start
+                                   (rtp/remove-continuation!
+                                    fork spin-id cont-id {:cancel? true}))]
+                (deliver start true)
+                (is (= 1 (count (filter some? [@completion @cancellation])))
+                    "exactly one side owns the CPS continuation")
+                (is (empty? (or (rtp/get-state
+                                 fork
+                                 [:subscriptions [:spin/complete child-id] spin-id])
+                                #{}))
+                    "a tombstone prevents the removed reverse edge falling through")))
+            (finally
+              (ctx/close-context! fork))))
+        (finally
+          (ctx/close-context! parent))))))
+
 (deftest test-pcontinuation-earliest
   (testing "earliest-continuation returns earliest by order"
     (th/with-ctx [ctx]

--- a/test/org/replikativ/spindel/runtime_protocols_test.clj
+++ b/test/org/replikativ/spindel/runtime_protocols_test.clj
@@ -7,6 +7,7 @@
             [org.replikativ.spindel.engine.protocols :as rtp]
             [org.replikativ.spindel.engine.impl.simple :as simple]
             [org.replikativ.spindel.engine.impl.graph :as graph]
+            [org.replikativ.spindel.engine.nodes :as nodes]
             [org.replikativ.spindel.signal :as sig]
             [org.replikativ.spindel.spin.cps :refer [spin]]
             [org.replikativ.spindel.spin.core :as spin-core]
@@ -265,12 +266,100 @@
           ;; Verify removed
           (is (nil? (ec/get-state [:track-subscriptions spin-id (:id added-cont)]))))))))
 
+(deftest replacing-continuation-detaches-previous-reverse-edge
+  (testing "a deterministic continuation ID can advance to another child"
+    (let [context (ctx/create-execution-context)
+          spin-id :reawait-parent
+          cont-id :reused-await-cont
+          base {:id cont-id
+                :kind :await-once
+                :on-resume identity
+                :resolve-fn identity
+                :reject-fn identity}]
+      (try
+        (rtp/add-continuation!
+         context spin-id (assoc base :event-key [:spin/complete :old-child]))
+        (rtp/add-continuation!
+         context spin-id (assoc base :event-key [:spin/complete :new-child]))
+        (is (empty? (or (rtp/get-state
+                         context
+                         [:subscriptions [:spin/complete :old-child] spin-id])
+                        #{}))
+            "the obsolete child cannot resume the replacement")
+        (is (= #{cont-id}
+               (rtp/get-state
+                context
+                [:subscriptions [:spin/complete :new-child] spin-id])))
+        (is (= :new-child
+               (-> (rtp/get-state context [:await-conts spin-id cont-id])
+                   :event-key second)))
+        (is (some? (simple/claim-continuation-for-resume!
+                    context spin-id cont-id)))
+        (is (contains? (rtp/get-state context [:engine/resuming-conts])
+                       [spin-id cont-id]))
+        (simple/release-continuation-resume! context spin-id cont-id)
+        (is (not (contains? (rtp/get-state context [:engine/resuming-conts])
+                            [spin-id cont-id])))
+        (finally
+          (ctx/close-context! context))))))
+
+(deftest truncating-stale-continuations-detaches-reverse-edges
+  (testing "reactive resume truncates both halves of every later await edge"
+    (let [context (ctx/create-execution-context)
+          spin-id :truncate-parent
+          mk-cont (fn [cont-id child-id order]
+                    {:id cont-id
+                     :event-key [:spin/complete child-id]
+                     :kind :await-once
+                     :order order
+                     :on-resume identity
+                     :resolve-fn identity
+                     :reject-fn identity})
+          resumed (mk-cont :resumed :resumed-child 0)
+          stale (mk-cont :stale :stale-child 1)]
+      (try
+        (rtp/add-continuation! context spin-id stale)
+        ((ns-resolve 'org.replikativ.spindel.engine.impl.simple
+                     'truncate-stale-conts!)
+         context spin-id resumed)
+        (is (nil? (rtp/get-state context [:await-conts spin-id :stale])))
+        (is (empty? (or (rtp/get-state
+                         context
+                         [:subscriptions [:spin/complete :stale-child] spin-id])
+                        #{}))
+            "the obsolete completion cannot repeatedly diagnose a missing cont")
+        (finally
+          (ctx/close-context! context))))))
+
+(deftest terminal-parent-converges-stale-completion-edge
+  (testing "an in-flight completion after terminal settlement is benign and pruned"
+    (let [context (ctx/create-execution-context)
+          parent-id :terminal-parent
+          child-id :late-child
+          cont-id :already-spent]
+      (try
+        (rtp/swap-state! context [:nodes parent-id]
+                         (constantly
+                          (nodes/->spin-node :cancelled :clean true false
+                                             #{} {} nil #{})))
+        (rtp/swap-state! context
+                         [:subscriptions [:spin/complete child-id] parent-id]
+                         (constantly #{cont-id}))
+        (simple/process-event! context {:type :spin-completion :id child-id})
+        (is (empty? (or (rtp/get-state
+                         context
+                         [:subscriptions [:spin/complete child-id] parent-id])
+                        #{}))
+            "one late event repairs the obsolete reverse edge")
+        (finally
+          (ctx/close-context! context))))))
+
 (deftest fork-overlay-continuation-claim-has-one-winner
   (testing "completion and cancellation atomically arbitrate in a fork overlay"
     (let [parent (ctx/create-execution-context)]
       (try
-        ;; Register before forking: await conts are copied into the fork while
-        ;; reverse subscriptions initially fall through to the parent backend.
+        ;; Register before forking: await conts and their reverse subscriptions
+        ;; are copied into one fork-local graph snapshot.
         (dotimes [i 100]
           (let [spin-id (keyword (str "fork-claim-spin-" i))
                 child-id (keyword (str "fork-claim-child-" i))
@@ -309,6 +398,89 @@
               (ctx/close-context! fork))))
         (finally
           (ctx/close-context! parent))))))
+
+(deftest fork-does-not-observe-post-fork-parent-subscriptions
+  (testing "a fork cannot see one half of a continuation registered later"
+    (let [parent (ctx/create-execution-context)
+          fork (ctx/fork-context parent)
+          spin-id :post-fork-parent
+          child-id :post-fork-child
+          cont-id :post-fork-cont]
+      (try
+        (rtp/add-continuation!
+         parent spin-id
+         {:id cont-id
+          :event-key [:spin/complete child-id]
+          :kind :await-once
+          :on-resume identity
+          :resolve-fn identity
+          :reject-fn identity})
+        (is (some? (rtp/get-state parent [:await-conts spin-id cont-id])))
+        (is (contains? (rtp/get-state
+                        parent [:subscriptions [:spin/complete child-id] spin-id])
+                       cont-id))
+        (is (nil? (rtp/get-state fork [:await-conts spin-id cont-id])))
+        (is (empty? (or (rtp/get-state
+                         fork [:subscriptions [:spin/complete child-id] spin-id])
+                        #{}))
+            "the reverse index shares the continuation snapshot boundary")
+        (finally
+          (ctx/close-context! fork)
+          (ctx/close-context! parent))))))
+
+(deftest nested-fork-removal-does-not-resurrect-reverse-subscription
+  (testing "whole-state claims materialize the complete overlay ancestry"
+    (let [root (ctx/create-execution-context)
+          spin-id :nested-parent
+          child-a :nested-child-a
+          child-b :nested-child-b]
+      (try
+        (doseq [[child-id cont-id] [[child-a :nested-cont-a]
+                                    [child-b :nested-cont-b]]]
+          (rtp/add-continuation!
+           root spin-id
+           {:id cont-id
+            :event-key [:spin/complete child-id]
+            :kind :await-once
+            :on-resume identity
+            :resolve-fn identity
+            :reject-fn identity}))
+        (let [fork-1 (ctx/fork-context root)]
+          (try
+            (is (some? (rtp/remove-continuation!
+                        fork-1 spin-id :nested-cont-a {:cancel? true})))
+            (let [fork-2 (ctx/fork-context fork-1)]
+              (try
+                (is (some? (simple/claim-continuation-for-resume!
+                            fork-2 spin-id :nested-cont-b)))
+                (is (empty? (or (rtp/get-state
+                                 fork-2
+                                 [:subscriptions [:spin/complete child-b]
+                                  spin-id])
+                                #{}))
+                    "the removed edge cannot fall through either overlay")
+                (is (nil? (rtp/get-state
+                           fork-2 [:await-conts spin-id :nested-cont-a]))
+                    "the parent fork's tombstone remains materialized")
+                (finally
+                  (ctx/close-context! fork-2))))
+            (finally
+              (ctx/close-context! fork-1))))
+        (finally
+          (ctx/close-context! root))))))
+
+(deftest reactive-resume-release-preserves-absent-continuation
+  (testing "cancellation during resume is not replaced with a nil entry"
+    (let [context (ctx/create-execution-context)]
+      (try
+        (simple/release-reactive-resume! context :reactive-parent :spent-cont)
+        (is (nil? (rtp/get-state
+                   context [:await-conts :reactive-parent :spent-cont])))
+        (is (empty? (or (rtp/get-state
+                         context [:await-conts :reactive-parent])
+                        {})))
+        (finally
+          (ctx/close-context! context))))))
 
 (deftest test-pcontinuation-earliest
   (testing "earliest-continuation returns earliest by order"


### PR DESCRIPTION
## Summary

- arbitrate continuation completion and cancellation through a single atomic claim
- detach continuation descriptors and their reverse subscriptions together on cancellation, completion, replacement, truncation, and terminal cleanup
- snapshot continuation tables and `:subscriptions` as one fork-local graph
- make nested overlays materialize ancestor state/tombstones recursively and make two-path handoffs safe after deletion
- retain bounded, exact retirement evidence so duplicate/late completion delivery is distinguishable from a genuinely missing parallel branch
- repair obsolete completion edges while retaining a warning for unretired missing continuations

## Why

Dvergr's ownership-coupled agent race exposed a family of related graph races. Cancellation could remove an await continuation while leaving its reverse completion edge; completion and concurrent cancellers could both process the same CPS slice; and a fork could observe a parent subscription without the matching fork-local continuation. Nested overlay tombstones and deterministic continuation replacement exposed further resurrection paths.

The runtime now treats the continuation descriptor plus reverse index as one graph edge and completion/cancellation as affine ownership of its resume slice. Forks receive one consistent graph snapshot, while execution already in flight is never inherited.

## Verification

- focused Spindel cancellation, lost-wakeup, nested-fork, context/fork, continuation, dependency and parallel suites: **116 tests, 844 assertions, 0 failures**
- Dvergr agent-program integration with this Spindel checkout: **36 tests, 205 assertions, 0 failures**
- exact Dvergr SCI ownership-race integration: **7 tests, 36 assertions, 0 failures**, without missing-continuation warning amplification
- repeated live Codex-subscription race environments: reward **1.0**, exact winner, durable loser cancellation, structural parentage and zero active Runs
- formatter and `git diff --check`: green

The full JVM suite still reaches the pre-existing `pubsub.pub-test` FIFO/backpressure hang/failure. The same isolated test fails/hangs on the unchanged pre-PR checkout, so it is not introduced by this PR.
