### PR TITLE
feat: partition fork settlement authority

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -849,6 +849,22 @@ A yggdrasil system held as a signal value.
 | `(system-of signal)` | Unwrap to the effective (writable) system. |
 | `(sync-opts system & {:keys [sync?]})` | Derive `sync-signal!` hooks from the system's CRDT protocols (`PConvergent → :merge-fn`, `PDeltaApply → :apply-delta-fn` + `:delta-fn` + `:clear-delta-fn`). |
 
+## `spindel.yggdrasil`
+
+Fork-aware registry and affine settlement of Yggdrasil systems in an execution
+context. See [Forking](forking.md#fork-registered-systems-and-settle-them-affinely).
+
+| Function | Description |
+|----------|-------------|
+| `(register! system)` / `(unregister! system-id)` | Add or remove a forkable Yggdrasil signal; rejected once that child world's settlement authority is partitioned/frozen. |
+| `(fork! opts)` | Fork the reactive context and selected registered systems; returns the sole open `ForkHandle`. |
+| `(fork-descriptor handle)` | Portable world/system basis plus current owner and settlement status; excludes live authority. |
+| `(transfer-fork! handle owner)` | Atomically consume the caller's authority and return the new owner's handle. |
+| `(partition-fork! handle parts)` | Consume a whole/scope handle into two or more disjoint, exhaustive per-system settlement handles. |
+| `(fork-diff handle)` / `(fork-conflicts handle)` | Diff or conflict projection restricted to the handle's settlement scope. |
+| `(merge-fork! handle opts)` / `(discard-fork! handle opts)` | Settle only the handle's scope exactly once; same-operation replay is idempotent. |
+| `(merge-fork-from-parent! handle opts)` | Advance only the open handle's systems from its immediate parent under an exclusive `:advancing` authority lease. |
+
 ## `spindel.distributed.workspace-peer`
 
 Pure gate + checkout/topology descriptor + single-writer lease (no transport deps).

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -87,9 +87,65 @@ the parent context for performance:
   etc. are not isolated. Spins that observably do something to the
   outside world will do it from every fork that runs them.
 
-If you need an external resource to fork along with the context, register
-it under `[:external-refs]` and implement the `PForkable` protocol so
-`fork-context` can ask it to copy itself.
+If an external resource has Yggdrasil fork/merge semantics, register it with
+`org.replikativ.spindel.yggdrasil/register!` and fork through that namespace's
+`fork!`. The returned `ForkHandle` wraps the execution-context fork and is the
+single settlement authority for all selected registered systems.
+
+## Fork registered systems and settle them affinely
+
+```clojure
+(require '[org.replikativ.spindel.yggdrasil :as ygg])
+
+(def world
+  (ygg/fork! {:systems #{:kb :repo}
+              :purpose :proposal
+              :owner :run-42}))
+
+;; Work in the isolated reactive context and its Yggdrasil branches.
+(binding [ec/*execution-context* (:child-ctx world)]
+  (perform-work!))
+
+;; Settlement is mutually exclusive and exactly once.
+(ygg/merge-fork! world)       ; or discard-fork! / transfer-fork!
+```
+
+The portable value from `fork-descriptor` contains world identity, ancestry,
+owner, policy, and per-system branch/basis data. It never contains the live
+contexts or affine token.
+
+After the world is physically quiescent, trusted host code may split one open
+whole-world settlement capability into disjoint per-system capabilities:
+
+```clojure
+(def parts
+  (ygg/partition-fork!
+   world
+   [{:systems #{:repo} :owner :code-review}
+    {:systems #{:kb}   :owner :knowledge-review}]))
+```
+
+Partitioning consumes `world`. Every descriptor-named system must occur exactly
+once; overlaps and omissions are rejected. All returned handles retain the same
+`:fork/id` because they govern one execution world, while each has a distinct
+`:fork/settlement-id`. `fork-diff`, `fork-conflicts`, `merge-fork!`,
+`discard-fork!`, and `merge-fork-from-parent!` operate only on that handle's
+scope.
+
+This divides settlement authority, not arbitrary runtime access: the handles
+share the child execution context and are host capabilities, not sandbox values.
+The system registry must also still match the creation descriptor; worlds with
+uncheckpointed child-only systems are refused until those systems receive a
+portable basis entry. A successful partition freezes registration in that child
+world (including recursive partitions), closing the race between exhaustive
+scope validation and later `register!`/`unregister!` calls. Settlement also fails
+closed if a scoped system is removed or replaced in the parent; it is never
+silently reclassified as child-only.
+
+`merge-fork-from-parent!` temporarily leases the same affine authority as
+`:advancing`. Transfer, partition, merge, and discard are rejected until the
+advance completes. A read-only preflight failure reopens the handle; failure
+after durable mutation begins leaves it `:incomplete` for explicit recovery.
 
 ## Fork and the spin cache
 

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -87,6 +87,29 @@
 ;;                                                  ygg-signal); fork-context forks
 ;;                                                  each of these signal values.
 (def registry-key :ygg-signals)
+(def ^:private fork-authority-key ::fork-authority)
+
+;; Registry shape is part of a fork's settlement authority. On the JVM this
+;; lock closes the validation/CAS race between partition-fork! and a concurrent
+;; register!/unregister!. ClojureScript executes these synchronous transitions
+;; on one event loop, so no monitor is needed there.
+#?(:clj (defonce ^:private registry-authority-lock (Object.)))
+
+(defn- with-registry-authority-lock [f]
+  #?(:clj (locking registry-authority-lock (f))
+     :cljs (f)))
+
+(defn- ensure-world-shape-mutable!
+  ([] (ensure-world-shape-mutable! (ec/current-execution-context)))
+  ([ctx]
+   (when-let [authority (rtp/get-state ctx [fork-authority-key])]
+     (let [{:keys [status operation]} @authority]
+       (when-not (= :open status)
+         (throw (ex-info "Fork world system registry is frozen"
+                         {:type ::fork-world-shape-frozen
+                          :status status
+                          :operation operation})))))
+   true))
 
 ;; =============================================================================
 ;; fork-value — how a context fork isolates a yggdrasil system value
@@ -277,19 +300,25 @@
      (def ygit (register! (git/create \".\")))
      @ygit  ; => the git system"
   [sys]
-  (let [sys-id (ygg/system-id sys)
-        sig    (ys/ygg-signal sys)]
-    (ec/swap-state! [registry-key] #(assoc (or % {}) sys-id sig))
-    (->YggRef sys-id)))
+  (with-registry-authority-lock
+    (fn []
+      (ensure-world-shape-mutable!)
+      (let [sys-id (ygg/system-id sys)
+            sig    (ys/ygg-signal sys)]
+        (ec/swap-state! [registry-key] #(assoc (or % {}) sys-id sig))
+        (->YggRef sys-id)))))
 
 (defn unregister!
   "Remove the system identified by `sys-id` — the mirror of `register!`. Drops it
    from the registry and the forkable-signal set. Returns true if removed."
   [sys-id]
-  (when-let [sig-ref (get (registry) sys-id)]
-    (ec/swap-state! [registry-key] #(dissoc % sys-id))
-    (ec/swap-state! [:forkable-signals] #(disj (or % #{}) (:id sig-ref)))
-    true))
+  (with-registry-authority-lock
+    (fn []
+      (ensure-world-shape-mutable!)
+      (when-let [sig-ref (get (registry) sys-id)]
+        (ec/swap-state! [registry-key] #(dissoc % sys-id))
+        (ec/swap-state! [:forkable-signals] #(disj (or % #{}) (:id sig-ref)))
+        true))))
 
 (defn system
   "Get a registered system by id from the current context — the EFFECTIVE writable
@@ -351,6 +380,29 @@
   (let [preg (registry parent-ctx)]
     (into {} (remove (fn [[sid _]] (contains? preg sid))) (registry child-ctx))))
 
+(defn- scoped-shared-pairs
+  "Shared pairs for `scope`, failing closed when a descriptor-owned system no
+   longer exists in the parent. A missing parent is a changed settlement shape,
+   never a child-only system that can be silently carried or skipped."
+  [child-ctx parent-ctx scope]
+  (let [pairs (vec (shared-pairs child-ctx parent-ctx))]
+    (if-not scope
+      pairs
+      (let [parent-reg (registry parent-ctx)
+            selected (filterv (fn [[sid child-ref _ _]]
+                                (and (contains? scope sid)
+                                     (= (:id child-ref)
+                                        (:id (get parent-reg sid)))))
+                              pairs)
+            present (set (map first selected))
+            missing (set (remove present scope))]
+        (when (seq missing)
+          (throw (ex-info "Fork settlement system shape changed"
+                          {:type ::fork-system-shape-changed
+                           :missing-from-parent missing
+                           :scope scope})))
+        selected))))
+
 (defn- set-node-value!
   "Swap ygg-signal `sig-ref`'s node value in `ctx` to `v` (system or overlay),
    preserving observers and bumping generation."
@@ -360,6 +412,37 @@
                      (nodes/->signal-node v nil nil false
                                           (if node (nodes/get-observers node) #{})
                                           (inc (or (:generation node) 0))))))
+
+(defn- ensure-parent-signal-and-seat!
+  "After durable merge work, atomically verify that `expected-ref` still names
+   `sid` in the parent registry and seat the merged value. This closes the async
+   unregister/re-register race that would otherwise update an obsolete node."
+  [parent-ctx sid expected-ref value]
+  (with-registry-authority-lock
+    (fn []
+      (let [current-ref (get (registry parent-ctx) sid)]
+        (when-not (= (:id expected-ref) (:id current-ref))
+          (throw (ex-info "Fork settlement system shape changed during merge"
+                          {:type ::fork-system-shape-changed
+                           :system sid
+                           :expected-signal (:id expected-ref)
+                           :current-signal (:id current-ref)})))
+        (set-node-value! parent-ctx expected-ref value)))))
+
+(defn- ensure-registry-mutable! [ctx]
+  (with-registry-authority-lock #(ensure-world-shape-mutable! ctx)))
+
+(defn- carry-child-only!
+  "Atomically carry child-only systems into a mutable parent registry. Internal
+   settlement must obey the same world-shape frontier as public registration."
+  [parent-ctx child-ctx systems]
+  (with-registry-authority-lock
+    (fn []
+      (ensure-world-shape-mutable! parent-ctx)
+      (doseq [[sid sig-ref] systems]
+        (rtp/swap-state! parent-ctx [registry-key] #(assoc (or % {}) sid sig-ref))
+        (rtp/swap-state! parent-ctx [:forkable-signals] #(conj (or % #{}) (:id sig-ref)))
+        (set-node-value! parent-ctx sig-ref (node-value child-ctx sig-ref))))))
 
 ;; =============================================================================
 ;; Async context conveyance
@@ -416,11 +499,12 @@
    heads for restart recovery. Non-forkable compatibility systems are reported
    honestly as `:kind :shared` rather than pretending they were isolated."
   [fork-handle]
-  (let [{:keys [status owner operation]} @(:authority fork-handle)]
+  (let [{:keys [status owner operation partitions]} @(:authority fork-handle)]
     (cond-> (assoc (:descriptor fork-handle)
                    :fork/owner owner
                    :fork/status status)
-      operation (assoc :fork/operation operation))))
+      operation (assoc :fork/operation operation)
+      partitions (assoc :fork/partitions partitions))))
 
 (defn fork-disposition
   "Process-local lifecycle view of a ForkHandle, without its authority token."
@@ -481,6 +565,123 @@
                  :token new-token
                  :descriptor (assoc (:descriptor fork-handle) :fork/owner new-owner))
           (recur))))))
+
+(defn- partition-fork-under-lock!
+  [fork-handle partitions]
+  ;; Fail on affine authority before inspecting caller-supplied partition data;
+  ;; an in-flight advance/settlement is the governing state of the capability.
+  (ensure-open-authority! fork-handle)
+  (let [parts (vec partitions)
+        descriptor (:descriptor fork-handle)
+        described (set (keys (:fork/systems descriptor)))
+        registered (set (keys (registry (:child-ctx fork-handle))))
+        world-systems (or (:fork/world-systems descriptor) described)
+        system-sets (mapv (comp set :systems) parts)
+        frequencies (frequencies (mapcat seq system-sets))
+        overlap (into #{} (keep (fn [[sid n]] (when (> n 1) sid))) frequencies)
+        covered (set (keys frequencies))
+        unknown (set (remove described covered))
+        omitted (set (remove covered described))]
+    (when (< (count parts) 2)
+      (throw (ex-info "Fork partition requires at least two parts"
+                      {:type ::invalid-fork-partition
+                       :partition-count (count parts)})))
+    (when-let [idx (first (keep-indexed (fn [idx part]
+                                          (when (or (not (set? (:systems part)))
+                                                    (empty? (:systems part)))
+                                            idx))
+                                        parts))]
+      (throw (ex-info "Each fork partition must name a non-empty system set"
+                      {:type ::invalid-fork-partition
+                       :partition-index idx
+                       :partition (nth parts idx)})))
+    (when-let [idx (first (keep-indexed (fn [idx part]
+                                          (when (nil? (:owner part)) idx))
+                                        parts))]
+      (throw (ex-info "Each fork partition requires an owner"
+                      {:type ::invalid-fork-owner
+                       :partition-index idx})))
+    (when (seq overlap)
+      (throw (ex-info "Fork partitions overlap"
+                      {:type ::overlapping-fork-partition
+                       :systems overlap})))
+    (when (or (seq unknown) (seq omitted))
+      (throw (ex-info "Fork partitions must exactly cover the described world"
+                      {:type ::incomplete-fork-partition
+                       :unknown unknown
+                       :omitted omitted
+                       :described described})))
+    ;; New child-only systems and removed descriptor systems do not yet have a
+    ;; portable creation/basis entry. Refuse to mint misleading partial handles;
+    ;; a later descriptor checkpoint/journal can make this case partitionable.
+    (when (not= world-systems registered)
+      (throw (ex-info "Fork system shape changed after creation"
+                      {:type ::fork-system-shape-changed
+                       :described world-systems
+                       :registered registered
+                       :added (set (remove world-systems registered))
+                       :removed (set (remove registered world-systems))})))
+    (let [partition-of (or (:fork/settlement-id descriptor)
+                           (:fork/id descriptor))
+          prepared
+          (mapv (fn [{:keys [systems owner purpose]}]
+                  (let [settlement-id (random-uuid)
+                        token (random-uuid)
+                        part-descriptor
+                        (cond-> (assoc descriptor
+                                       :fork/settlement-id settlement-id
+                                       :fork/partition-of partition-of
+                                       :fork/world-systems world-systems
+                                       :fork/systems (select-keys (:fork/systems descriptor)
+                                                                  systems)
+                                       :fork/owner owner)
+                          purpose (assoc :fork/purpose purpose))]
+                    {:descriptor part-descriptor
+                     :authority (atom {:status :open :owner owner :token token})
+                     :token token}))
+                parts)
+          authority (:authority fork-handle)]
+      (loop []
+        (let [state @authority]
+          (when-not (and (= :open (:status state))
+                         (= (:token fork-handle) (:token state)))
+            (throw (authority-error fork-handle state)))
+          (let [next-state (assoc state
+                                  :status :partitioned
+                                  :operation :partition
+                                  :partitions (mapv #(get-in % [:descriptor
+                                                                :fork/settlement-id])
+                                                    prepared))]
+            (if (compare-and-set! authority state next-state)
+              (mapv (fn [{:keys [descriptor authority token]}]
+                      (->ForkHandle (:child-ctx fork-handle)
+                                    (:parent-ctx fork-handle)
+                                    (:fork-id fork-handle)
+                                    descriptor authority token))
+                    prepared)
+              (recur))))))))
+
+(defn partition-fork!
+  "Consume one OPEN fork settlement capability and return disjoint capabilities
+   over the same execution world.
+
+   `partitions` is a vector of at least two maps:
+
+     [{:systems #{system-id ...} :owner owner-id :purpose optional-tag} ...]
+
+   Every descriptor-named system must occur exactly once: overlaps, omissions,
+   unknown systems, nil owners, and worlds whose registered system shape changed
+   after fork creation are rejected without consuming the original handle. Each
+   returned handle may then be transferred, merged, or discarded independently.
+
+   This partitions substrate *settlement authority*, not runtime access. The
+   handles intentionally retain the same child execution context and must remain
+   trusted host capabilities rather than values exposed to sandboxed code. Once
+   partitioned, that world's system registry is frozen so its exhaustive scopes
+   cannot be invalidated by later registration changes."
+  [fork-handle partitions]
+  (with-registry-authority-lock
+    #(partition-fork-under-lock! fork-handle partitions)))
 
 (defn- terminal-status [operation]
   (case operation
@@ -557,6 +758,64 @@
                           :last-operation operation
                           :last-error error)
                    (update :settlement-attempts (fnil inc 0))))
+             state)))
+  error)
+
+(defn- claim-advance! [fork-handle]
+  (loop []
+    (let [authority (:authority fork-handle)
+          state @authority]
+      (when-not (and (= :open (:status state))
+                     (= (:token fork-handle) (:token state)))
+        (throw (authority-error fork-handle state)))
+      (let [next-state (-> state
+                           (assoc :status :advancing
+                                  :operation :advance-from-parent
+                                  :phase :preflight)
+                           (dissoc :last-operation :last-error))]
+        (if (compare-and-set! authority state next-state)
+          true
+          (recur))))))
+
+(defn- mark-advance-mutating! [fork-handle]
+  (swap! (:authority fork-handle)
+         (fn [state]
+           (if (and (= (:token fork-handle) (:token state))
+                    (= :advancing (:status state))
+                    (= :advance-from-parent (:operation state)))
+             (assoc state :phase :mutating)
+             state))))
+
+(defn- complete-advance! [fork-handle]
+  (swap! (:authority fork-handle)
+         (fn [state]
+           (if (and (= (:token fork-handle) (:token state))
+                    (= :advancing (:status state))
+                    (= :advance-from-parent (:operation state)))
+             (-> state
+                 (assoc :status :open)
+                 (dissoc :operation :phase :last-operation :last-error))
+             state)))
+  nil)
+
+(defn- fail-advance! [fork-handle error]
+  (swap! (:authority fork-handle)
+         (fn [state]
+           (if (and (= (:token fork-handle) (:token state))
+                    (= :advancing (:status state))
+                    (= :advance-from-parent (:operation state)))
+             (if (= :preflight (:phase state))
+               (-> state
+                   (assoc :status :open
+                          :last-operation :advance-from-parent
+                          :last-error error)
+                   (update :advance-attempts (fnil inc 0))
+                   (dissoc :operation :phase))
+               (-> state
+                   (assoc :status :incomplete
+                          :last-operation :advance-from-parent
+                          :last-error error)
+                   (update :advance-attempts (fnil inc 0))))
              state)))
   error)
 
@@ -837,6 +1096,10 @@
                           :fork/systems systems}
               token (random-uuid)
               authority (atom {:status :open :owner owner :token token})]
+          ;; The child world observes this shared authority atom. It remains
+          ;; mutable while OPEN, but partition-fork!'s atomic transition freezes
+          ;; registry shape for every recursively subdivided capability.
+          (rtp/swap-state! child-ctx [fork-authority-key] (constantly authority))
           (->ForkHandle child-ctx parent-ctx fork-id descriptor authority token))))))))
 
 ;; `with-fork` is a JVM-only convenience macro. On cljs use the engine form it
@@ -882,19 +1145,16 @@
             (catch #?(:clj Throwable :cljs :default) t
               (ygt/diff-error psnap fsnap (ex-message t)))))))))
 
-(defn context-diff
-  "Per-system delta of a forked context vs its parent — the unified diff a
-   reviewer reads: {system-id -> typed yggdrasil delta (GitDiff / DatahikeDiff /
-   DiffError)}. nil when the context has no parent. Non-Mergeable systems are
-   omitted."
-  [child-ctx]
+(defn- context-diff-scoped
+  [child-ctx scope]
   (convey-context
    (async+sync
     (:sync? yc/default-opts)
     (async
      (when-let [parent-ctx (:parent-ctx child-ctx)]
       ;; accumulating loop (not `into`/`keep`) — `system-merge-base-diff` is awaited.
-       (loop [ps (seq (shared-pairs child-ctx parent-ctx)) acc {}]
+       (loop [ps (seq (scoped-shared-pairs child-ctx parent-ctx scope))
+              acc {}]
          (if ps
            (let [[sid _ cval psys] (first ps)
                  fsys (ys/effective-system cval)
@@ -905,33 +1165,72 @@
              (recur (next ps) acc*))
            acc)))))))
 
-(defn context-conflicts
-  "Per-system conflicts of a forked context vs its parent, each tagged
-   `:system`. nil when the context has no parent."
+(defn context-diff
+  "Per-system delta of a forked context vs its parent — the unified diff a
+   reviewer reads: {system-id -> typed yggdrasil delta (GitDiff / DatahikeDiff /
+   DiffError)}. nil when the context has no parent. Non-Mergeable systems are
+  omitted."
   [child-ctx]
+  (context-diff-scoped child-ctx nil))
+
+(defn- context-conflicts-scoped
+  [child-ctx scope]
   (convey-context
    (async+sync
     (:sync? yc/default-opts)
     (async
      (when-let [parent-ctx (:parent-ctx child-ctx)]
-      ;; accumulating loop (not `into`/`mapcat`) — `snapshot-id`/`conflicts` are `await`ed
-      ;; ONLY when a continuation (a fn): default-opts `snapshot-id` is a plain value on the
-      ;; JVM but a CPS on cljs; `conflicts` is `[]` for conflict-free CRDTs, CPS for versioned.
-       (loop [ps (seq (shared-pairs child-ctx parent-ctx)) acc []]
+      ;; accumulating loop (not `into`/`mapcat`) — durable calls are awaited.
+       (loop [ps (seq (scoped-shared-pairs child-ctx parent-ctx scope))
+              acc []]
          (if ps
            (let [[sid _ cval psys] (first ps)
                  fsys (ys/effective-system cval)
                  more (if (satisfies? ygg/Mergeable fsys)
                         (try
-                          (let [ps1  (let [v (ygg/snapshot-id psys)] (if (fn? v) (await v) v))
-                                fs1  (let [v (ygg/snapshot-id fsys)] (if (fn? v) (await v) v))
+                          (let [ps1 (let [v (ygg/snapshot-id psys)]
+                                      (if (fn? v) (await v) v))
+                                fs1 (let [v (ygg/snapshot-id fsys)]
+                                      (if (fn? v) (await v) v))
                                 pres (ygg/conflicts psys ps1 fs1)
-                                cs   (if (fn? pres) (await pres) pres)]
+                                cs (if (fn? pres) (await pres) pres)]
                             (mapv #(assoc % :system sid) cs))
                           (catch #?(:clj Throwable :cljs :default) _ nil))
                         nil)]
              (recur (next ps) (into acc (or more []))))
            acc)))))))
+
+(defn context-conflicts
+  "Per-system conflicts of a forked context vs its parent, each tagged
+   `:system`. nil when the context has no parent."
+  [child-ctx]
+  (context-conflicts-scoped child-ctx nil))
+
+(declare handle-system-scope)
+
+(defn fork-diff
+  "Per-system delta restricted to the settlement authority of `fork-handle`.
+   Original handles see the whole child world; partition handles see only their
+   disjoint descriptor-named scope."
+  [fork-handle]
+  (convey-context
+   (async+sync
+    (:sync? yc/default-opts)
+    (async
+     (let [x (context-diff-scoped (:child-ctx fork-handle)
+                                  (handle-system-scope fork-handle))]
+       (if (fn? x) (await x) x))))))
+
+(defn fork-conflicts
+  "Conflict projection restricted to `fork-handle`'s settlement scope."
+  [fork-handle]
+  (convey-context
+   (async+sync
+    (:sync? yc/default-opts)
+    (async
+     (let [x (context-conflicts-scoped (:child-ctx fork-handle)
+                                       (handle-system-scope fork-handle))]
+       (if (fn? x) (await x) x))))))
 
 ;; =============================================================================
 ;; Merge / Discard (Parent-Controlled)
@@ -945,6 +1244,26 @@
   (let [{:keys [kind branch]} (get-in (:descriptor fork-handle) [:fork/systems sid])]
     (and (contains? #{:branch :snapshot} kind)
          (= branch (ygg/current-branch cval)))))
+
+(defn- handle-system-scope
+  "nil means the original handle owns the whole evolving child world. A
+   partitioned handle owns exactly the systems named in its descriptor."
+  [fork-handle]
+  (when (contains? (:descriptor fork-handle) :fork/partition-of)
+    (set (keys (get-in fork-handle [:descriptor :fork/systems])))))
+
+(defn- handle-shared-pairs [fork-handle]
+  (scoped-shared-pairs (:child-ctx fork-handle)
+                       (:parent-ctx fork-handle)
+                       (handle-system-scope fork-handle)))
+
+(defn- handle-child-only [fork-handle]
+  ;; A partition's descriptor systems were all shared when the exhaustive split
+  ;; was minted. If one later disappears from the parent, handle-shared-pairs
+  ;; fails closed; it must never be reclassified as child-only.
+  (if (handle-system-scope fork-handle)
+    {}
+    (child-only (:child-ctx fork-handle) (:parent-ctx fork-handle))))
 
 (defn- merge-fork-context!
   "Merge a ForkHandle's per-system overlays into its parent.
@@ -969,8 +1288,13 @@
       (:sync? (merge yc/default-opts opts))
       (async
        (when-let [parent-ctx (:parent-ctx child-ctx)]
-         (let [pairs (shared-pairs child-ctx parent-ctx)
-               co (child-only child-ctx parent-ctx)]
+         (let [pairs (handle-shared-pairs fork-handle)
+               co (handle-child-only fork-handle)]
+           ;; Carrying a newly registered child system changes the parent's
+           ;; world shape. Reject before any substrate mutation when that parent
+           ;; has already been partitioned/frozen.
+           (when (seq co)
+             (ensure-registry-mutable! parent-ctx))
          ;; 1. conflict pre-check (FAIL-SAFE: a throwing detector counts as an
          ;; indeterminate conflict so the gate aborts rather than blind-merges).
          ;; `snapshot-id`/`conflicts` are `await`ed ONLY when a continuation (a fn):
@@ -1011,7 +1335,8 @@
                                        ;; OVERLAY fork (convergent :overlay opt + datahike/git): join back.
                                          (ovl/overlay? cval)
                                          (let [m (await (ygg/merge-down! cval opts))]
-                                           (set-node-value! parent-ctx sig-ref m)
+                                           (ensure-parent-signal-and-seat!
+                                            parent-ctx sid sig-ref m)
                                            (ygg/discard! cval)
                                            (conj acc sid))
 
@@ -1027,19 +1352,20 @@
                                                fbranch (ygg/current-branch cval)
                                                pbranch (ygg/current-branch psys)
                                                co      (await (ygg/checkout cval pbranch mopts))
-                                               mg      (await (ygg/merge! co fbranch mopts))
-                                               m       (await (ygg/delete-branch! mg fbranch mopts))]
-                                           (set-node-value! parent-ctx sig-ref m)
+                                               mg      (await (ygg/merge! co fbranch mopts))]
+                                           (ensure-parent-signal-and-seat!
+                                            parent-ctx sid sig-ref mg)
+                                           (let [m (await (ygg/delete-branch! mg fbranch mopts))]
+                                             (ensure-parent-signal-and-seat!
+                                              parent-ctx sid sig-ref m))
                                            (conj acc sid))
 
                                          :else acc)]
                               (recur (next ps) acc*))
                             acc))]
             ;; 3. carry child-only systems into the parent registry + nodes.
-             (doseq [[sid sig-ref] co]
-               (rtp/swap-state! parent-ctx [registry-key] #(assoc (or % {}) sid sig-ref))
-               (rtp/swap-state! parent-ctx [:forkable-signals] #(conj (or % #{}) (:id sig-ref)))
-               (set-node-value! parent-ctx sig-ref (node-value child-ctx sig-ref)))
+             (when (seq co)
+               (carry-child-only! parent-ctx child-ctx co))
              {:merged merged :child-only (vec (keys co))
               :parent-ctx parent-ctx :child-ctx child-ctx}))))))))
 
@@ -1058,8 +1384,8 @@
       (:sync? (merge yc/default-opts opts))
       (async
        (when-let [parent-ctx (:parent-ctx child-ctx)]
-         (let [pairs (shared-pairs child-ctx parent-ctx)
-               co (child-only child-ctx parent-ctx)]
+         (let [pairs (handle-shared-pairs fork-handle)
+               co (handle-child-only fork-handle)]
            (when (seq pairs)
              (mark-settlement-mutating! fork-handle :discard))
        ;; `discard!` on an overlay is a synchronous no-op (returns nil); `delete-branch!`
@@ -1127,34 +1453,44 @@
       (async+sync
        (:sync? (merge yc/default-opts opts))
        (async
-      ;; In the CPS mode this check runs when the awaitable executes, so an
-      ;; authority transfer between construction and execution invalidates it.
-        (ensure-open-authority! fork-handle)
-        (when-let [parent-ctx (:parent-ctx child-ctx)]
-       ;; Loop (not doseq) so `checkout`/`merge!` await-thread on cljs.
-          (loop [ps (seq (filter (fn [[sid _ _ _]]
-                                   (not= :shared (get-in (:descriptor fork-handle)
-                                                         [:fork/systems sid :kind])))
-                                 (shared-pairs child-ctx parent-ctx)))]
-            (when ps
-              (let [[_ sig-ref cval psys] (first ps)
-                    fsys (ys/effective-system cval)]
-                (when (and (satisfies? ygg/Branchable fsys)
-                           (satisfies? ygg/Mergeable fsys))
-                  (let [cbranch (ygg/current-branch fsys)
-                        pbranch (ygg/current-branch psys)
-                     ;; thread :sync? — `opts` is a merge-opts map without it; else the
-                     ;; JVM async branch seats a CPS continuation (the finding-#3 twin).
-                        mopts   (merge yc/default-opts {:message (str "Merge from " (name pbranch))} opts)
-                        co      (await (ygg/checkout fsys cbranch mopts))
-                        m       (await (ygg/merge! co pbranch mopts))]
-                 ;; repoint: if cval is an overlay, update its writable system in
-                 ;; place; else repoint the node. (both sync)
-                    (if (ovl/overlay? cval)
-                      (ovl/reseat-overlay! cval m)
-                      (set-node-value! child-ctx sig-ref m)))))
-              (recur (next ps)))))
-        nil))))))
+        ;; Claim when the CPS expression executes, not when it is constructed.
+        ;; The :advancing lease excludes transfer, partition, and settlement for
+        ;; the full async checkout/merge interval.
+        (claim-advance! fork-handle)
+        (try
+          (when-let [parent-ctx (:parent-ctx child-ctx)]
+            (let [pairs (vec (filter (fn [[sid _ _ _]]
+                                       (not= :shared (get-in (:descriptor fork-handle)
+                                                             [:fork/systems sid :kind])))
+                                     (handle-shared-pairs fork-handle)))]
+              (when (seq pairs)
+                ;; From this point a durable adapter may have changed even if a
+                ;; later operation rejects; do not reopen authority on failure.
+                (mark-advance-mutating! fork-handle))
+              ;; Loop (not doseq) so checkout/merge await-thread on cljs.
+              (loop [ps (seq pairs)]
+                (when ps
+                  (let [[_ sig-ref cval psys] (first ps)
+                        fsys (ys/effective-system cval)]
+                    (when (and (satisfies? ygg/Branchable fsys)
+                               (satisfies? ygg/Mergeable fsys))
+                      (let [cbranch (ygg/current-branch fsys)
+                            pbranch (ygg/current-branch psys)
+                            ;; Thread :sync?; otherwise the JVM async branch can
+                            ;; accidentally seat a CPS continuation as a system.
+                            mopts (merge yc/default-opts
+                                         {:message (str "Merge from " (name pbranch))}
+                                         opts)
+                            co (await (ygg/checkout fsys cbranch mopts))
+                            m (await (ygg/merge! co pbranch mopts))]
+                        (if (ovl/overlay? cval)
+                          (ovl/reseat-overlay! cval m)
+                          (set-node-value! child-ctx sig-ref m)))))
+                  (recur (next ps))))))
+          (complete-advance! fork-handle)
+          (catch #?(:clj Throwable :cljs :default) error
+            (fail-advance! fork-handle error)
+            (throw error)))))))))
 
 (defn merge-fork-from-parent!
   "Merge the parent's current state into an OPEN fork. The ForkHandle is the

--- a/test/org/replikativ/spindel/ygg_bridge_portable_test.cljc
+++ b/test/org/replikativ/spindel/ygg_bridge_portable_test.cljc
@@ -69,3 +69,44 @@
       (is (nil? (<? (ygg/discard-fork! fork {:sync? sync?})))
           "a later idempotent call preserves the asynchronous return shape")
       (is (= :discarded (:status (ygg/fork-disposition fork)))))))
+
+(deftest-async settlement-authority-partition-is-portable
+  (th/with-ctx [ctx]
+    (ygg/register! (->TinySys "kb"))
+    (ygg/register! (->TinySys "ledger"))
+    (ygg/register! (->TinySys "files"))
+    (let [whole (<? (ygg/fork! {:sync? sync? :owner :run}))
+          [knowledge files]
+          (ygg/partition-fork!
+           whole
+           [{:systems #{"kb" "ledger"} :owner :knowledge-review}
+            {:systems #{"files"} :owner :code-review}])
+          [kb ledger]
+          (ygg/partition-fork!
+           knowledge
+           [{:systems #{"kb"} :owner :research-review}
+            {:systems #{"ledger"} :owner :accounting-review}])]
+      (is (= :partitioned (:status (ygg/fork-disposition whole))))
+      (is (not (ygg/open-fork? whole)))
+      (is (= :partitioned (:status (ygg/fork-disposition knowledge)))
+          "a partition can be recursively subdivided without a new world fork")
+      (is (= #{"kb"} (set (keys (:fork/systems (ygg/fork-descriptor kb))))))
+      (is (= #{"ledger"} (set (keys (:fork/systems (ygg/fork-descriptor ledger))))))
+      (is (not= (:fork/settlement-id (ygg/fork-descriptor kb))
+                (:fork/settlement-id (ygg/fork-descriptor ledger))))
+      (binding [ec/*execution-context* (:child-ctx whole)]
+        (let [register-error (try
+                               (ygg/register! (->TinySys "late"))
+                               nil
+                               (catch #?(:clj Throwable :cljs :default) error error))
+              unregister-error (try
+                                 (ygg/unregister! "kb")
+                                 nil
+                                 (catch #?(:clj Throwable :cljs :default) error error))]
+          (is (= ::ygg/fork-world-shape-frozen
+                 (:type (ex-data register-error))))
+          (is (= ::ygg/fork-world-shape-frozen
+                 (:type (ex-data unregister-error))))))
+      (is (nil? (<? (ygg/discard-fork! kb {:sync? sync?}))))
+      (is (nil? (<? (ygg/discard-fork! ledger {:sync? sync?}))))
+      (is (nil? (<? (ygg/discard-fork! files {:sync? sync?})))))))

--- a/test/org/replikativ/spindel/yggdrasil_test.clj
+++ b/test/org/replikativ/spindel/yggdrasil_test.clj
@@ -404,6 +404,219 @@
         (is (nil? (ygg/discard-fork! adopted)))
         (is (= :discarded (:status (ygg/fork-disposition adopted))))))))
 
+(deftest test-fork-settlement-authority-partitions-by-system
+  (testing "partition consumes the whole handle and independently settles disjoint systems"
+    (let [ctx (ctx/create-execution-context)
+          second-repo (create-temp-repo)
+          second-system (git-adapter/create second-repo {:system-name "partition-second"})]
+      (try
+        (binding [ec/*execution-context* ctx]
+          (let [first-ref (ygg/register! *test-git-system*)
+                second-ref (ygg/register! second-system)
+                first-id (ygg-proto/system-id @first-ref)
+                second-id (ygg-proto/system-id @second-ref)
+                whole (ygg/fork! {:purpose :proposal :owner :run})]
+            (ygg/with-fork whole
+              (doseq [[yref filename] [[first-ref "accepted.txt"]
+                                       [second-ref "dismissed.txt"]]]
+                (let [branch (name (ygg-proto/current-branch @yref))
+                      wt (str (:worktrees-dir @yref) "/" branch)]
+                  (spit (str wt "/" filename) filename)
+                  (sh "git" "add" filename :dir wt)
+                  (sh "git" "commit" "-m" filename :dir wt))))
+            (let [[accepted dismissed]
+                  (ygg/partition-fork!
+                   whole
+                   [{:systems #{first-id} :owner :code-review}
+                    {:systems #{second-id} :owner :data-review}])
+                  accepted-desc (ygg/fork-descriptor accepted)
+                  dismissed-desc (ygg/fork-descriptor dismissed)]
+              (is (not (ygg/open-fork? whole)))
+              (is (= :partitioned (:status (ygg/fork-disposition whole))))
+              (is (= (:fork/id accepted-desc) (:fork/id dismissed-desc)
+                     (:fork/id (ygg/fork-descriptor whole)))
+                  "partitioning preserves one world identity")
+              (is (not= (:fork/settlement-id accepted-desc)
+                        (:fork/settlement-id dismissed-desc)))
+              (is (= #{first-id} (set (keys (:fork/systems accepted-desc)))))
+              (is (= #{second-id} (set (keys (:fork/systems dismissed-desc)))))
+              (is (= #{first-id} (set (keys (ygg/fork-diff accepted)))))
+              (is (= #{second-id} (set (keys (ygg/fork-diff dismissed)))))
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not open"
+                                    (ygg/merge-fork! whole)))
+              (let [adopted (ygg/transfer-fork! accepted :governance)]
+                (is (not (ygg/open-fork? accepted)))
+                (is (ygg/open-fork? adopted))
+                (ygg/merge-fork! adopted))
+              (is (.exists (io/file (str *test-repo-path* "/accepted.txt"))))
+              (is (not (.exists (io/file (str second-repo "/dismissed.txt"))))
+                  "settling one partition cannot merge a sibling partition")
+              (ygg/discard-fork! dismissed)
+              (is (not (.exists (io/file (str second-repo "/dismissed.txt"))))))))
+        (finally
+          (ctx/stop-context! ctx)
+          (cleanup-temp-repo second-repo))))))
+
+(deftest test-invalid-fork-partitions-do-not-consume-authority
+  (let [ctx (ctx/create-execution-context)
+        second-repo (create-temp-repo)
+        second-system (git-adapter/create second-repo {:system-name "partition-validation"})]
+    (try
+      (binding [ec/*execution-context* ctx]
+        (let [first-ref (ygg/register! *test-git-system*)
+              second-ref (ygg/register! second-system)
+              first-id (ygg-proto/system-id @first-ref)
+              second-id (ygg-proto/system-id @second-ref)
+              whole (ygg/fork!)]
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"overlap"
+                                (ygg/partition-fork!
+                                 whole
+                                 [{:systems #{first-id} :owner :a}
+                                  {:systems #{first-id second-id} :owner :b}])))
+          (is (ygg/open-fork? whole))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exactly cover"
+                                (ygg/partition-fork!
+                                 whole
+                                 [{:systems #{first-id} :owner :a}
+                                  {:systems #{:unknown} :owner :b}])))
+          (is (ygg/open-fork? whole)
+              "validation failures leave the original affine capability open")
+          (ygg/discard-fork! whole)))
+      (finally
+        (ctx/stop-context! ctx)
+        (cleanup-temp-repo second-repo)))))
+
+(deftest test-partition-rejects-an-uncheckpointed-child-only-system
+  (let [ctx (ctx/create-execution-context)
+        second-repo (create-temp-repo)
+        child-repo (create-temp-repo)
+        second-system (git-adapter/create second-repo {:system-name "partition-base"})]
+    (try
+      (binding [ec/*execution-context* ctx]
+        (let [first-ref (ygg/register! *test-git-system*)
+              second-ref (ygg/register! second-system)
+              first-id (ygg-proto/system-id @first-ref)
+              second-id (ygg-proto/system-id @second-ref)
+              whole (ygg/fork!)]
+          (ygg/with-fork whole
+            (ygg/register! (git-adapter/create child-repo
+                                               {:system-name "uncheckpointed-child"})))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"shape changed"
+                                (ygg/partition-fork!
+                                 whole
+                                 [{:systems #{first-id} :owner :a}
+                                  {:systems #{second-id} :owner :b}])))
+          (is (ygg/open-fork? whole))
+          (ygg/discard-fork! whole)))
+      (finally
+        (ctx/stop-context! ctx)
+        (cleanup-temp-repo child-repo)
+        (cleanup-temp-repo second-repo)))))
+
+(deftest test-partition-settlement-fails-closed-when-parent-system-is-removed
+  (let [ctx (ctx/create-execution-context)
+        second-repo (create-temp-repo)
+        second-system (git-adapter/create second-repo {:system-name "partition-parent-shape"})]
+    (try
+      (binding [ec/*execution-context* ctx]
+        (let [first-ref (ygg/register! *test-git-system*)
+              second-ref (ygg/register! second-system)
+              first-id (ygg-proto/system-id @first-ref)
+              second-id (ygg-proto/system-id @second-ref)
+              whole (ygg/fork!)
+              [first-part removed-part]
+              (ygg/partition-fork!
+               whole
+               [{:systems #{first-id} :owner :first}
+                {:systems #{second-id} :owner :second}])]
+          (is (true? (ygg/unregister! second-id))
+              "the parent control plane may change independently")
+          (doseq [operation [(fn [] (ygg/fork-diff removed-part))
+                             (fn [] (ygg/discard-fork! removed-part))]]
+            (let [error (try (operation) nil (catch Throwable error error))]
+              (is (= ::ygg/fork-system-shape-changed (:type (ex-data error))))
+              (is (= #{second-id} (:missing-from-parent (ex-data error))))))
+          (is (ygg/open-fork? removed-part)
+              "preflight shape failure remains retryable and never skips cleanup")
+          (ygg/discard-fork! first-part)))
+      (finally
+        (ctx/stop-context! ctx)
+        (cleanup-temp-repo second-repo)))))
+
+(deftest test-nested-child-only-merge-cannot-bypass-partition-freeze
+  (let [ctx (ctx/create-execution-context)
+        second-repo (create-temp-repo)
+        child-repo (create-temp-repo)
+        second-system (git-adapter/create second-repo {:system-name "partition-frozen-parent"})
+        child-system (git-adapter/create child-repo {:system-name "late-child-only"})]
+    (try
+      (binding [ec/*execution-context* ctx]
+        (let [first-ref (ygg/register! *test-git-system*)
+              second-ref (ygg/register! second-system)
+              first-id (ygg-proto/system-id @first-ref)
+              second-id (ygg-proto/system-id @second-ref)
+              child-id (ygg-proto/system-id child-system)
+              whole (ygg/fork!)
+              [first-part second-part]
+              (ygg/partition-fork!
+               whole
+               [{:systems #{first-id} :owner :first}
+                {:systems #{second-id} :owner :second}])
+              nested (ygg/with-fork whole (ygg/fork!))]
+          (ygg/with-fork nested (ygg/register! child-system))
+          (let [error (try
+                        (ygg/merge-fork! nested)
+                        nil
+                        (catch Throwable error error))]
+            (is (= ::ygg/fork-world-shape-frozen (:type (ex-data error)))))
+          (is (ygg/open-fork? nested)
+              "a frozen-parent preflight failure leaves the nested fork retryable")
+          (is (nil? (ygg/with-fork whole (ygg/system child-id)))
+              "internal child-only carry cannot mutate the frozen registry")
+          (ygg/discard-fork! nested)
+          (ygg/discard-fork! first-part)
+          (ygg/discard-fork! second-part)))
+      (finally
+        (ctx/stop-context! ctx)
+        (cleanup-temp-repo child-repo)
+        (cleanup-temp-repo second-repo)))))
+
+(deftest test-parent-registry-replacement-during-merge-fails-incomplete
+  (th/with-ctx [ctx]
+    (let [yref (ygg/register! *test-git-system*)
+          sid (ygg-proto/system-id @yref)
+          fork-handle (ygg/fork!)
+          seat-var (ns-resolve 'org.replikativ.spindel.yggdrasil
+                               'ensure-parent-signal-and-seat!)
+          original-seat @seat-var
+          entered (promise)
+          release (promise)]
+      (ygg/with-fork fork-handle
+        (let [branch (name (ygg-proto/current-branch @yref))
+              wt (str (:worktrees-dir @yref) "/" branch)]
+          (spit (str wt "/registry-race.txt") "race")
+          (sh "git" "add" "registry-race.txt" :dir wt)
+          (sh "git" "commit" "-m" "registry race" :dir wt)))
+      (let [task (future
+                   (try
+                     (with-redefs-fn
+                       {seat-var (fn [& args]
+                                   (deliver entered :entered)
+                                   @release
+                                   (apply original-seat args))}
+                       #(ygg/merge-fork! fork-handle {:force true}))
+                     (catch Throwable error error)))]
+        (try
+          (is (= :entered (deref entered 5000 :timeout)))
+          (is (true? (ygg/unregister! sid)))
+          (finally
+            (deliver release true)))
+        (let [error @task]
+          (is (= ::ygg/fork-system-shape-changed (:type (ex-data error))))
+          (is (= sid (:system (ex-data error)))))
+        (is (= :incomplete (:status (ygg/fork-disposition fork-handle))))
+        (is (= :mutating (:phase (ygg/fork-disposition fork-handle))))))))
+
 (deftest test-post-commit-callback-failure-does-not-reopen-settlement
   (testing "callback failure reports an integration error after the substrate is terminal"
     (th/with-ctx [ctx]
@@ -588,6 +801,64 @@
                 "Parent's update pulled in after merge")))
 
         (ygg/discard-fork! fork-handle)))))
+
+(deftest test-merge-from-parent-holds-affine-authority
+  (testing "an in-flight parent advance excludes transfer, partition, and settlement"
+    (th/with-ctx [ctx]
+      (ygg/register! *test-git-system*)
+      (let [fork-handle (ygg/fork!)
+            repo-path (:repo-path *test-git-system*)
+            entered (promise)
+            release (promise)
+            shared-pairs-var (ns-resolve 'org.replikativ.spindel.yggdrasil
+                                         'handle-shared-pairs)
+            original-shared-pairs @shared-pairs-var]
+        (spit (str repo-path "/advance-lease.txt") "lease")
+        (sh "git" "add" "advance-lease.txt" :dir repo-path)
+        (sh "git" "commit" "-m" "advance lease" :dir repo-path)
+        (let [task (future
+                     (with-redefs-fn
+                       {shared-pairs-var
+                        (fn [& args]
+                          (deliver entered :entered)
+                          @release
+                          (apply original-shared-pairs args))}
+                       #(ygg/merge-fork-from-parent! fork-handle)))]
+          (try
+            (is (= :entered (deref entered 5000 :timeout)))
+            (is (= :advancing (:status (ygg/fork-disposition fork-handle))))
+            (doseq [operation [(fn [] (ygg/transfer-fork! fork-handle :other))
+                               (fn [] (ygg/partition-fork!
+                                       fork-handle
+                                       [{:systems #{(ygg-proto/system-id *test-git-system*)}
+                                         :owner :a}
+                                        {:systems #{:unknown} :owner :b}]))
+                               (fn [] (ygg/discard-fork! fork-handle))]]
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not open"
+                                    (operation))))
+            (finally
+              (deliver release true)))
+          (is (nil? @task))
+          (is (ygg/open-fork? fork-handle))
+          (ygg/discard-fork! fork-handle))))))
+
+(deftest test-merge-from-parent-mutation-failure-consumes-authority
+  (th/with-ctx [ctx]
+    (ygg/register! *test-git-system*)
+    (let [fork-handle (ygg/fork!)
+          mark-var (ns-resolve 'org.replikativ.spindel.yggdrasil
+                               'mark-advance-mutating!)
+          original-mark @mark-var]
+      (with-redefs-fn
+        {mark-var (fn [handle]
+                    (original-mark handle)
+                    (throw (ex-info "advance mutation probe" {})))}
+        #(is (thrown-with-msg? clojure.lang.ExceptionInfo #"advance mutation probe"
+                               (ygg/merge-fork-from-parent! fork-handle))))
+      (is (= :incomplete (:status (ygg/fork-disposition fork-handle))))
+      (is (= :mutating (:phase (ygg/fork-disposition fork-handle))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not open"
+                            (ygg/discard-fork! fork-handle))))))
 
 (deftest test-merge-fork-from-parent
   (testing "merge-fork-from-parent! works with ForkHandle"


### PR DESCRIPTION
## Summary

- consume one open `ForkHandle` into exhaustive, disjoint per-system settlement capabilities
- preserve one world identity while assigning each partition a durable settlement ID and owner
- scope diff, conflict, parent advance, merge, and discard to the partition handle
- reject overlap, omission, unknown systems, nil owners, and uncheckpointed world-shape changes without consuming authority
- support recursive subdivision without creating another execution-context or substrate fork
- document the unified Yggdrasil world/settlement API

## Why

Dvergr can now transfer a quiesced Run world to durable governance. Simmis ForkSets support per-scope decisions, but directly settling descriptor branches would bypass Spindel affine ownership. This primitive supplies the missing algebra: one world fork, partitioned settlement authority, no competing fork implementation.

This is intentionally a trusted host capability. It partitions Yggdrasil settlement rights, not access to the shared child execution context; Dvergr remains responsible for quiescing the world before transfer/partition.

## Laws covered

- validation failures do not consume the source handle
- a successful partition consumes the source handle
- partitions are disjoint and exhaustive
- one partition cannot merge a sibling system
- each partition transfers and settles independently
- recursive partitioning preserves the original world ID
- uncheckpointed child-only systems fail closed
- JVM and ClojureScript semantics agree

## Verification

- JVM full suite: 941 tests, 3260 assertions, 0 failures
- focused JVM: 35 tests, 134 assertions, 0 failures
- ClojureScript/node: 415 tests, 1573 assertions, 0 failures
- formatting: clean