### PR TITLE
Fix logical reads across nested overlay forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ index. The essentials:
 | [Pub/Sub](docs/pubsub.md) | `mult`, `pub`, buffers, async-sequence-based fan-out. |
 | [Distributed](docs/distributed.md) | `defn-spin-remote`, `spin-remote`, spin↔channel bridge; convergent signal sync; workspace reflection + cross-system forking. |
 | [SCI Integration](docs/sci-integration.md) | Sandboxed spin execution via the Small Clojure Interpreter. |
+| [Inference Worlds](docs/inference.md) | SMC particles as canonical forked worlds, lifecycle, failure recovery, and resource boundaries. |
 
 For contributor patterns and AI-assistant guidance (do's/don'ts when
 modifying the engine, project-specific conventions), see

--- a/deps.edn
+++ b/deps.edn
@@ -42,7 +42,8 @@
                       ;; notably sci/lock_test, which pins that `common-classes`
                       ;; is locked (no `:allow :all`). Needs >= 0.14 for ADR 0007
                       ;; instance-member control (the deny direction of that test).
-                      org.babashka/sci {:mvn/version "0.15.56"}
+                      org.replikativ/sci
+                      {:mvn/version "0.15.59-replikativ.1"}
                       io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts ["-m" "cognitect.test-runner"]
@@ -74,7 +75,10 @@
   :dev {:extra-paths ["test"]
         :extra-deps {org.clojure/tools.namespace {:mvn/version "1.5.0"}}}
 
-  :sci {:extra-deps {org.babashka/sci {:mvn/version "0.8.42"}}}
+  ;; Replikativ compatibility distribution of SCI with forkable interpreter
+  ;; worlds. Do not combine it with org.babashka/sci on one classpath.
+  :sci {:extra-deps {org.replikativ/sci
+                     {:mvn/version "0.15.59-replikativ.1"}}}
 
   :cljs {:extra-paths ["test"]
          :extra-deps {thheller/shadow-cljs {:mvn/version "2.28.21"}

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ with **Getting Started**, then **Concepts**.
 - **[Pub/Sub](pubsub.md)** — `mult`, `pub`, buffers, async-sequence fan-out
 - **[Distributed](distributed.md)** — `defn-spin-remote`, `spin-remote`, the spin↔channel bridge, distributed-scope integration; convergent signal sync; workspace reflection + cross-system forking (`wire-topology!`, `fork-remote!`/`merge-fork-remote!`)
 - **[SCI Integration](sci-integration.md)** — sandboxed spin execution via the Small Clojure Interpreter
+- **[Inference Worlds](inference.md)** — SMC particles as canonical, isolated, affine worlds
 
 ## Internals & Reference
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -724,7 +724,8 @@ SCI integration — functional API. See [SCI Integration](sci-integration.md).
 | Function | Description |
 |----------|-------------|
 | `(create-spindel-sci-context opts)` | Create SCI context with spindel support |
-| `(wrap-spin-for-sci task runtime)` | Wrap native spin as BoundaryTask |
+| `(wrap-capability-for-sci task)` | Wrap an inherited capability for ambient-world execution |
+| `(wrap-spin-for-sci task runtime)` | Wrap an explicit task hosted by `runtime` |
 | `(make-spin-for-sci spin-fn id runtime)` | Create spin from SCI context |
 
 ### Options for `create-spindel-sci-context`

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -27,8 +27,44 @@ Spindel supports **O(1) copy-on-write forking** of execution contexts. Forks sha
   :state-updates {...}     ;; initial overlay state
   :bindings {:key "val"}   ;; fork-local configuration (merged with parent)
   :metadata {:label "my-fork"}
-  :process-id 42)          ;; override auto-assigned process ID
+  :process-id 42           ;; override auto-assigned process ID
+  :executor executor       ;; optional; otherwise shares the parent scheduler
+  :mode :frozen            ;; pin untouched state instead of following parent
+  :forkable-components #{}) ;; optional capability attenuation
 ```
+
+### Fork-selected world components
+
+Some world state is not an FRP signal and is not a mergeable substrate: an
+interpreter heap, capability table, or other process-local realization. Register
+such state with `org.replikativ.spindel.engine.component/register!`. It returns
+a stable `ComponentRef`; resolving that reference in a context selects the
+realization belonging to that world. Values implement `PForkable`, the same
+forking protocol already used by fork-aware signals.
+
+Components are fork-local and are copied automatically by `fork-context`.
+Passing `:forkable-components` explicitly selects the IDs available in the
+child, so a fork can attenuate capabilities instead of inheriting all of them.
+Components are runtime state, not settlement units: durable Yggdrasil systems
+and their merge/discard authority remain governed by `ForkHandle`. Portable
+snapshots deliberately omit components; an embedding reconstructs transient
+realizations from durable source, configuration, and capability descriptors.
+
+Component forks are restricted to rollback-free process-local values. Because
+component realization can happen before a child handle exists, it must not
+acquire a worktree, database branch, or other resource needing compensation.
+Those substrates remain Yggdrasil systems acquired and settled through
+`ForkHandle`; a component may hold the transient interpreter or client view over
+them. Registration requires an explicit forkable or shared declaration, so a
+mutable host object cannot be shared accidentally.
+
+Host callbacks are effects outside copy-on-write state and are isolated by
+default. A child completion is cached in that child but cannot fire a callback
+registered by another world. Inference coordinators deliberately attach the
+engine-only `:causal-follow` authority to callback edges that must survive
+particle resampling. The authority belongs to the edge rather than mutable world
+bindings, so interpreted code cannot promote its own egress. Engine listeners
+and duplicate pending callbacks are always fork-local.
 
 ## Isolation
 
@@ -56,11 +92,19 @@ A fork is **fully isolated from parent for its own writes** (fork→parent never
 | Parent mutates state on a *fork-local* path | Yes | No (fork has its own value or `nil`) |
 | Fork creates new state | No | Yes (in overlay) |
 
-**Fork-local paths** (full isolation, no fall-through from parent): `:continuations`, `:engine/pending`, `:engine/draining?`, `:engine/delayed-spins`, `:engine/timer-handles`, plus any path added via the OverlayBackend's `local-paths` set.
+**Fork-local paths** (full isolation, no fall-through from parent): `:continuations`, `:world/components`, `:world/forkable-components`, `:engine/pending`, `:engine/draining?`, `:engine/delayed-spins`, `:engine/timer-handles`, plus any path added via the OverlayBackend's `local-paths` set.
 
 **Shared paths** (overlay fall-through, parent-following on reads): everything else, including `:nodes`, `:subscriptions`, `:spin-tracking`, `:atoms`, and `:engine/cancelled-tokens`.
 
-If you need fully-isolated semantics on a shared path — a fork that does not track parent's later writes — use `snapshot-context` instead of `fork-context`. A snapshot returns a new root with `ImmutableBackend`, no parent, no fall-through. The cancellation interaction with `:engine/cancelled-tokens` (a shared path) is discussed in the source comments at `src/org/replikativ/spindel/effects/await.cljc` (search for `cancellable-external-pair`).
+If you need fully-isolated semantics on a shared path — a fork that does not
+track parent's later writes while remaining a writable child — use
+`(fork-context parent :mode :frozen)`. This materializes the parent's complete
+fork-time view once and uses it as the immutable base of the child's writable
+overlay. Use `snapshot-context` when the result itself should be an immutable,
+parentless checkpoint. The cancellation interaction with
+`:engine/cancelled-tokens` (a shared path) is discussed in the source comments
+at `src/org/replikativ/spindel/effects/await.cljc` (search for
+`cancellable-external-pair`).
 
 ## Overlay Backend
 
@@ -77,10 +121,10 @@ The fork itself is O(1) — only the overlay structure is created. State is copi
 A fork is fully isolated for *state*, but a few resources are shared with
 the parent context for performance:
 
-- **Executor**: Both parent and fork submit work to the same executor
+- **Executor by default**: Parent and fork submit work to the same executor
   (thread pool on JVM, event loop on CLJS). Concurrent forks compete for
-  the same workers. If you need an isolated executor, create a fresh root
-  context instead.
+  the same workers. Pass `:executor` to `fork-context`/`ygg/fork!` when the
+  child should use a separately managed scheduler.
 - **Drain thread / drain signal** (JVM): One background thread drains
   events for the parent and all of its forks.
 - **External side effects**: HTTP requests, file I/O, console output,

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,0 +1,98 @@
+# Inference Worlds
+
+Spindel's inference combinators execute probabilistic programs as `Spin`
+values. Pure models can keep the default `:world-policy :fresh`. A model that
+reads or changes registered room systems can request canonical worlds:
+
+```clojure
+(smc-infer model 32
+  {:world-policy :fork
+   :world-opts {:systems #{:knowledge :repository}}
+   :resample-threshold 0.5})
+```
+
+Each initial particle is a frozen `ygg/fork!` of the ambient execution
+context. At resampling, each selected ancestor is forked again. Selecting one
+ancestor three times therefore produces three independently writable child
+worlds, not three aliases to one context.
+
+This makes inference a composition of existing Spindel operations:
+
+```text
+ambient world
+  -> fork N frozen particles
+  -> run until a probabilistic checkpoint
+  -> score and select ancestors
+  -> fork each selected ancestor
+  -> resume
+  -> project values and traces into an EmpiricalMeasure
+  -> discard the speculative world tree
+```
+
+The `EmpiricalMeasure` retains result and trace projections in parentless,
+immutable contexts. It therefore retains neither the resampling ancestry nor
+writable settlement authority. On successful completion,
+all particle `ForkHandle`s are consumed newest-generation first. Construction
+and resampling failures are also cleaned up automatically because no affected
+particle is running at those boundaries.
+
+## Failure and recovery
+
+Model failures are fail-fast. Spindel cooperatively cancels sibling particles,
+tracks their terminal callbacks, and discards their worlds automatically once
+they are quiescent. The thrown exception also contains actionable process-local
+recovery operations:
+
+```clojure
+(:world/recovery (ex-data error))
+;; => {:status :open
+;;     :manager <process-local capability>
+;;     :await-quiescent <CPS operation>
+;;     :cancel! <host function>
+;;     :discard! <host function>
+;;     :descriptors [<portable fork descriptors> ...]}
+```
+
+Descriptors are safe durable/audit projections. The manager, operations, and
+its live handles are process-local capabilities. A supervising host can await
+quiescence and retry cleanup if automatic settlement encountered a recoverable
+preflight failure. Cleanup is idempotent, concurrent callers share one result,
+and a read-only preflight failure permits a later retry; failures after mutation
+remain terminal for explicit substrate recovery.
+
+## State placement
+
+Particle-local program state belongs in the particle `ExecutionContext`:
+signals, Spindel atoms, continuations, trace, score, and checkpoint state all
+fork with the world. The manager contains only host lifecycle capabilities for
+the entire inference execution. Durable application records should store fork
+descriptors, not contexts or handles.
+
+The optional top-level `:executor` is used by every particle and forwarded to
+its canonical fork. Without it, world-backed inference shares the ambient
+world's executor, preserving scheduler ownership. The legacy `:fresh` policy
+keeps its existing inference-local shared executor behavior.
+
+## Resources are not copied authority
+
+Forking a Kontor ledger or another registered system creates a hypothetical
+branch of its state. It does not grant duplicate authority to spend external
+compute, tokens, money, or network capacity. Effects that consume real
+resources need an explicit host capability and an affine split/reservation
+policy. Simulations can instead receive stubbed effects, cheaper models, or a
+forked accounting scenario.
+
+## Recursive SCI interpreters
+
+SCI code can construct another Spindel+SCI interpreter inside a child world,
+provided the host explicitly injects the constructor, evaluator, and world
+fork capabilities. The inner interpreter executes `Spin` values against the
+child runtime, and the parent retains settlement authority. Raw `sci.core`
+does not need to be exposed to untrusted Dvergr programs; recursive
+self-programming is a curated capability, not ambient reflection. The world
+API gives SCI opaque IDs backed by a host registry. Raw `ForkHandle` records
+contain mutable affine authority and must never cross the sandbox boundary.
+
+PGAS ancestor scoring still uses legacy snapshot particles, so Spindel rejects
+`:world-policy :fork` together with `:pgas-ancestor-sampling?`. That combination
+can be enabled once auxiliary scoring particles also use canonical worlds.

--- a/docs/sci-integration.md
+++ b/docs/sci-integration.md
@@ -2,6 +2,21 @@
 
 Spindel integrates with [SCI](https://github.com/babashka/sci) (Small Clojure Interpreter) for sandboxed execution of spindel code. This enables agent isolation, security sandboxing, and dynamic code evaluation while maintaining full access to spindel's reactive primitives.
 
+SCI support is optional and is therefore not included in Spindel's published
+POM. Applications using this integration must add the replikativ compatibility
+distribution, which provides the forkable interpreter-world APIs:
+
+```clojure
+{:deps {org.replikativ/spindel {:mvn/version "<version>"}
+        org.replikativ/sci {:mvn/version "0.15.59-replikativ.1"}}}
+```
+
+Do not put `org.replikativ/sci` and `org.babashka/sci` on the same classpath:
+they provide the same `sci.*` namespaces, while only the replikativ coordinate
+currently contains the forkable runtime required by this integration. Once
+those changes are released upstream, this guide will return to the upstream
+coordinate.
+
 ## Overview
 
 SCI provides a safe subset of Clojure that runs in an interpreter. Spindel's SCI integration bridges the gap between native and interpreted contexts using a **BoundaryTask** wrapper pattern that propagates runtime bindings across the boundary.
@@ -12,6 +27,37 @@ Two APIs are provided:
 |-----|-----------|----------|
 | **Functional** | `spindel.sci.boundary` | `make-spin` with CPS functions — simpler, lower overhead |
 | **Macro** | `spindel.sci.macro` | Full `spin` macro with `await`/`track` — full language support |
+
+For a forkable application world, `org.replikativ.spindel.sci.world` is the
+canonical composition layer. It registers the interpreter as a world component
+and returns a stable reference instead of making callers carry a parallel
+`{:runtime ... :sci-ctx ...}` pair.
+
+```clojure
+(require '[org.replikativ.spindel.sci.world :as sci-world])
+
+(def interpreter (sci-world/create! rt))
+
+(binding [ec/*execution-context* rt]
+  (sci-world/eval-string*
+   interpreter
+   "(def memory (atom []))"))
+
+(def child (ctx/fork-context rt :mode :frozen))
+
+;; The same reference now selects the child's forked SCI heap.
+(binding [ec/*execution-context* child]
+  (sci-world/eval-string* interpreter
+                          "(swap! memory conj :child)"))
+```
+
+Suspended `spin` continuations carry an SCI continuation-context token. When
+resumed in a descendant Spindel context, the token is retargeted to the paired
+SCI component, so dynamic bindings and interpreter state continue in that
+world. Parent and child may then resume the copied computation independently.
+The macro/world APIs enable SCI's opt-in `:forkable` runtime mode themselves;
+callers cannot accidentally construct a standard SCI runtime that lacks the
+managed continuation world.
 
 ## Setup
 
@@ -102,7 +148,10 @@ The macro API provides the full `spin` syntax with CPS transformation:
 
 ## Exposing Native Spins to SCI
 
-Pass native spins via the `:native-spins` option. They are automatically wrapped with `BoundaryTask` to propagate runtime bindings:
+Pass native spins via the `:native-spins` option. They are installed as ambient
+capabilities: invoking one uses the caller's currently selected Spindel world,
+so an inherited capability cannot mutate the parent by retaining its creation
+runtime.
 
 ```clojure
 (require '[org.replikativ.spindel.spin.cps :refer [spin]])
@@ -132,12 +181,12 @@ Pass native spins via the `:native-spins` option. They are automatically wrapped
 
 ### Manual Wrapping
 
-You can also wrap spins manually using `wrap-spin-for-sci`:
+Use `wrap-spin-for-sci` only for an explicit cross-world task handle:
 
 ```clojure
 (def wrapped (boundary/wrap-spin-for-sci my-native-spin rt))
 ;; wrapped implements IFn and IDeref
-;; Call as: (wrapped resolve reject) — bindings established automatically
+;; The task executes in rt; callbacks re-enter their caller's world.
 ```
 
 ## Bidirectional Interop
@@ -160,44 +209,40 @@ Native code can directly invoke SCI-created spins because SCI functions implemen
 ;; => 42
 ```
 
-### SCI to Native (BoundaryTask)
+### SCI to Native
 
-SCI code calls native spins through BoundaryTask wrappers. The wrapper establishes `*execution-context*` and `*spin-id*` bindings before invoking the native spin:
+Inherited capabilities follow the ambient world. Explicit task handles retain
+their host world and restore the caller when they complete:
 
 ```
-Native Spin → wrap-spin-for-sci → BoundaryTask
-                                       ↓
-SCI code calls BoundaryTask(resolve, reject)
-                                       ↓
-BoundaryTask binds *execution-context* + *spin-id*
-                                       ↓
-Native spin executes with proper context
+:native-spins → AmbientBoundaryTask → caller's selected world
+
+explicit task → wrap-spin-for-sci → task's host world
+                                    ↓ completion
+                                caller's world
 ```
 
 ## Agent Isolation Pattern
 
-For agent systems (like ratatosk), each agent gets an isolated SCI context with a forked runtime:
+For agent systems, create the interpreter as a component before forking:
 
 ```clojure
 (require '[org.replikativ.spindel.engine.context :as ctx])
 
-(defn create-agent-context
-  "Create isolated agent environment with forked runtime and SCI sandbox."
-  [parent-ctx native-spins]
-  (let [forked-rt (ctx/fork-context parent-ctx)]
-    {:runtime forked-rt
-     :sci-ctx (macro/create-spin-macro-context
-                {:runtime forked-rt
-                 :native-spins native-spins})}))
+(def interpreter
+  (sci-world/create! rt {:native-spins {'tool-1 tool-spin-1}}))
 
 ;; Create isolated agents
-(def agent-a (create-agent-context rt {'tool-1 tool-spin-1}))
-(def agent-b (create-agent-context rt {'tool-2 tool-spin-2}))
+(def agent-a (ctx/fork-context rt :mode :frozen))
+(def agent-b (ctx/fork-context rt :mode :frozen))
 
-;; Each agent sees its own state (fork isolation)
-;; Each agent can only access its own native spins (SCI sandboxing)
-;; Parent runtime unaffected by agent mutations (COW)
+;; `interpreter` selects a distinct heap in rt, agent-a, and agent-b.
 ```
+
+Create different roots when agents need different capability sets. Within one
+root, `:forkable-components` can remove entire components from a child; SCI's
+own namespace and class allowlists govern what code can do inside an inherited
+interpreter.
 
 ### Isolation Guarantees
 

--- a/src/org/replikativ/spindel/effects/await.cljc
+++ b/src/org/replikativ/spindel/effects/await.cljc
@@ -16,8 +16,7 @@
             [org.replikativ.spindel.engine.effects :as eff]
             [org.replikativ.spindel.effects.track :as track]
             [replikativ.logging :as log]
-            [is.simm.partial-cps.async :as pcps-async])
-  #?(:clj (:import [org.replikativ.spindel.spin.core Spin])))
+            [is.simm.partial-cps.async :as pcps-async]))
 
 ;; =============================================================================
 ;; Public API Shim
@@ -29,6 +28,17 @@
   Must only be called inside a spin; outside, this throws."
   [& _]
   (throw (ex-info "await called outside of spin context (should be CPS-transformed)" {})))
+
+(defn ^:no-doc await-finalization
+  "Suspend for an asynchronous resource finalizer even after the owning Spin
+  has been cancelled.
+
+  This is an internal structured-concurrency primitive. Unlike `await`, a
+  repeated `cancel-spin!` does not truncate this cleanup boundary. It preserves
+  the already-running rejection/finally path; it does not hide the Spin's cached
+  cancellation from observers that begin dereferencing afterward."
+  [& _]
+  (throw (ex-info "await-finalization called outside of spin context (should be CPS-transformed)" {})))
 
 ;; *external-await-cancel-token* lives in engine.core so resource
 ;; implementations (Mailbox in spin/sync.cljc) can read it without
@@ -139,7 +149,7 @@
 
   NOTE: In rebuild mode, we SKIP the fast path to ensure child spin bodies execute
   (for side effects like nested spin creation and continuation registration)."
-  [^Spin spin-ref spin-id source-loc resolve reject]
+  [spin-ref spin-id source-loc resolve reject]
   (let [awaited-spin-id (spin-core/spin-id spin-ref)
         noop (fn [& _] nil)
         ctx (ec/current-execution-context)
@@ -238,7 +248,7 @@
         ;; - reactive spins (parallel etc.) that re-complete on signal changes
         ;;   keep using the same continuation across multiple drain dispatches.
         :else
-        (let [child-spin-fn (.-spin-fn ^Spin spin-ref)
+        (let [child-spin-fn (spin-core/spin-body spin-ref)
               child-value (volatile! nil)
               child-error (volatile! nil)
               child-completed? (volatile! false)
@@ -394,15 +404,17 @@
   waiters without losing the message. The Deferred path doesn't need
   the token (its `:pending` callbacks all receive the same value, and
   the cancellation gate makes orphaned ones harmlessly no-op)."
-  [spin-id resolve reject ext-tag source-loc]
-  (let [;; The cancel-token is a fresh UUID per call. Repeated awaits at
+  ([spin-id resolve reject ext-tag source-loc]
+   (cancellable-external-pair spin-id resolve reject ext-tag source-loc true))
+  ([spin-id resolve reject ext-tag source-loc cancellable?]
+   (let [;; The cancel-token is a fresh UUID per call. Repeated awaits at
         ;; the same source-loc on the same resource get DIFFERENT
         ;; tokens, but the cont-id is deterministic — `add-continuation!`
         ;; calls the displaced cont's `:cancel!` before overwriting
         ;; (closes the orphaned-by-re-await loop).
-        cancel-token (keyword "external-await-cancel" (str (random-uuid)))
-        cont-id (keyword (str "external-await-"
-                              (h/content-hash [spin-id ext-tag source-loc])))
+         cancel-token (keyword "external-await-cancel" (str (random-uuid)))
+         cont-id (keyword (str "external-await-"
+                               (h/content-hash [spin-id ext-tag source-loc])))
         ;; Resolve the CURRENT execution context dynamically. If
         ;; *execution-context* is unbound (we're being called from a
         ;; truly external thread that hasn't entered the engine yet),
@@ -412,39 +424,40 @@
         ;;
         ;; Returns the resolved context (or nil) along with the result
         ;; so the caller can reuse it for the self-cleanup disj below.
-        check-and-clean!
-        (fn []
-          (let [ctx (try (ec/current-execution-context)
-                         (catch #?(:clj Throwable :cljs :default) _ nil))
-                cancelled (when ctx (rtp/get-state ctx [:engine/cancelled-tokens]))
-                in-set? (boolean (and cancelled (contains? cancelled cancel-token)))]
+         check-and-clean!
+         (fn []
+           (let [ctx (try (ec/current-execution-context)
+                          (catch #?(:clj Throwable :cljs :default) _ nil))
+                 cancelled (when ctx (rtp/get-state ctx [:engine/cancelled-tokens]))
+                 in-set? (boolean (and cancelled (contains? cancelled cancel-token)))]
             ;; Self-cleaning: external resources deliver each consumer's
             ;; closure at most once. After the closure fires (cancelled or
             ;; not), drop our token from the cancelled set so it doesn't
             ;; accumulate over the context's lifetime. Bounds the set's
             ;; growth to closures that never get fired (e.g. a Deferred
             ;; that's abandoned without being delivered).
-            (when (and ctx in-set?)
-              (rtp/swap-state! ctx [:engine/cancelled-tokens]
-                               (fn [s] (if s (disj s cancel-token) s))))
-            in-set?))
-        wrapped-resolve (fn [v]
-                          (when-not (check-and-clean!)
-                            (resolve v)))
-        wrapped-reject  (fn [e]
-                          (when-not (check-and-clean!)
-                            (reject e)))
-        cont {:id cont-id
+             (when (and ctx in-set?)
+               (rtp/swap-state! ctx [:engine/cancelled-tokens]
+                                (fn [s] (if s (disj s cancel-token) s))))
+             (and cancellable? in-set?)))
+         wrapped-resolve (fn [v]
+                           (when-not (check-and-clean!)
+                             (resolve v)))
+         wrapped-reject  (fn [e]
+                           (when-not (check-and-clean!)
+                             (reject e)))
+         cont {:id cont-id
               ;; Event-key is informational — no handler reads
               ;; `[:external-await …]`. Keeping a key makes the cont
               ;; uniform with the rest of the registry and lets the
               ;; `:subscriptions` cleanup in clear-all-await-
               ;; continuations! / clear-deps! work without special-
               ;; casing.
-              :event-key [:external-await ext-tag]
-              :kind :external-await
-              :source-loc source-loc
-              :cancel-token cancel-token
+               :event-key [:external-await ext-tag]
+               :kind :external-await
+               :cancellation-shielded? (not cancellable?)
+               :source-loc source-loc
+               :cancel-token cancel-token
               ;; Same per-slice snapshot the Spin-await cont carries. We
               ;; are on the awaiter's stack here, so the ambient context
               ;; IS the environment the post-await slice must resume in.
@@ -453,38 +466,55 @@
               ;; body-scoped context was smuggled through the enqueue
               ;; closure, i.e. sometimes accidentally right, never
               ;; guaranteed. See .internal/slice-environment-integrity.md.
-              :slice-state (capture-slice-state (ec/current-execution-context) spin-id)
+               :slice-state (capture-slice-state (ec/current-execution-context) spin-id)
               ;; `:cancel!` takes the engine context to record the
               ;; cancellation in. Engine truncation sites pass the
               ;; context they're operating on, which is what makes
               ;; this fork-safe: fork's truncation records into
               ;; fork's overlay, parent's into parent's.
-              :cancel! (fn [ctx]
-                         (rtp/swap-state! ctx [:engine/cancelled-tokens]
-                                          (fn [s] (conj (or s #{}) cancel-token))))
-              :resolve-fn wrapped-resolve
+               :cancel! (when cancellable?
+                          (fn [ctx]
+                            (rtp/swap-state! ctx [:engine/cancelled-tokens]
+                                             (fn [s] (conj (or s #{}) cancel-token)))))
+               :resolve-fn wrapped-resolve
               ;; Engine cancellation first arms cancel-token and then resumes
               ;; the body through this raw reject continuation so finally/catch
               ;; still run. The external resource alone receives wrapped-reject.
-              :reject-fn reject
+               :reject-fn reject
               ;; on-resume is required for the cont protocol but
               ;; never fires for external-await conts — the engine
               ;; doesn't dispatch on :external-await events.
-              :on-resume (fn [_rt] nil)}]
-    (ec/continuation-add! spin-id cont)
-    (let [cancellation
-          (when (ec/spin-is-cancelled? spin-id)
+               :on-resume (fn [_rt] nil)}]
+     (ec/continuation-add! spin-id cont)
+     (let [cancellation
+           (when (and cancellable? (ec/spin-is-cancelled? spin-id))
             ;; cancel-spin! may have run after await-handler's entry check but
             ;; before this continuation became visible. Claim the just-added
             ;; continuation and reject this slice synchronously; callers must
             ;; then avoid registering a now-orphaned external reader.
-            (when (ec/continuation-remove! spin-id cont-id {:cancel? true})
-              {:result
-               (reject
-                (ex-info "Spin cancelled"
-                         {:type spin-core/spin-cancelled
-                          :spin-id spin-id}))}))]
-      [wrapped-resolve wrapped-reject cancel-token cancellation])))
+             (when (ec/continuation-remove! spin-id cont-id {:cancel? true})
+               {:result
+                (reject
+                 (ex-info "Spin cancelled"
+                          {:type spin-core/spin-cancelled
+                           :spin-id spin-id}))}))]
+       [wrapped-resolve wrapped-reject cancel-token cancellation]))))
+
+(defn await-finalization-handler
+  "Direct handler for the cancellation-shielded finalization boundary."
+  [awaitable spin-id source-loc resolve reject]
+  (try
+    (if (ifn? awaitable)
+      (let [[wr wj _cancel-token _cancellation]
+            (cancellable-external-pair
+             spin-id resolve reject
+             [::finalization #?(:clj (System/identityHashCode awaitable)
+                                :cljs (or (.-name awaitable) (str awaitable)))]
+             source-loc false)]
+        (awaitable wr wj))
+      (reject (eff/type-error 'await-finalization "async thunk" awaitable)))
+    (catch #?(:clj Throwable :cljs :default) error
+      (reject error))))
 
 (defn- await-deferred
   "Direct await handler for Deferred.
@@ -516,9 +546,10 @@
         spin-core/incomplete))))
 
 (defn reactive-spin?
-  "Check if value is a Spin. Works across CLJ/CLJS."
+  "Check if value exposes both reactive identity and an engine Spin body."
   [x]
-  (instance? #?(:clj Spin :cljs spin-core/Spin) x))
+  (and (satisfies? spin-core/PSpin x)
+       (satisfies? spin-core/PSpinBody x)))
 
 (defn await-handler
   "Unified direct await handler - dispatches based on type.
@@ -627,3 +658,9 @@
  ::await-handler
  'org.replikativ.spindel.engine.effects/one-arg->awaitable-map
  'org.replikativ.spindel.effects.await/await-handler)
+
+(eff/register-effect-by-symbol!
+ 'org.replikativ.spindel.effects.await/await-finalization
+ ::await-finalization-handler
+ 'org.replikativ.spindel.engine.effects/one-arg->awaitable-map
+ 'org.replikativ.spindel.effects.await/await-finalization-handler)

--- a/src/org/replikativ/spindel/engine/component.cljc
+++ b/src/org/replikativ/spindel/engine/component.cljc
@@ -1,0 +1,119 @@
+(ns org.replikativ.spindel.engine.component
+  "Non-reactive, context-selected components of an execution world.
+
+  Signals represent values whose changes participate in the FRP graph. A world
+  component instead represents ambient runtime state—an interpreter heap, a
+  capability table, or another process-local resource. `ComponentRef` is stable
+  across forks; resolving it through a bound ExecutionContext selects that
+  world's realization.
+
+  Registration is fail-closed: a value must explicitly implement
+  `PWorldComponent`, or be wrapped with `forkable`/`shared`. Component forking
+  must be rollback-free and process-local. Effectful resources such as database
+  branches and worktrees use Yggdrasil ForkHandles, where acquisition can be
+  settled."
+  (:refer-clojure :exclude [resolve])
+  (:require [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.protocols :as rtp]))
+
+(defrecord ComponentRef [id])
+
+(defprotocol PWorldComponent
+  (realization [component]
+    "Return the value selected for programs running in this world."))
+
+(defrecord ForkableComponent [value fork-fn]
+  PWorldComponent
+  (realization [_] value)
+
+  rtp/PForkable
+  (fork-value [_ fork-id directive]
+    (->ForkableComponent (fork-fn value fork-id directive) fork-fn)))
+
+(defrecord SharedComponent [value]
+  PWorldComponent
+  (realization [_] value)
+
+  rtp/PForkable
+  (fork-value [this _fork-id _directive] this))
+
+(defn forkable
+  "Declare how a rollback-free process-local value is realized in a fork.
+
+  `fork-fn` must not acquire durable resources requiring explicit cleanup."
+  [value fork-fn]
+  (->ForkableComponent value fork-fn))
+
+(defn shared
+  "Explicitly declare that `value` may be shared by reference across worlds."
+  [value]
+  (->SharedComponent value))
+
+(defn component-ref?
+  [x]
+  (instance? ComponentRef x))
+
+(defn register!
+  "Register `value` in the bound ExecutionContext and return its stable ref.
+
+  `id` is optional and useful when an embedding needs deterministic addressing.
+  Registration updates the component map and fork index atomically."
+  ([value]
+   (register! (random-uuid) value))
+  ([id value]
+   (when-not (satisfies? PWorldComponent value)
+     (throw (ex-info
+             "World component requires an explicit fork or sharing policy"
+             {:type ::missing-fork-policy
+              :component/id id
+              :hint "Implement PWorldComponent and PForkable, or use component/forkable or component/shared."})))
+   (let [ref (->ComponentRef id)]
+     (ec/swap-state!
+      []
+      (fn [state]
+        (when (contains? (or (:world/components state) {}) id)
+          (throw (ex-info "World component id is already registered"
+                          {:type ::duplicate-component
+                           :component/id id})))
+        (-> state
+            (assoc-in [:world/components id] value)
+            (update :world/forkable-components (fnil conj #{}) id))))
+     ref)))
+
+(defn unregister!
+  "Remove a component reference from the bound world.
+
+   Idempotent and world-local: unregistering a component in a child hides that
+   realization without removing its parent's. Existing descendants that
+   already materialized the component retain their own realization."
+  [ref]
+  (let [id (:id ref)]
+    (ec/swap-state!
+     []
+     (fn [state]
+       (-> state
+           (update :world/components #(dissoc (or % {}) id))
+           (update :world/forkable-components #(disj (or % #{}) id))))))
+  nil)
+
+(defn resolve-in
+  "Resolve `ref` in `ctx`, returning its fork-local realization."
+  [ctx ref]
+  (let [id (:id ref)
+        components (ec/get-state-in ctx [:world/components])]
+    (if (contains? components id)
+      (realization (get components id))
+      (throw (ex-info "World component is not available in this context"
+                      {:type ::missing-component
+                       :component/id id
+                       :fork-id (:fork-id ctx)})))))
+
+(defn resolve
+  "Resolve `ref` through the currently bound ExecutionContext."
+  [ref]
+  (resolve-in (ec/current-execution-context) ref))
+
+(defn registered
+  "Return the bound world's `{component-id value}` map. Intended for inspection."
+  []
+  (update-vals (or (ec/get-state [:world/components]) {}) realization))

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -253,6 +253,8 @@
                               :subscriptions {}      ; Event subscriptions (reverse index of the continuation tables)
                               :engine/retired-conts {} ; Exact edges consumed by valid continuation retirement
                               :atoms {}              ; Fork-safe execution context atoms
+                              :world/components {}   ; Non-reactive fork-selected resources
+                              :world/forkable-components #{}
                               ;; Engine state
                               :engine/pending []
                               :engine/draining? false
@@ -386,6 +388,10 @@
                 Map of keys to values that spins can read via (:bindings *execution-context*)
     :metadata - Fork metadata (default: parent metadata with updated process-id/depth)
     :process-id - Override auto-assigned process-id (default: parent + 1)
+    :executor - Executor for the fork (default: share the parent's executor)
+    :mode - :following (default), where untouched state reads through to the
+            live parent, or :frozen, where untouched state reads from a
+            materialized fork-time view. Both modes remain copy-on-write.
 
   Returns: New ExecutionContext with overlay backend
 
@@ -408,19 +414,31 @@
     (def fork2 (fork-context fork))        ; process-id 2
 
   Properties:
-  - Fork creation is O(1) with OverlayBackend
+  - :following fork creation is O(1) with OverlayBackend
+  - :frozen materializes the parent view once, then writes copy-on-write
   - Overlay stores only modifications (memory efficient)
   - Reads fall through to parent (shared observer graph)
   - Fork-local state (continuations, engine queue/timers) doesn't fall back
   - Bindings are merged (child overrides parent)
   - Process-id auto-increments for Elle compatibility"
-  [parent-ctx & {:keys [state-updates bindings metadata process-id mode snapshots convergent-fork
-                        forkable-signals]
+  [parent-ctx & {:keys [state-updates bindings metadata process-id mode snapshots convergent-fork executor
+                        forkable-signals forkable-components]
                  :or {state-updates {}
                       bindings {}
                       metadata nil
                       process-id nil
                       mode :following}}]
+  (when-let [reserved (seq (select-keys state-updates
+                                        [:world/components
+                                         :world/forkable-components]))]
+    (throw (ex-info "World component state is owned by fork-context"
+                    {:type ::reserved-component-state
+                     :state/keys (set (keys reserved))})))
+  (when-not (#{:following :frozen} mode)
+    (throw (ex-info "Invalid execution-context fork mode"
+                    {:type ::invalid-fork-mode
+                     :mode mode
+                     :supported #{:following :frozen}})))
   (let [fork-id (keyword (str "fork-" (random-uuid)))
         ;; Copy parent's continuations — both kinds — so the fork inherits
         ;; the parent's reactive subscriptions. Without this, spins
@@ -516,11 +534,41 @@
                          (transient {})
                          forkable-ids)))
 
+        ;; Normalize explicit collections so one component is acquired once.
+        ;; Component forks are rollback-free, process-local operations;
+        ;; durable resources belong behind Yggdrasil ForkHandles.
+        component-ids (set (if (nil? forkable-components)
+                             (rtp/get-state parent-ctx [:world/forkable-components])
+                             forkable-components))
+        parent-components (or (rtp/get-state parent-ctx [:world/components]) {})
+        unknown-component-ids (seq (remove #(contains? parent-components %)
+                                           component-ids))
+        _ (when unknown-component-ids
+            (throw (ex-info "Cannot fork unknown world components"
+                            {:type ::unknown-world-components
+                             :component/ids (set unknown-component-ids)
+                             :fork/parent (:fork-id parent-ctx)})))
+        forked-components
+        (persistent!
+         (reduce
+          (fn [ret component-id]
+            (if (contains? parent-components component-id)
+              (assoc! ret component-id
+                      (rtp/fork-value
+                       (get parent-components component-id)
+                       fork-id
+                       {:fork :component :mode mode}))
+              ret))
+          (transient {})
+          component-ids))
+
         ;; Initialize fork-local state (engine state, continuations, forked nodes)
         fork-local-state (cond-> (merge
                                   {:track-subscriptions (or parent-track-subscriptions {}) ; ← Copy parent's track conts!
                                    :await-conts (or parent-await-conts {})                 ; ← Copy parent's await conts!
                                    :subscriptions (or parent-subscriptions {})             ; ← Copy their reverse index!
+                                   :world/components forked-components
+                                   :world/forkable-components (set component-ids)
                                    :engine/retired-conts {} ; retirement history is world-local
                                    :engine/pending [] ; ← NO inherited events; see the claim-undo below
                                    :engine/draining? false
@@ -533,9 +581,23 @@
                            (seq forked-nodes)
                            (update :nodes merge forked-nodes))
 
-        ;; Create overlay backend over parent's backend
+        ;; A frozen child must not observe later parent writes through untouched
+        ;; paths. Materialize the complete fork-time view as an immutable base,
+        ;; while retaining the real parent context separately for lineage and
+        ;; higher-level Yggdrasil settlement. Registered external systems are
+        ;; overridden by `forked-nodes` above, so their handles are never copied
+        ;; as writable aliases into the child view.
+        parent-view-backend
+        (if (= :frozen mode)
+          (backend/create-immutable-backend
+           (backend/backend-deref (:backend parent-ctx))
+           {:source-fork-id (:fork-id parent-ctx)
+            :fork-mode :frozen})
+          (:backend parent-ctx))
+
+        ;; Create overlay backend over the live or frozen parent view.
         overlay-backend (backend/create-overlay-backend
-                         (:backend parent-ctx)
+                         parent-view-backend
                          fork-local-state)
 
         ;; Merge bindings (child overrides parent)
@@ -576,7 +638,7 @@
                     fork-id
                     overlay-backend
                     parent-ctx  ; Keep parent reference
-                    (:executor parent-ctx)  ; Share executor (for now)
+                    (or executor (:executor parent-ctx))
                     merged-bindings
                     fork-metadata
                     (:running parent-ctx)        ; Share parent's lifecycle flag
@@ -808,9 +870,14 @@
                         state)
 
         ;; Remove pending events if requested
-        final-state (if-not include-pending?
-                      (assoc cleaned-state :engine/pending [])
-                      cleaned-state)
+        final-state (cond-> cleaned-state
+                      (not include-pending?) (assoc :engine/pending [])
+                      ;; Components are live, process-local realizations. A
+                      ;; portable snapshot keeps their durable substrates and
+                      ;; descriptors elsewhere, never interpreter heaps or
+                      ;; capability objects.
+                      true (assoc :world/components {}
+                                  :world/forkable-components #{}))
 
         ;; Create immutable backend
         snapshot-backend (backend/create-immutable-backend
@@ -832,6 +899,46 @@
      nil   ; No :running atom — drain-events! treats this as always-allowed
      nil)  ; No drain-active counter — no stop-context! to wait on
     ))
+
+(defn materialized-fork-context
+  "Create an independent in-process child with a fully materialized backend.
+
+  This is `fork-context` followed by backend materialization, so it preserves
+  lineage, lifecycle ownership, continuation semantics, and component forking.
+  External forkable signals are rejected: they require the affine Yggdrasil
+  ForkHandle lifecycle and therefore canonical `:world-policy :fork` inference.
+  The child starts without copied queues, callbacks, listeners, or timers."
+  [source-ctx & {:keys [clean-in-flight?]
+                 :or {clean-in-flight? true}}]
+  (let [forkable-signals
+        (set (rtp/get-state source-ctx [:forkable-signals]))]
+    (when (seq forkable-signals)
+      (throw
+       (ex-info
+        "Materialized inference forks cannot own external forkable signals"
+        {:type ::materialized-external-state
+         :signal/ids forkable-signals
+         :hint "Use inference :world-policy :fork for affine Yggdrasil settlement."})))
+    (let [child (fork-context source-ctx
+                              :mode :frozen
+                              :forkable-signals #{})
+          effective-state (backend/backend-deref (:backend child))
+          materialized-state
+          (-> (if clean-in-flight?
+                (clean-in-flight-spins effective-state)
+                effective-state)
+              (assoc :engine/pending []
+                     :engine/draining? false
+                     :engine/delayed-spins (sorted-map)
+                     :engine/timer-handles {}
+                     :engine/retired-conts {}
+                     :listeners {}
+                     :pending-callbacks {}))]
+      (-> child
+          (assoc :backend (backend/create-atom-backend materialized-state))
+          (update :metadata assoc
+                  :materialized-fork? true
+                  :source-fork-id (:fork-id source-ctx))))))
 
 (defn restore-snapshot
   "Restore a snapshot to a live execution context.

--- a/src/org/replikativ/spindel/engine/core.cljc
+++ b/src/org/replikativ/spindel/engine/core.cljc
@@ -73,6 +73,15 @@
   a require cycle with `spin/sync.cljc`."
   nil)
 
+(def ^:dynamic *callback-egress-policy*
+  "Authority attached to callbacks created by the current host invocation.
+
+  The default is world-local. Inference coordinators may bind
+  `:causal-follow` when a continuation copied into a descendant is explicitly
+  authorized to complete the coordinating callback. This authority is captured
+  on the callback edge; interpreted code cannot grant it by rebinding a world."
+  :isolated)
+
 ;; =============================================================================
 ;; CLJS Binding Registration
 ;; =============================================================================
@@ -318,6 +327,15 @@
   [path]
   (let [ctx (current-execution-context)]
     (rtp/get-state ctx path)))
+
+(defn get-state-in
+  "Read `path` from the explicit execution context `ctx`.
+
+  Most programs should use `get-state`, which follows the dynamic world. This
+  arity exists for stable world references that must resolve against a context
+  supplied by an embedding or continuation boundary."
+  [ctx path]
+  (rtp/get-state ctx path))
 
 (defn notify-listeners!
   "Fire the watch/egress listeners registered for reference `ref` (id `id`) with the

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -1206,6 +1206,7 @@
           spin (:spin event)
           resolve-fn (:resolve-fn event)
           reject-fn (:reject-fn event)
+          callback-egress-policy (or (:callback-egress-policy event) :isolated)
           execution-context (:execution-context event)]  ; May be nil for normal spins
       (log/trace :engine/spin-execution {:spin-id tid})
       ;; Try to atomically claim execution
@@ -1245,6 +1246,7 @@
                               base-ctx)]
           (binding [ec/*execution-context* effective-ctx
                     ec/*spin-id* tid
+                    ec/*callback-egress-policy* callback-egress-policy
                     pcps-async/*in-trampoline* false]
             ;; Invoke spin (Spin implements IFn)
             (let [result (spin resolve-fn reject-fn)]

--- a/src/org/replikativ/spindel/engine/protocols.cljc
+++ b/src/org/replikativ/spindel/engine/protocols.cljc
@@ -159,15 +159,14 @@
 ;; ----------------------------------------------------------------------------
 
 (defprotocol PForkable
-  "Protocol for a SIGNAL VALUE that needs explicit forking when its host context
-  forks — a reference to external mutable state (a yggdrasil system) that the
-  overlay backend's copy-on-write does NOT isolate by itself, because the value
-  is a handle onto a shared store (a git repo, a datahike conn, a konserve CRDT).
+  "Protocol for a WORLD-BOUND VALUE that needs explicit forking when its host
+  context forks. This includes signal values that reference external mutable
+  state (a yggdrasil system) and non-reactive world components such as an
+  interpreter heap that the overlay backend's copy-on-write cannot isolate.
 
-  When an ExecutionContext is forked, every signal whose id is in
-  [:forkable-signals] is forked by calling `fork-value` on its current value and
-  writing the result as the fork-local signal node. Pure signal values (numbers,
-  maps, …) are NOT in that set and fall through the overlay unchanged.
+  When an ExecutionContext is forked, registered forkable signals and world
+  components call `fork-value`; their results are seated in the child context.
+  Pure values (numbers, maps, …) are not registered and fall through unchanged.
 
   Implementations should:
   - Return a NEW value representing the isolated fork (an Overlay or a branched

--- a/src/org/replikativ/spindel/engine/state_backend.cljc
+++ b/src/org/replikativ/spindel/engine/state_backend.cljc
@@ -114,6 +114,31 @@
     :engine/delayed-spins :engine/timer-handles :listeners})
 
 (def ^:private deleted ::deleted)
+(def ^:private full-replacement-key ::full-replacement)
+
+(defn- full-replacement-map? [value]
+  (and (map? value)
+       (true? (get (meta value) full-replacement-key))))
+
+(defn- mark-full-replacement [value]
+  (if (map? value)
+    (vary-meta value assoc full-replacement-key true)
+    value))
+
+(defn- unmark-full-replacement [value]
+  (if (full-replacement-map? value)
+    (vary-meta value dissoc full-replacement-key)
+    value))
+
+(defn full-replacement
+  "Mark a map-valued initial overlay entry as authoritative.
+
+  Ordinary map entries in an OverlayBackend's initial state are sparse entity
+  deltas and inherit untouched entities from the parent. Use this marker when
+  the supplied map is the complete value and parent entries must be hidden. The
+  marker is internal metadata and is removed from every logical read."
+  [value]
+  (mark-full-replacement value))
 
 (defn- deleted-ancestor?
   "True when an overlay path or one of its prefixes is an explicit tombstone."
@@ -136,6 +161,40 @@
           overlay
           (range 1 (inc (count path)))))
 
+(defn- materialize-entity-tombstones
+  "Remove entity-level tombstones when a caller reads their containing map.
+
+  Exact reads already treat a tombstoned path as absent through
+  `deleted-ancestor?`. A top-level map read must present the same logical view;
+  returning the sparse overlay marker as an ordinary value leaks implementation
+  state into runtime queues such as `:engine/delayed-spins`."
+  [value]
+  (if (map? value)
+    (reduce-kv (fn [logical k v]
+                 (if (= deleted v)
+                   (dissoc logical k)
+                   logical))
+               (unmark-full-replacement value)
+               value)
+    value))
+
+(defn- merge-entity-overlay
+  "Apply a sparse entity map to its logical parent collection.
+
+  OverlayBackend copies shared state at entity granularity. Consequently a
+  read of the containing top-level collection must combine inherited entities
+  with this layer's replacements and tombstones. Exact entity reads remain
+  simple overrides and do not use this function."
+  [parent-value overlay-value]
+  (reduce-kv (fn [entities entity-id entity-value]
+               (if (= deleted entity-value)
+                 (dissoc entities entity-id)
+                 (assoc entities entity-id entity-value)))
+             (if (map? parent-value)
+               parent-value
+               (empty overlay-value))
+             overlay-value))
+
 (defn- merged-overlay-state
   "Materialize the shallow entity-level overlay view, applying tombstones."
   [parent-state overlay local-paths]
@@ -144,6 +203,13 @@
      (cond
        (= deleted overlay-value)
        (dissoc state top-key)
+
+       (full-replacement-map? overlay-value)
+       (assoc state top-key
+              (materialize-entity-tombstones overlay-value))
+
+       (record? overlay-value)
+       (assoc state top-key overlay-value)
 
        (map? overlay-value)
        (assoc state top-key
@@ -177,21 +243,35 @@
 (defrecord OverlayBackend [overlay-atom parent-backend local-paths]
   PStateBackend
 
-  (backend-read [_this path]
-    ;; Special handling for fork-local state (don't fall back to parent)
-    (if (and (seq path) (fork-local-path? (first path) local-paths))
-      ;; Fork-local: overlay only, no parent fallback
-      (let [overlay @overlay-atom]
-        (when-not (deleted-ancestor? overlay path)
-          (get-in overlay path)))
-      ;; Shared state: check overlay, fall back to parent
-      (let [overlay @overlay-atom
-            overlay-val (get-in overlay path ::not-found)]
-        (cond
-          (deleted-ancestor? overlay path) nil
-          (not= overlay-val ::not-found) overlay-val
-          parent-backend (backend-read parent-backend path)
-          :else nil))))
+  (backend-read [this path]
+    (if (empty? path)
+      (backend-deref this)
+      ;; Special handling for fork-local state (don't fall back to parent)
+      (if (fork-local-path? (first path) local-paths)
+        ;; Fork-local: overlay only, no parent fallback
+        (let [overlay @overlay-atom]
+          (when-not (deleted-ancestor? overlay path)
+            (materialize-entity-tombstones (get-in overlay path))))
+        ;; Shared state: check overlay, fall back to parent
+        (let [overlay @overlay-atom
+              overlay-val (get-in overlay path ::not-found)
+              top-overlay (get overlay (first path) ::not-found)]
+          (cond
+            (deleted-ancestor? overlay path) nil
+            (and (> (count path) 1) (full-replacement-map? top-overlay))
+            (materialize-entity-tombstones
+             (get-in (unmark-full-replacement top-overlay) (rest path)))
+            (not= overlay-val ::not-found)
+            (if (and (= 1 (count path))
+                     (map? overlay-val)
+                     (not (record? overlay-val))
+                     (not (full-replacement-map? overlay-val)))
+              (merge-entity-overlay
+               (when parent-backend (backend-read parent-backend path))
+               overlay-val)
+              (materialize-entity-tombstones overlay-val))
+            parent-backend (backend-read parent-backend path)
+            :else nil)))))
 
   (backend-write! [this path f]
     ;; All writes go to overlay
@@ -219,7 +299,10 @@
                         (fn [acc top-key]
                           (let [old-value (get merged top-key)
                                 new-value (get new-state top-key)]
-                            (if (and (map? old-value) (map? new-value))
+                            (if (and (map? old-value)
+                                     (not (record? old-value))
+                                     (map? new-value)
+                                     (not (record? new-value)))
                               (reduce
                                (fn [acc' entity-id]
                                  (let [old-entity (get old-value entity-id)
@@ -238,7 +321,7 @@
                                 acc
                                 (conj acc [[top-key]
                                            (if (contains? new-state top-key)
-                                             new-value
+                                             (mark-full-replacement new-value)
                                              deleted)])))))
                         []
                         top-keys)]
@@ -272,12 +355,15 @@
                     (fn [ov]
                       (let [entity-in-overlay? (not= ::not-found
                                                      (get-in ov entity-path ::not-found))
+                            full-top? (full-replacement-map?
+                                       (get ov (first path)))
                         ;; If entity not in overlay, copy from parent first
                             ov (if entity-in-overlay?
                                  (if (= deleted (get-in ov entity-path))
                                    (assoc-in ov entity-path {})
                                    ov)
-                                 (if-let [parent-entity (when parent-backend
+                                 (if-let [parent-entity (when (and parent-backend
+                                                                   (not full-top?))
                                                           (backend-read parent-backend entity-path))]
                                    (assoc-in ov entity-path parent-entity)
                                    ov))
@@ -312,17 +398,17 @@
           (get-in
            (swap! overlay-atom
                   (fn [ov]
-                    (let [overlay-has? (not= ::not-found
-                                             (get-in ov path ::not-found))
-                          ov (if overlay-has?
-                               ov
-                               (if-some [parent-val (backend-read parent-backend path)]
-                                 (assoc-in ov path parent-val)
-                                 ov))]
-                      (assoc-in ov path
-                                (f (if (= deleted (get-in ov path))
-                                     nil
-                                     (get-in ov path)))))))
+                    (let [overlay-val (get-in ov path ::not-found)
+                          parent-val (backend-read parent-backend path)
+                          current (cond
+                                    (= overlay-val ::not-found) parent-val
+                                    (= overlay-val deleted) nil
+                                    (full-replacement-map? overlay-val)
+                                    (unmark-full-replacement overlay-val)
+                                    (and (map? overlay-val) (not (record? overlay-val)))
+                                    (merge-entity-overlay parent-val overlay-val)
+                                    :else overlay-val)]
+                      (assoc-in ov path (mark-full-replacement (f current))))))
            path)
 
           :else
@@ -345,18 +431,37 @@
               (if (or (fork-local-path? (first path) local-paths)
                       (nil? parent-backend))
                 ov
-                (let [seed-path (if (>= (count path) 2)
+                (let [depth (count path)
+                      seed-path (if (>= depth 2)
                                   (vec (take 2 path)) ;; entity-level CoW
-                                  path)]
+                                  path)
+                      full-top? (full-replacement-map?
+                                 (get ov (first path)))]
                   (if (not= ::not-found (get-in ov seed-path ::not-found))
-                    (if (= deleted (get-in ov seed-path))
+                    (cond
+                      (= deleted (get-in ov seed-path))
                       ;; A whole-state transaction removed this entity.
                       ;; Revive an empty fork-local entity before assoc-in
                       ;; descends through the tombstone.
                       (assoc-in ov seed-path {})
-                      ov)
-                    (if-some [parent-val (backend-read parent-backend seed-path)]
-                      (assoc-in ov seed-path parent-val)
+
+                      (and (= depth 1)
+                           (map? (get-in ov seed-path))
+                           (not (record? (get-in ov seed-path)))
+                           (not (full-replacement-map? (get-in ov seed-path))))
+                      (assoc-in ov seed-path
+                                (mark-full-replacement
+                                 (merge-entity-overlay
+                                  (backend-read parent-backend seed-path)
+                                  (get-in ov seed-path))))
+
+                      :else ov)
+                    (if-some [parent-val (when-not full-top?
+                                           (backend-read parent-backend seed-path))]
+                      (assoc-in ov seed-path
+                                (if (= depth 1)
+                                  (mark-full-replacement parent-val)
+                                  parent-val))
                       ov)))))]
       (swap! overlay-atom
              (fn [ov]
@@ -366,8 +471,18 @@
                                     (get-in ov path)))
                      [a' b'] (f2 (read-local path-a) (read-local path-b))]
                  (-> ov
-                     (assoc-in path-a a')
-                     (assoc-in path-b b'))))))
+                     (assoc-in path-a
+                               (if (and (= 1 (count path-a))
+                                        (not (fork-local-path?
+                                              (first path-a) local-paths)))
+                                 (mark-full-replacement a')
+                                 a'))
+                     (assoc-in path-b
+                               (if (and (= 1 (count path-b))
+                                        (not (fork-local-path?
+                                              (first path-b) local-paths)))
+                                 (mark-full-replacement b')
+                                 b')))))))
     nil)
 
   (backend-deref [_]

--- a/src/org/replikativ/spindel/engine/state_backend.cljc
+++ b/src/org/replikativ/spindel/engine/state_backend.cljc
@@ -110,8 +110,10 @@
   fork must not inherit-then-fire the parent's listener on a fork-private mutation
   (that would leak speculative state). A fork that wants to egress adds its own."
   #{:track-subscriptions :await-conts :subscriptions :engine/retired-conts
+    :world/components :world/forkable-components
     :engine/pending :engine/draining?
-    :engine/delayed-spins :engine/timer-handles :listeners})
+    :engine/delayed-spins :engine/timer-handles :listeners
+    :pending-callbacks})
 
 (def ^:private deleted ::deleted)
 (def ^:private full-replacement-key ::full-replacement)

--- a/src/org/replikativ/spindel/inference/coordinator.cljc
+++ b/src/org/replikativ/spindel/inference/coordinator.cljc
@@ -26,9 +26,12 @@
   (:require [org.replikativ.spindel.engine.protocols :as rtp]
             [org.replikativ.spindel.engine.context :as ctx]
             [org.replikativ.spindel.engine.core :as rtc]
-            [org.replikativ.spindel.engine.executor :refer [execute!]]
+            [org.replikativ.spindel.engine.state-backend :as backend]
+            [org.replikativ.spindel.engine.executor :as executor
+             :refer [execute!]]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.spin.sync :as sync]
+            [org.replikativ.spindel.yggdrasil :as ygg]
             [org.replikativ.spindel.inference.measure :as m]
             [org.replikativ.spindel.inference.kernel :as k]
             [replikativ.logging :as log]
@@ -111,28 +114,475 @@
   (instance? InferenceFailure x))
 
 ;; =============================================================================
+;; Canonical particle worlds
+;; =============================================================================
+
+(defn create-world-manager
+  "Create process-local ownership for every canonical world fork in one
+  inference execution. Handles remain host capabilities; only their portable
+  descriptors may cross a durable boundary."
+  [fork-opts]
+  (atom {:id (random-uuid)
+         :status :open
+         :fork-opts (or fork-opts {})
+         :handles []
+         :pending-forks 0
+         :active-contexts {}
+         :cancel-requested? false
+         :generation-phase nil
+         :cleanup-started? false
+         :quiescence (atom {:status :pending :readers []})
+         :cleanup (atom {:status :pending :readers []})}))
+
+(declare maybe-complete-particle-quiescence!)
+
+(defn world-descriptors
+  "Return the portable projections retained by a particle-world manager."
+  [manager]
+  (let [{:keys [descriptors handles]} @manager]
+    (or descriptors (mapv ygg/fork-descriptor handles))))
+
+(defn- invoke-result!
+  "Invoke a value-or-CPS result without assuming a JVM synchronous substrate."
+  [operation resolve reject]
+  (try
+    (if (fn? operation)
+      (operation resolve reject)
+      (resolve operation))
+    (catch #?(:clj Throwable :cljs :default) error
+      (reject error))))
+
+(defn fork-particle-world!
+  "Fork `source-context` through the canonical Yggdrasil bridge and deliver its
+  ForkHandle. Particle forks are frozen at their source checkpoint: ordinary
+  execution state reads from the fork-time view and every registered external
+  system is independently forked through PForkable."
+  [manager source-context resolve reject]
+  (swap! manager update :pending-forks inc)
+  (let [{:keys [id fork-opts]} @manager
+        settled? (atom false)
+        finish! (fn [update-state f value]
+                  (when (compare-and-set! settled? false true)
+                    (swap! manager update-state)
+                    (try
+                      ;; Fork creation is an effect hosted by a child world,
+                      ;; but its continuation belongs to the source program.
+                      ;; Re-enter the caller explicitly so initialization does
+                      ;; not migrate the coordinating Spin into the new child.
+                      (binding [rtc/*execution-context* source-context]
+                        (f value))
+                      (finally
+                        (maybe-complete-particle-quiescence! manager)))))
+        opts (-> fork-opts
+                 (assoc :mode :frozen
+                        :purpose :particle
+                        :owner id
+                        :sync? false))]
+    (letfn [(succeed! [handle]
+              (finish! (fn [state]
+                         (-> state
+                             (update :handles conj handle)
+                             (update :pending-forks dec)))
+                       resolve handle))
+            (fail! [error]
+              (finish! #(update % :pending-forks dec) reject error))]
+      (binding [rtc/*execution-context* source-context
+                pcps-async/*in-trampoline* false]
+        (try
+          (invoke-result! (ygg/fork! opts) succeed! fail!)
+          (catch #?(:clj Throwable :cljs :default) error
+            (fail! error)))))))
+
+(defn discard-particle-worlds!
+  "Discard all worlds owned by `manager`, newest generation first. Returns a
+  CPS operation and is idempotent after successful cleanup."
+  [manager]
+  (fn [resolve reject]
+    (let [cleanup (:cleanup @manager)
+          immediate (volatile! nil)]
+      ;; A read-only settlement preflight reopens its ForkHandle. Retrying gets
+      ;; a fresh subscriber generation; mutating/incomplete failures remain
+      ;; terminal in the manager and keep their memoized rejection.
+      (loop []
+        (let [state @cleanup]
+          (when (and (= :failed (:status state))
+                     (= :open (:status @manager))
+                     (not (compare-and-set!
+                           cleanup state {:status :pending :readers []})))
+            (recur))))
+      ;; Subscribe before trying to become the cleanup owner. Completion and
+      ;; subscription linearize on this atom, so concurrent callers neither
+      ;; hang nor execute settlement twice.
+      (swap! cleanup
+             (fn [state]
+               (if (= :pending (:status state))
+                 (update state :readers conj {:resolve resolve :reject reject})
+                 (do (vreset! immediate state) state))))
+      (when-let [{:keys [status value error]} @immediate]
+        (if (= :done status) (resolve value) (reject error)))
+      (letfn [(complete! [status payload]
+                (let [readers (volatile! [])]
+                  (swap! cleanup
+                         (fn [state]
+                           (if (= :pending (:status state))
+                             (do
+                               (vreset! readers (:readers state))
+                               (cond-> {:status status :readers []}
+                                 (= status :done) (assoc :value payload)
+                                 (= status :failed) (assoc :error payload)))
+                             state)))
+                  (doseq [{:keys [resolve reject]} @readers]
+                    ((if (= status :done) resolve reject) payload))))
+              (fail! [handle error]
+                (swap! manager assoc
+                       :status (if (ygg/open-fork? handle) :open :failed)
+                       :error error)
+                (complete! :failed error))
+              (step [handles]
+                (if-let [handle (first handles)]
+                  (if (ygg/open-fork? handle)
+                    (binding [rtc/*execution-context* (:parent-ctx handle)
+                              pcps-async/*in-trampoline* false]
+                      (invoke-result!
+                       (ygg/discard-fork! handle {:sync? false})
+                       (fn [_] (step (next handles)))
+                       (fn [error] (fail! handle error))))
+                    (step (next handles)))
+                  (do
+                    ;; Replace process-local affine capabilities with portable
+                    ;; audit projections. This releases every superseded
+                    ;; generation once the final measure no longer needs it.
+                    (swap! manager
+                           (fn [state]
+                             (-> state
+                                 (assoc :status :discarded
+                                        :descriptors
+                                        (mapv ygg/fork-descriptor
+                                              (:handles state))
+                                        :handles [])
+                                 (dissoc :coordinator))))
+                    (complete! :done nil))))
+              (claim! []
+                (let [state @manager]
+                  (case (:status state)
+                    :open
+                    (if (compare-and-set! manager state
+                                          (assoc state :status :discarding))
+                      (step (reverse (:handles state)))
+                      (recur))
+
+                    :discarded (complete! :done nil)
+                    :failed (complete! :failed (:error state))
+                    ;; Another caller owns :discarding; this caller is already
+                    ;; subscribed to the shared cleanup outcome.
+                    :discarding nil
+                    nil)))]
+        (when-not @immediate (claim!))))))
+
+(defn await-particle-world-quiescence
+  "Return a CPS operation resolved when no particle context is still running."
+  [manager]
+  (fn [resolve _reject]
+    (let [quiescence (:quiescence @manager)
+          immediate? (volatile! false)]
+      (swap! quiescence
+             (fn [state]
+               (if (= :done (:status state))
+                 (do (vreset! immediate? true) state)
+                 (update state :readers conj resolve))))
+      (when @immediate? (resolve nil)))))
+
+(defn discard-particle-worlds-when-quiescent!
+  "Return a CPS operation that waits for terminal particle callbacks before
+  consuming world settlement authority."
+  [manager]
+  (fn [resolve reject]
+    ((await-particle-world-quiescence manager)
+     (fn [_]
+       (invoke-result! (discard-particle-worlds! manager) resolve reject))
+     reject)))
+
+(defn register-particle-contexts!
+  "Replace the live particle generation tracked by a world manager."
+  [manager contexts]
+  (swap! manager assoc
+         :active-contexts (into {} (map (juxt :fork-id identity)) contexts))
+  nil)
+
+(defn begin-particle-generation-transition!
+  "Keep quiescence closed while replacement worlds are constructed and their
+  superseded source generation unwinds."
+  [manager]
+  (swap! manager assoc
+         :generation-transition? true
+         :generation-phase :forking)
+  nil)
+
+(defn- claim-particle-generation-retirement!
+  "Linearize source retirement against cancellation during child construction.
+  True means retirement owns the source checkpoints; false means cancellation
+  already owns them and the never-started children must not be admitted."
+  [manager]
+  (let [claimed? (volatile! false)]
+    (swap! manager
+           (fn [state]
+             (if (and (= :forking (:generation-phase state))
+                      (not (:cancel-requested? state)))
+               (do (vreset! claimed? true)
+                   (assoc state :generation-phase :retiring))
+               state)))
+    @claimed?))
+
+(defn complete-particle-generation-transition!
+  "Atomically admit `contexts` unless cancellation won the transition.
+
+  Returns false only when cancellation rejects a non-empty replacement. An
+  empty replacement closes a failed transition without erasing source contexts
+  that still owe terminal callbacks; callers route the failure separately."
+  [manager contexts]
+  (let [contexts (vec contexts)
+        admitted? (volatile! false)]
+    (swap! manager
+           (fn [state]
+             (let [admit? (or (empty? contexts)
+                              (not (:cancel-requested? state)))]
+               (vreset! admitted? admit?)
+               (assoc state
+                      ;; Empty/cancelled replacements were never admitted.
+                      ;; Preserve any source contexts still unwinding so their
+                      ;; terminal callbacks remain the quiescence proof.
+                      :active-contexts
+                      (if (and (seq contexts) admit?)
+                        (into {} (map (juxt :fork-id identity)) contexts)
+                        (:active-contexts state))
+                      :generation-transition? false
+                      :generation-phase nil))))
+    (maybe-complete-particle-quiescence! manager)
+    @admitted?))
+
+(defn- maybe-clean-cancelled-worlds! [manager]
+  (loop []
+    (let [state @manager]
+      (when (and (:cancel-requested? state)
+                 (empty? (:active-contexts state))
+                 (not (:generation-transition? state))
+                 (zero? (:pending-forks state))
+                 (not (:cleanup-started? state)))
+        (if (compare-and-set! manager state (assoc state :cleanup-started? true))
+          (invoke-result!
+           (discard-particle-worlds! manager)
+           (constantly nil)
+           (fn [error]
+             (log/error :inference/particle-world-cleanup-failed
+                        {:error error})))
+          (recur))))))
+
+(defn- maybe-complete-particle-quiescence! [manager]
+  (let [{:keys [active-contexts generation-transition? pending-forks]} @manager]
+    (when (and (empty? active-contexts)
+               (not generation-transition?)
+               (zero? pending-forks))
+      (let [readers (volatile! [])
+            quiescence (:quiescence @manager)]
+        (swap! quiescence
+               (fn [state]
+                 (if (= :done (:status state))
+                   state
+                   (do (vreset! readers (:readers state))
+                       {:status :done :readers []}))))
+        (doseq [reader @readers] (reader nil))
+        (maybe-clean-cancelled-worlds! manager)))))
+
+(defn particle-context-terminal!
+  "Mark one particle context quiescent and trigger deferred failure cleanup."
+  [manager context]
+  (let [remaining (volatile! nil)]
+    (swap! manager
+           (fn [state]
+             (let [active (dissoc (:active-contexts state) (:fork-id context))]
+               (vreset! remaining active)
+               (assoc state :active-contexts active))))
+    (when (empty? @remaining)
+      (maybe-complete-particle-quiescence! manager))
+    nil))
+
+(defn- cancellation-error []
+  (ex-info "Inference particle cancelled"
+           {:type spin-core/spin-cancelled}))
+
+(defn- cancellation-error? [error]
+  (= spin-core/spin-cancelled (:type (ex-data error))))
+
+(defn- resume-checkpoint-reject!
+  "Reject one kernel checkpoint on its owning executor.  If admission is
+  rejected, run the terminal slice through a synchronous executor over the
+  same context/backend so finally blocks and terminal callbacks still run."
+  [context checkpoint error]
+  (let [reject-checkpoint!
+        (fn [execution-context]
+          (binding [rtc/*execution-context* execution-context
+                    pcps-async/*in-trampoline* false]
+            (spin-core/resume (:reject checkpoint) error)))]
+    (try
+      (execute! (:executor context) #(reject-checkpoint! context))
+      (catch #?(:clj Throwable :cljs :default) scheduling-error
+        (log/warn :inference/checkpoint-reject-schedule-failed
+                  {:fork-id (:fork-id context)
+                   :error scheduling-error})
+        (reject-checkpoint!
+         (assoc context :executor (executor/synchronous-executor)))))))
+
+(defn- take-retirement!
+  "Atomically claim a source context's expected retirement callback."
+  [coordinator context]
+  (let [claimed (volatile! nil)
+        fork-id (:fork-id context)]
+    (swap! (:retiring-contexts coordinator)
+           (fn [retiring]
+             (if-let [entry (get retiring fork-id)]
+               (do (vreset! claimed entry)
+                   (dissoc retiring fork-id))
+               retiring)))
+    @claimed))
+
+(defn- retirement-entry [coordinator context]
+  (get @(:retiring-contexts coordinator) (:fork-id context)))
+
+(defn- retire-particle-generation!
+  "Unwind all suspended source particles after their child worlds have been
+  constructed.  Retirement is expected control flow, not inference failure.
+
+  The coordinator methods claim each terminal callback through
+  `:retiring-contexts`; only after every source has quiesced does this CPS
+  operation resolve or reject.  The first non-cancellation cleanup error is
+  retained while the remaining sources continue unwinding."
+  [coordinator particle-states]
+  (fn [resolve reject]
+    (let [states (vec particle-states)
+          remaining (atom (count states))
+          first-error (atom nil)
+          finish-one!
+          (fn [error]
+            (when error (compare-and-set! first-error nil error))
+            (when (zero? (swap! remaining dec))
+              (if-let [error @first-error]
+                (reject error)
+                (resolve nil))))]
+      (if (empty? states)
+        (resolve nil)
+        (do
+          ;; Publish the complete retirement set before rejecting any source;
+          ;; synchronous executors may deliver a terminal callback inline.
+          (doseq [[_ {:keys [context]}] states]
+            (swap! (:retiring-contexts coordinator)
+                   assoc (:fork-id context) {:finish! finish-one!}))
+          (swap! (:particles coordinator)
+                 (fn [particles]
+                   (reduce (fn [next-particles [particle-id state]]
+                             (assoc next-particles particle-id
+                                    (assoc state :status :retiring)))
+                           particles
+                           states)))
+          (doseq [[_particle-id {:keys [context checkpoint]}] states]
+            (try
+              ;; Cascade into ordinary await/owned-spin edges first.  The
+              ;; kernel checkpoint itself is outside that graph and is rejected
+              ;; explicitly below.
+              (when-let [task (rtp/get-state context [:inference :task])]
+                (binding [rtc/*execution-context* context]
+                  (spin-core/cancel-spin! task)))
+              (resume-checkpoint-reject! context checkpoint
+                                         (cancellation-error))
+              (catch #?(:clj Throwable :cljs :default) error
+                ;; A synchronous fallback can throw before reaching the model's
+                ;; terminal callback. Claim and account for that source here.
+                (when-let [{:keys [finish!]} (take-retirement! coordinator context)]
+                  (particle-context-terminal!
+                   (:world-manager coordinator) context)
+                  (finish! (when-not (cancellation-error? error)
+                             error)))))))))))
+
+(defn- cancel-kernel-checkpoints!
+  "Atomically claim and reject continuations parked at a kernel barrier.
+
+  Kernel checkpoints are deliberately coordinated outside Spin's ordinary
+  await graph, so `cancel-spin!` cannot discover them. Claiming the particle
+  status first prevents a concurrent cancellation from rejecting the same CPS
+  slice twice. Terminal accounting still happens only through the particle's
+  top-level reject callback."
+  [coordinator]
+  (when-let [particles (:particles coordinator)]
+    (let [claimed (volatile! [])
+          error (ex-info "Inference particle cancelled"
+                         {:type spin-core/spin-cancelled})]
+      (swap! particles
+             (fn [states]
+               (reduce-kv
+                (fn [next-states particle-id state]
+                  (if (= :checkpoint (:status state))
+                    (do
+                      (vswap! claimed conj state)
+                      (assoc next-states particle-id
+                             (assoc state :status :cancelling)))
+                    (assoc next-states particle-id state)))
+                {}
+                states)))
+      (doseq [{:keys [context checkpoint]} @claimed]
+        (try
+          (resume-checkpoint-reject! context checkpoint error)
+          (catch #?(:clj Throwable :cljs :default) unwind-error
+            ;; The synchronous fallback provides the executor-task boundary
+            ;; inline. Cancellation is its expected terminal throw; report only
+            ;; a genuine cleanup failure and continue unwinding other sources.
+            (when-not (cancellation-error? unwind-error)
+              (log/error :inference/checkpoint-cancel-unwind-failed
+                         {:fork-id (:fork-id context)
+                          :error unwind-error}))))))))
+
+(defn cancel-particle-worlds!
+  "Cooperatively cancel every live particle. Cleanup begins automatically once
+  their resolve/reject callbacks prove quiescence."
+  [manager]
+  (let [{:keys [active-contexts coordinator generation-phase]}
+        (swap! manager assoc :cancel-requested? true)
+        contexts (vals active-contexts)]
+    ;; During :retiring, retirement owns the source checkpoint rejection and
+    ;; will observe :cancel-requested? before admitting children. Cancelling the
+    ;; same continuations here would race/double-resume them. During :forking,
+    ;; cancellation owns the still-current sources; the transition gate keeps
+    ;; cleanup from consuming handles while child construction unwinds.
+    (when-not (= :retiring generation-phase)
+      (doseq [context contexts]
+        (when-let [task (rtp/get-state context [:inference :task])]
+          (try
+            (binding [rtc/*execution-context* context]
+              (spin-core/cancel-spin! task))
+            (catch #?(:clj Throwable :cljs :default) error
+              (log/error :inference/particle-cancel-failed
+                         {:fork-id (:fork-id context) :error error})))))
+      (cancel-kernel-checkpoints! coordinator))
+    (maybe-clean-cancelled-worlds! manager)
+    (discard-particle-worlds-when-quiescent! manager)))
+
+;; =============================================================================
 ;; Helper: Snapshot-Based Context Forking
 ;; =============================================================================
 
 (defn fork-particle-context
-  "Create independent copy of particle context using snapshot-based forking.
+  "Create an independent, fully materialized child particle context.
 
-  Uses snapshot-context + restore-snapshot instead of fork-context to avoid
-  overlay backend isolation issues (see OVERLAY_BACKEND_BUG.md).
-
-  This creates a complete independent copy with AtomBackend, ensuring no
-  shared state between particles.
+  This avoids overlay-backend coupling while retaining parent lineage and
+  independently forking live world components such as SCI interpreters. It is
+  an in-process operation, not a portable snapshot.
 
   Args:
     ctx - ExecutionContext to fork
 
   Returns: New ExecutionContext with AtomBackend (complete independent copy)"
   [ctx]
-  (let [snap (ctx/snapshot-context ctx
-                                   :clean-in-flight? false   ; Keep spin states as-is
-                                   :include-pending? false)] ; Don't include pending events
-    (ctx/restore-snapshot snap
-                          :drain-events? false)))  ; Don't drain - caller initializes state first
+  (ctx/materialized-fork-context
+   ctx
+   :clean-in-flight? false))
 
 ;; =============================================================================
 ;; Helper: Pair Checkpoints for Resampling
@@ -186,6 +636,46 @@
                :particle-id new-particle-id
                :original-idx original-idx}))  ; For debugging
           resampled-contexts)))
+
+(defn pair-world-checkpoints!
+  "Asynchronously fork each selected source particle through Yggdrasil, then
+  pair the frozen child context with the source checkpoint. Duplicate selected
+  ancestors produce distinct writable worlds."
+  [manager resampled-contexts original-contexts particles resolve reject]
+  (let [particle-vec (vec particles)
+        particle-ids (mapv first particle-vec)
+        particle-states (mapv second particle-vec)]
+    (letfn [(step [remaining acc]
+              (if-let [source-context (first remaining)]
+                (let [original-idx
+                      (first
+                       (keep-indexed
+                        (fn [idx original]
+                          (when (identical? source-context original) idx))
+                        original-contexts))]
+                  (if (nil? original-idx)
+                    (reject
+                     (ex-info "Resampled particle has no source checkpoint"
+                              {:type ::missing-particle-source}))
+                    (let [original-particle-id (nth particle-ids original-idx)
+                          particle-state (nth particle-states original-idx)
+                          checkpoint (:checkpoint particle-state)]
+                      (fork-particle-world!
+                       manager source-context
+                       (fn [handle]
+                         (step
+                          (next remaining)
+                          (conj acc
+                                {:context (:child-ctx handle)
+                                 :world handle
+                                 :checkpoint checkpoint
+                                 :particle-id
+                                 (keyword (str "particle-" (gensym)))
+                                 :source-particle-id original-particle-id
+                                 :original-idx original-idx})))
+                       reject))))
+                (resolve acc)))]
+      (step resampled-contexts []))))
 
 ;; =============================================================================
 ;; Continuation Resume
@@ -356,6 +846,8 @@
             current-sweep    ; atom: which checkpoint round we're on
             parent-runtime   ; runtime where coordinator was created (for delivery)
             delivered?       ; atom: flag to ensure we only deliver once
+            world-manager    ; canonical particle worlds, or nil for legacy fresh roots
+            retiring-contexts ; atom: fork-id -> expected generation-retirement callback
    ;; PGIBBS/PGAS support
             pgibbs-retained-trace  ; atom: retained trace for PGIBBS/PGAS (nil if not using)
             retained-particle-id   ; atom: particle-id of retained particle
@@ -364,151 +856,184 @@
   InferenceCoordinator
 
   (notify-checkpoint! [this particle-id context checkpoint]
-    (let [particle-sweep (rtp/get-state context [:inference :sweep])
-          coordinator-sweep @current-sweep]
+    (if (retirement-entry this context)
+      ;; A cancellation `finally` may itself reach a probabilistic checkpoint.
+      ;; It cannot join the next generation's barrier; keep unwinding the same
+      ;; retired slice through its reject continuation.
+      (try
+        (resume-checkpoint-reject! context checkpoint (cancellation-error))
+        (catch #?(:clj Throwable :cljs :default) error
+          (when-let [{:keys [finish!]} (take-retirement! this context)]
+            (when world-manager
+              (particle-context-terminal! world-manager context))
+            (finish! (when-not (cancellation-error? error)
+                       error)))))
+      (let [particle-sweep (rtp/get-state context [:inference :sweep])
+            coordinator-sweep @current-sweep]
       ;; Ignore notifications from previous sweeps (race condition protection)
-      (when (= particle-sweep coordinator-sweep)
-        (let [;; Get current trace from context
-              trace (or (rtp/get-state context [:inference :trace]) {})
-              {:keys [options address]} checkpoint
-              {:keys [observe]} options
+        (when (= particle-sweep coordinator-sweep)
+          (let [;; Get current trace from context
+                trace (or (rtp/get-state context [:inference :trace]) {})
+                {:keys [options address]} checkpoint
+                {:keys [observe]} options
 
               ;; PGIBBS: Check if this is the retained particle at a sample site
               ;; If so, use value from retained trace instead of sampling fresh
-              retained-trace @pgibbs-retained-trace
-              is-retained? (and retained-trace
-                                (= particle-id @retained-particle-id))
-              use-retained-value? (and is-retained?
-                                       (not (some? observe))  ; sample site, not observe
-                                       (contains? retained-trace address))
+                retained-trace @pgibbs-retained-trace
+                is-retained? (and retained-trace
+                                  (= particle-id @retained-particle-id))
+                use-retained-value? (and is-retained?
+                                         (not (some? observe))  ; sample site, not observe
+                                         (contains? retained-trace address))
 
               ;; Override kernel result if using retained trace value
-              kernel-result (if use-retained-value?
+                kernel-result (if use-retained-value?
                               ;; Use retained trace value directly
-                              (let [retained-value (get-in retained-trace [address :value])]
-                                (log/debug :pgibbs/use-retained-value {:particle-id particle-id
-                                                                       :address address
-                                                                       :value retained-value})
-                                {:action :assign :value retained-value})
+                                (let [retained-value (get-in retained-trace [address :value])]
+                                  (log/debug :pgibbs/use-retained-value {:particle-id particle-id
+                                                                         :address address
+                                                                         :value retained-value})
+                                  {:action :assign :value retained-value})
                               ;; Otherwise ask kernel what to do
-                              (k/step kernel context checkpoint trace))]
+                                (k/step kernel context checkpoint trace))]
 
-          (log/debug :kernel-coord/checkpoint {:particle-id particle-id
-                                               :sweep coordinator-sweep
-                                               :action (:action kernel-result)
-                                               :is-retained? is-retained?})
+            (log/debug :kernel-coord/checkpoint {:particle-id particle-id
+                                                 :sweep coordinator-sweep
+                                                 :action (:action kernel-result)
+                                                 :is-retained? is-retained?})
 
-          (case (:action kernel-result)
+            (case (:action kernel-result)
             ;; Simple assignment - resume immediately or barrier
-            :assign
-            (let [{:keys [value]} kernel-result]
+              :assign
+              (let [{:keys [value]} kernel-result]
 
               ;; If barrier policy requires waiting at observations
-              (if (and (= barrier-policy :every-observe) (some? observe))
+                (if (and (= barrier-policy :every-observe) (some? observe))
                 ;; Store state and wait at barrier
-                (do
-                  (swap! particles assoc particle-id
-                         {:context context
-                          :checkpoint checkpoint
-                          :value value
-                          :status :checkpoint
-                          :log-weight (rtp/get-state context [:inference :log-weight])
-                          :retained? is-retained?})
+                  (do
+                    (swap! particles assoc particle-id
+                           {:context context
+                            :checkpoint checkpoint
+                            :value value
+                            :status :checkpoint
+                            :log-weight (rtp/get-state context [:inference :log-weight])
+                            :retained? is-retained?})
 
-                  (let [count (swap! barrier-count inc)]
-                    (log/debug :kernel-coord/barrier-count {:count count :total total-particles})
-                    (when (= count total-particles)
+                    (let [count (swap! barrier-count inc)]
+                      (log/debug :kernel-coord/barrier-count {:count count :total total-particles})
+                      (when (= count total-particles)
                       ;; All particles at barrier - trigger resample logic
-                      (future (trigger-kernel-resample! this)))))
+                        (future (trigger-kernel-resample! this)))))
 
                 ;; No barrier - resume immediately
-                (resume-particle-with-value! context checkpoint value)))
+                  (resume-particle-with-value! context checkpoint value)))
 
             ;; Modify existing trace values - replay from earliest modified checkpoint
-            :modify
-            (let [{:keys [updates]} kernel-result]
-              (log/debug :kernel-coord/modify {:particle-id particle-id
-                                               :num-updates (count updates)})
-              (resume-from-checkpoint! context updates))
+              :modify
+              (let [{:keys [updates]} kernel-result]
+                (log/debug :kernel-coord/modify {:particle-id particle-id
+                                                 :num-updates (count updates)})
+                (resume-from-checkpoint! context updates))
 
             ;; Assign current value, then modify others and replay
-            :assign-and-modify
-            (let [{:keys [value updates]} kernel-result
-                  {:keys [address]} checkpoint]
-              (log/debug :kernel-coord/assign-and-modify {:particle-id particle-id
-                                                          :address address
-                                                          :value value
-                                                          :num-updates (count updates)})
+              :assign-and-modify
+              (let [{:keys [value updates]} kernel-result
+                    {:keys [address]} checkpoint]
+                (log/debug :kernel-coord/assign-and-modify {:particle-id particle-id
+                                                            :address address
+                                                            :value value
+                                                            :num-updates (count updates)})
               ;; First record current assignment in trace
-              (rtp/swap-state! context [:inference :trace]
-                               (fn [t] (assoc (or t {}) address value)))
+                (rtp/swap-state! context [:inference :trace]
+                                 (fn [t] (assoc (or t {}) address value)))
               ;; Then replay from earliest modified
-              (resume-from-checkpoint! context updates)))))))
+                (resume-from-checkpoint! context updates))))))))
 
   (notify-complete! [this particle-id context result]
-    (let [particle-sweep (rtp/get-state context [:inference :sweep])
-          coordinator-sweep @current-sweep]
+    (if-let [{:keys [finish!]} (take-retirement! this context)]
+      (do
+        (when world-manager
+          (particle-context-terminal! world-manager context))
+        (finish! nil))
+      (let [particle-sweep (rtp/get-state context [:inference :sweep])
+            coordinator-sweep @current-sweep]
       ;; Ignore notifications from previous sweeps
-      (when (= particle-sweep coordinator-sweep)
-        (log/debug :kernel-coord/complete {:particle-id particle-id})
+        (when (= particle-sweep coordinator-sweep)
+          (log/debug :kernel-coord/complete {:particle-id particle-id})
 
         ;; Store result in context
-        (rtp/swap-state! context [:inference :result] (constantly result))
+          (rtp/swap-state! context [:inference :result] (constantly result))
 
         ;; Get trace and ask kernel
-        (let [trace (or (rtp/get-state context [:inference :trace]) {})
-              kernel-result (k/on-complete kernel context trace result)]
+          (let [trace (or (rtp/get-state context [:inference :trace]) {})
+                kernel-result (k/on-complete kernel context trace result)]
 
-          (case (:action kernel-result)
+            (case (:action kernel-result)
             ;; Done - record completion
-            :done
-            (let [;; Use kernel's accepted result (may differ from current if proposal rejected)
-                  accepted-result (or (:result kernel-result) result)
-                  accepted-trace (or (:trace kernel-result) trace)]
+              :done
+              (let [;; Use kernel's accepted result (may differ from current if proposal rejected)
+                    accepted-result (or (:result kernel-result) result)
+                    accepted-trace (or (:trace kernel-result) trace)]
 
               ;; Update context with accepted state (for m/get-value to return correct value)
-              (rtp/swap-state! context [:inference :result] (constantly accepted-result))
-              (rtp/swap-state! context [:inference :trace] (constantly accepted-trace))
+                (rtp/swap-state! context [:inference :result] (constantly accepted-result))
+                (rtp/swap-state! context [:inference :trace] (constantly accepted-trace))
 
-              (swap! particles assoc particle-id
-                     {:context context
-                      :status :complete
-                      :result accepted-result
-                      :log-weight (:log-weight kernel-result)})
+                (swap! particles assoc particle-id
+                       {:context context
+                        :status :complete
+                        :result accepted-result
+                        :log-weight (:log-weight kernel-result)})
+
+                (when world-manager
+                  (particle-context-terminal! world-manager context))
 
               ;; Increment barrier count for completion
-              (let [count (swap! barrier-count inc)]
-                (log/debug :kernel-coord/completion-count {:count count :total total-particles})
-                (when (= count total-particles)
-                  (future (trigger-kernel-resample! this)))))
+                (let [count (swap! barrier-count inc)]
+                  (log/debug :kernel-coord/completion-count {:count count :total total-particles})
+                  (when (= count total-particles)
+                    (future (trigger-kernel-resample! this)))))
 
             ;; Iterate - replay from beginning with optional updates
-            :iterate
-            (let [{:keys [updates]} kernel-result]
-              (log/debug :kernel-coord/iterate {:particle-id particle-id
-                                                :num-updates (count updates)})
+              :iterate
+              (let [{:keys [updates]} kernel-result]
+                (log/debug :kernel-coord/iterate {:particle-id particle-id
+                                                  :num-updates (count updates)})
               ;; Clear result since we're re-running
-              (rtp/swap-state! context [:inference :result] (constantly nil))
+                (rtp/swap-state! context [:inference :result] (constantly nil))
               ;; Resume from checkpoint (empty updates = full replay from first checkpoint)
-              (resume-from-checkpoint! context (or updates {}))))))))
+                (resume-from-checkpoint! context (or updates {})))))))))
 
-  (notify-failed! [_this particle-id context error]
-    (log/error :kernel-coord/particle-failed {:particle-id particle-id
-                                              :error error})
+  (notify-failed! [this particle-id context error]
+    (if-let [{:keys [finish!]} (take-retirement! this context)]
+      (do
+        (when world-manager
+          (particle-context-terminal! world-manager context))
+        ;; Cancellation is the expected control signal. A finally/cleanup
+        ;; failure remains a real inference failure, but only after every
+        ;; superseded source has been given a chance to unwind.
+        (finish! (when-not (cancellation-error? error) error)))
+      (do
+        (log/error :kernel-coord/particle-failed {:particle-id particle-id
+                                                  :error error})
     ;; Record the failure on the particle (so it counts as "done" for any
     ;; bookkeeping that walks particle state). No sweep check: a particle
     ;; abort fails the whole inference regardless of sweep — a broken
     ;; model fails every particle identically.
-    (swap! particles assoc particle-id
-           {:context context :status :failed :error error})
+        (swap! particles assoc particle-id
+               {:context context :status :failed :error error})
+        (when world-manager
+          (particle-context-terminal! world-manager context))
     ;; Fail fast: deliver an InferenceFailure marker to on-complete once.
     ;; kernel-infer awaits this Deferred and re-throws on the marker.
     ;; Without this, the still-running particles (if any) never let
     ;; barrier-count reach total-particles, so on-complete is never
     ;; delivered and (await (await-completion …)) waits forever.
-    (when (compare-and-set! delivered? false true)
-      (binding [rtc/*execution-context* parent-runtime]
-        (sync/deliver! on-complete (->InferenceFailure particle-id error)))))
+        (when (compare-and-set! delivered? false true)
+          (binding [rtc/*execution-context* parent-runtime]
+            (sync/deliver! on-complete (->InferenceFailure particle-id error)))
+          (when world-manager
+            (cancel-particle-worlds! world-manager))))))
 
   (await-completion [_this]
     on-complete))
@@ -720,6 +1245,89 @@
 ;; Kernel Coordinator Resample Logic
 ;; =============================================================================
 
+(defn- resume-resampled-contexts!
+  [coordinator particles-state particles-ordered should-resample?
+   is-pgibbs? is-pgas? ancestor-idx contexts-with-checkpoints]
+  (when-let [manager (:world-manager coordinator)]
+    (register-particle-contexts! manager (mapv :context contexts-with-checkpoints)))
+  ;; Reset weights if we resampled.
+  (when should-resample?
+    (doseq [{:keys [context]} contexts-with-checkpoints]
+      (rtp/swap-state! context [:inference :log-weight] (constantly 0.0))))
+
+  (reset! (:particles coordinator) {})
+  (reset! (:barrier-count coordinator) 0)
+
+  (let [retained-pid @(:retained-particle-id coordinator)
+        effective-retained-idx
+        (if (and is-pgas? ancestor-idx)
+          ancestor-idx
+          (when is-pgibbs?
+            (first
+             (keep-indexed
+              (fn [i p] (when (= (first p) retained-pid) i))
+              particles-state))))
+        new-retained-pid
+        (when effective-retained-idx
+          (some->> contexts-with-checkpoints
+                   (filter #(= (:original-idx %) effective-retained-idx))
+                   first
+                   :particle-id))]
+
+    (log/debug :kernel-coord/retained-tracking
+               {:is-pgas? is-pgas?
+                :ancestor-idx ancestor-idx
+                :effective-retained-idx effective-retained-idx
+                :new-retained-pid new-retained-pid})
+
+    (when (and is-pgibbs? new-retained-pid)
+      (reset! (:retained-particle-id coordinator) new-retained-pid))
+
+    (doseq [{:keys [context checkpoint particle-id original-idx world]}
+            contexts-with-checkpoints]
+      (let [orig-state (nth particles-ordered original-idx)
+            value (:value orig-state)
+            is-new-retained? (and is-pgibbs?
+                                  (= particle-id new-retained-pid))]
+        (rtp/swap-state! context [:inference :particle-id]
+                         (constantly particle-id))
+        (rtp/swap-state! context [:inference :sweep]
+                         (constantly @(:current-sweep coordinator)))
+        (when world
+          (rtp/swap-state! context [:inference :world]
+                           (constantly world)))
+        (swap! (:particles coordinator) assoc particle-id
+               {:context context
+                :world world
+                :status :running
+                :retained? is-new-retained?})
+        (resume-particle-with-value! context checkpoint value)))))
+
+(def ^:private projected-inference-keys
+  #{:log-weight :choice-stack :trace :particle-id :sweep :result
+    :deterministic :interventions :mcmc :rw-mcmc :block-gibbs})
+
+(defn- project-settled-particle-context
+  "Create a parentless immutable posterior context. Returning the settled
+  execution context itself would retain its complete resampling ancestry."
+  [context]
+  (let [inference-state (rtp/get-state context [:inference])
+        projected (cond-> (select-keys inference-state
+                                       projected-inference-keys)
+                    (:world inference-state)
+                    (assoc :world-descriptor
+                           (ygg/fork-descriptor (:world inference-state))))]
+    (assoc context
+           :backend (backend/create-immutable-backend
+                     {:inference projected}
+                     {:source-fork-id (:fork-id context)
+                      :projection :inference-posterior})
+           :parent-ctx nil
+           :bindings {}
+           :metadata {:inference/projection true}
+           :running nil
+           :drain-active nil)))
+
 (defn trigger-kernel-resample!
   "Trigger barrier processing for KernelCoordinator.
 
@@ -787,69 +1395,66 @@
             ;; Pair with original checkpoints and fork
             particles-ordered (vec (vals particles-state))
             original-contexts-ordered (mapv :context particles-ordered)
+            continue!
+            (fn [contexts-with-checkpoints]
+              (if-let [manager (:world-manager coordinator)]
+                (if (claim-particle-generation-retirement! manager)
+                  (invoke-result!
+                   (retire-particle-generation! coordinator particles-state)
+                   (fn [_]
+                     (if (complete-particle-generation-transition!
+                          manager (mapv :context contexts-with-checkpoints))
+                       (resume-resampled-contexts!
+                        coordinator particles-state particles-ordered
+                        should-resample? is-pgibbs? is-pgas? ancestor-idx
+                        contexts-with-checkpoints)
+                       ;; Cancellation landed while source finalizers were
+                       ;; running. The children were never started; close the
+                       ;; coordinator and let normal manager cleanup settle all
+                       ;; source/child handles.
+                       (notify-failed! coordinator :particle-generation
+                                       (:parent-runtime coordinator)
+                                       (cancellation-error))))
+                   (fn [retirement-error]
+                     (complete-particle-generation-transition! manager [])
+                     (notify-failed! coordinator :particle-retirement
+                                     (:parent-runtime coordinator)
+                                     retirement-error)))
+                  ;; Cancellation won while child worlds were being forked and
+                  ;; already owns the old source checkpoints. Never retire them
+                  ;; a second time or admit the replacement generation.
+                  (do
+                    (complete-particle-generation-transition! manager [])
+                    (notify-failed! coordinator :particle-generation
+                                    (:parent-runtime coordinator)
+                                    (cancellation-error))))
+                (resume-resampled-contexts!
+                 coordinator particles-state particles-ordered
+                 should-resample? is-pgibbs? is-pgas? ancestor-idx
+                 contexts-with-checkpoints)))]
 
-            contexts-with-checkpoints (pair-checkpoints resampled-contexts
-                                                        original-contexts-ordered
-                                                        particles-state)]
-
-        ;; Reset weights if we resampled
-        (when should-resample?
-          (doseq [{:keys [context]} contexts-with-checkpoints]
-            (rtp/swap-state! context [:inference :log-weight] (constantly 0.0))))
-
-        ;; Update coordinator state
-        (reset! (:particles coordinator) {})
-        (reset! (:barrier-count coordinator) 0)
-
-        ;; Resume all particles with their assigned values
-        ;; particles-ordered is in the SAME order as original-contexts-ordered
-        (let [;; For PGIBBS: find which particle inherited the retained trace
-              ;; by checking which resampled context came from the original retained particle
-              retained-pid @(:retained-particle-id coordinator)
-
-              ;; PGAS: In PGAS mode, ancestor-idx determines which particle's history
-              ;; the retained particle adopts. Use that index directly.
-              ;; PGIBBS: Use the original retained particle index.
-              effective-retained-idx (if (and is-pgas? ancestor-idx)
-                                       ancestor-idx
-                                       (when is-pgibbs?
-                                         (first (keep-indexed
-                                                 (fn [i p] (when (= (first p) retained-pid) i))
-                                                 particles-state))))
-
-              ;; Find which new particle inherits from the retained/ancestor source
-              new-retained-pid (when effective-retained-idx
-                                 (let [matches (filter #(= (:original-idx %) effective-retained-idx)
-                                                       contexts-with-checkpoints)]
-                                   (when (seq matches)
-                                     (:particle-id (first matches)))))]
-
-          (log/debug :kernel-coord/retained-tracking {:is-pgas? is-pgas?
-                                                      :ancestor-idx ancestor-idx
-                                                      :effective-retained-idx effective-retained-idx
-                                                      :new-retained-pid new-retained-pid})
-
-          ;; Update retained particle ID for next barrier
-          (when (and is-pgibbs? new-retained-pid)
-            (reset! (:retained-particle-id coordinator) new-retained-pid))
-
-          (doseq [{:keys [context checkpoint particle-id original-idx]} contexts-with-checkpoints]
-            ;; Get the value that was assigned by the kernel (from original particle state)
-            ;; original-idx indexes into particles-ordered (same order as original-contexts-ordered)
-            (let [orig-state (nth particles-ordered original-idx)
-                  value (:value orig-state)
-                  is-new-retained? (and is-pgibbs? (= particle-id new-retained-pid))]
-
-              ;; Update particle-id and sweep in forked context
-              (rtp/swap-state! context [:inference :particle-id] (constantly particle-id))
-              (rtp/swap-state! context [:inference :sweep] (constantly @(:current-sweep coordinator)))
-
-              ;; Register forked particle
-              (swap! (:particles coordinator) assoc particle-id
-                     {:context context :status :running :retained? is-new-retained?})
-
-              ;; Resume with the value from kernel step
-              (resume-particle-with-value! context checkpoint value)))))
+        (if-let [manager (:world-manager coordinator)]
+          (do
+            ;; Hold quiescence before the first asynchronous child fork. A
+            ;; concurrent cancellation may unwind the source particles, but it
+            ;; cannot settle the tree until every in-flight fork callback has
+            ;; crossed `continue!` or the failure callback below.
+            (begin-particle-generation-transition! manager)
+            (pair-world-checkpoints!
+             manager resampled-contexts original-contexts-ordered particles-state
+             continue!
+             (fn [fork-error]
+               (complete-particle-generation-transition! manager [])
+               ;; Source particles are suspended, not terminal: structured
+               ;; cancellation must unwind their parked continuations and user
+               ;; finally blocks before automatic quiescent cleanup consumes the
+               ;; source and partially constructed child worlds.
+               (notify-failed! coordinator :particle-world
+                               (:parent-runtime coordinator) fork-error))))
+          (continue!
+           (pair-checkpoints resampled-contexts
+                             original-contexts-ordered
+                             particles-state))))
 
       ;; All particles completed - deliver final result
       all-complete?
@@ -857,13 +1462,30 @@
         (let [final-particles (vals particles-state)
               contexts (mapv :context final-particles)
               log-weights (mapv :log-weight final-particles)
-              final-measure (m/empirical (mapv vector contexts log-weights))]
+              legacy-measure (when-not (:world-manager coordinator)
+                               (m/empirical
+                                (mapv vector contexts log-weights)))]
 
           (log/debug :kernel-coord/all-complete {:num-sweeps @(:current-sweep coordinator)
                                                  :num-particles (count contexts)})
-
-          (binding [rtc/*execution-context* (:parent-runtime coordinator)]
-            (sync/deliver! (:on-complete coordinator) final-measure))))
+          (let [deliver!
+                (fn [value]
+                  (binding [rtc/*execution-context*
+                            (:parent-runtime coordinator)]
+                    (sync/deliver! (:on-complete coordinator) value)))]
+            (if-let [manager (:world-manager coordinator)]
+              (invoke-result!
+               (discard-particle-worlds! manager)
+               (fn [_]
+                 (deliver!
+                  (m/empirical
+                   (mapv vector
+                         (mapv project-settled-particle-context contexts)
+                         log-weights))))
+               (fn [error]
+                 (deliver! (->InferenceFailure :particle-world-cleanup
+                                               error))))
+              (deliver! legacy-measure)))))
 
       ;; Mixed state
       :else
@@ -901,6 +1523,8 @@
    (atom 0)                                         ; current-sweep
    runtime                                          ; parent-runtime
    (atom false)                                     ; delivered?
+   (:world-manager opts)                            ; world-manager
+   (atom {})                                        ; retiring-contexts
     ;; PGIBBS/PGAS fields
    (atom (:pgibbs-retained-trace opts))             ; pgibbs-retained-trace
    (atom nil)                                       ; retained-particle-id (set by first particle)

--- a/src/org/replikativ/spindel/inference/inference.cljc
+++ b/src/org/replikativ/spindel/inference/inference.cljc
@@ -35,7 +35,7 @@
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.spin.cps :refer [spin]]
             [org.replikativ.spindel.spin.combinators :as comb]
-            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.effects.await :refer [await await-finalization]]
             [replikativ.logging :as log]
             [anglican.runtime :as ar]
             [clojure.set :as set]))
@@ -112,18 +112,41 @@
                             ;; than silently swallow.
                             (throw error))))]
 
-        ;; Enqueue spin execution event
-        ;; The particle's executor will process this asynchronously
-        (rtc/enqueue-event! {:type :spin-execution
-                             :id spin-id
-                             :spin task
-                             :execution-context context  ; Use particle's context
-                             :resolve-fn resolve-fn
-                             :reject-fn reject-fn})))))
+        ;; Enqueue spin execution event. PEngine currently appends the event
+        ;; before asking its executor to drain, so executor rejection can throw
+        ;; after the event became visible. Cache cancellation immediately: a
+        ;; later drain can then only observe the cancelled result, never run the
+        ;; particle body in a world the startup recovery has already settled.
+        (try
+          (rtc/enqueue-event! {:type :spin-execution
+                               :id spin-id
+                               :spin task
+                               :execution-context context
+                               :callback-egress-policy :causal-follow
+                               :resolve-fn resolve-fn
+                               :reject-fn reject-fn})
+          (catch #?(:clj Throwable :cljs :default) error
+            (spin-core/cancel-spin! task)
+            (when-let [manager (:world-manager coordinator)]
+              (coord/particle-context-terminal! manager context))
+            (throw error)))))))
 
 ;; =============================================================================
 ;; Kernel-Based Inference
 ;; =============================================================================
+
+(defn- particle-world-recovery [world-manager]
+  {:status (:status @world-manager)
+   :manager world-manager
+   :await-quiescent
+   (coord/await-particle-world-quiescence world-manager)
+   :cancel! #(coord/cancel-particle-worlds! world-manager)
+   :discard!
+   #(coord/discard-particle-worlds-when-quiescent! world-manager)
+   :descriptors (coord/world-descriptors world-manager)})
+
+(defmacro ^:private inference-spin [& body]
+  `(spin-core/with-causal-descendant-egress (spin ~@body)))
 
 (defn kernel-infer
   "Run inference using a PInferenceKernel.
@@ -142,6 +165,11 @@
     - :barrier-policy - :every-observe | :none (default :every-observe for SMC behavior)
     - :resample-threshold - ESS threshold (default 0.5)
     - :executor - Shared executor for all particles
+    - :world-policy - :fresh (default) for pure inference, or :fork to
+      execute each particle in a frozen canonical Yggdrasil world that is
+      discarded after the final particle values are captured
+    - :world-opts - Optional :systems/:rights/:snapshots policy forwarded to
+      canonical particle forks; lifecycle fields are owned by inference
 
   Returns: Spin<EmpiricalMeasure>
 
@@ -159,82 +187,177 @@
                                         {:barrier-policy :every-observe}))]
         (query measure identity)))"
   [model-task kernel num-particles & [opts]]
-  (spin
+  (inference-spin
    (log/debug :kernel-infer/start {:kernel-id (k/kernel-id kernel)
                                    :num-particles num-particles
                                    :barrier-policy (:barrier-policy opts :every-observe)})
 
    (let [runtime rtc/*execution-context*
+         world-policy (get opts :world-policy :fresh)
+         _ (when-not (#{:fresh :fork} world-policy)
+             (throw (ex-info "Unknown inference world policy"
+                             {:type ::invalid-world-policy
+                              :world-policy world-policy
+                              :supported #{:fresh :fork}})))
+         _ (when (and (= :fork world-policy)
+                      (:pgas-ancestor-sampling? opts))
+             (throw
+              (ex-info
+               "PGAS ancestor scoring does not yet support canonical worlds"
+               {:type ::world-pgas-unsupported
+                :world-policy world-policy})))
+          ;; Create or use provided shared executor
+         shared-executor (or (:executor opts)
+                             ;; Canonical child worlds share the ambient runtime
+                             ;; unless the caller explicitly delegates another
+                             ;; scheduler. This keeps executor ownership with the
+                             ;; enclosing world instead of leaking an inference-
+                             ;; local pool after affine world settlement.
+                             (when (= :fork world-policy)
+                               (:executor runtime))
+                             (sched/thread-pool-executor {:threads 2}))
+         world-manager (when (= :fork world-policy)
+                         (coord/create-world-manager
+                          (assoc (:world-opts opts) :executor shared-executor)))
          coordinator (coord/create-kernel-coordinator
                       runtime
                       kernel
                       num-particles
-                      opts)
-
-          ;; Create or use provided shared executor
-         shared-executor (or (:executor opts)
-                             (sched/thread-pool-executor {:threads 2}))
+                      (assoc opts :world-manager world-manager))
+         _ (when world-manager
+             (swap! world-manager assoc :coordinator coordinator))
 
           ;; PGIBBS: Check if we have a retained trace (for conditional SMC)
          pgibbs-retained-trace (:pgibbs-retained-trace opts)
 
+         _initial-generation
+         (when world-manager
+           (coord/begin-particle-generation-transition! world-manager))
+
           ;; Initialize particles with coordinator reference
-          ;; For PGIBBS: first particle is retained
+         ;; For PGIBBS: first particle is retained
          initial-particles
-         (vec (map-indexed
-               (fn [idx _]
-                 (let [ctx (ctx/create-execution-context
-                            :executor shared-executor)
-                       particle-id (keyword (str "particle-" (gensym)))
-                       is-retained? (and pgibbs-retained-trace (= idx 0))]
+         (try
+           (let [particles
+                 (loop [idx 0
+                        particles []]
+                   (if (= idx num-particles)
+                     particles
+                     (let [world (when world-manager
+                                   (await
+                                    (fn [resolve reject]
+                                      (coord/fork-particle-world!
+                                       world-manager runtime resolve reject))))
+                           particle-ctx (if world
+                                          (:child-ctx world)
+                                          (ctx/create-execution-context
+                                           :executor shared-executor))
+                           particle-id (keyword (str "particle-" (gensym)))
+                           is-retained? (and pgibbs-retained-trace (= idx 0))]
 
-                    ;; Initialize probabilistic state
-                   (rtp/swap-state! ctx [:inference]
-                                    (constantly {:log-weight 0.0
-                                                 :choice-stack []
-                                                 :trace {}
-                                                 :checkpoints {}
-                                                 :particle-id particle-id
-                                                 :sweep 0
-                                                 :inference-coordinator coordinator}))
+                       (rtp/swap-state!
+                        particle-ctx [:inference]
+                        (constantly
+                         {:log-weight 0.0
+                          :choice-stack []
+                          :trace {}
+                          :checkpoints {}
+                          :particle-id particle-id
+                          :sweep 0
+                          :world world
+                          :inference-coordinator coordinator}))
+                       (rtp/swap-state! particle-ctx [:inference :task]
+                                        (constantly model-task))
 
-                    ;; Store model spin in context
-                   (rtp/swap-state! ctx [:inference :task]
-                                    (constantly model-task))
+                       (when is-retained?
+                         (reset! (.-retained-particle-id coordinator) particle-id)
+                         (log/debug :kernel-infer/set-retained-particle
+                                    {:particle-id particle-id}))
 
-                    ;; PGIBBS: Set retained particle ID in coordinator
-                   (when is-retained?
-                     (reset! (.-retained-particle-id coordinator) particle-id)
-                     (log/debug :kernel-infer/set-retained-particle {:particle-id particle-id}))
-
-                   ctx))
-               (range num-particles)))]
+                       (recur (inc idx) (conj particles particle-ctx)))))]
+             (when (and world-manager
+                        (not (coord/complete-particle-generation-transition!
+                              world-manager particles)))
+               (throw (ex-info "Inference cancelled during particle initialization"
+                               {:type spin-core/spin-cancelled})))
+             particles)
+           (catch #?(:clj Throwable :cljs :default) error
+             (when world-manager
+               ;; Close the generation transaction, then wait past the owning
+               ;; Spin's cancellation for every in-flight fork callback and
+               ;; affine discard to finish.
+               (coord/complete-particle-generation-transition!
+                world-manager [])
+               (await-finalization
+                (coord/cancel-particle-worlds! world-manager)))
+             (throw error)))]
 
      (log/debug :kernel-infer/particles-initialized {:num-particles (count initial-particles)})
 
-      ;; Start all particles
-     (doseq [particle-ctx initial-particles]
-       (start-particle! particle-ctx coordinator))
+     ;; Once particles are registered, this Spin owns their complete lifecycle.
+     ;; Normal completion sets `completed?` only after world settlement and
+     ;; posterior projection. Every other exit — especially cancellation of the
+     ;; public inference Spin by an enclosing Run — cancels and joins the manager
+     ;; before propagating the original result/error.
+     (let [completed? (atom false)]
+       (try
+         ;; Start all particles. Initialization is all-or-nothing from the
+         ;; caller's perspective, but an executor can reject midway through the
+         ;; enqueue loop. In that case distinguish successfully started contexts
+         ;; from contexts that never ran, then enter the normal supervised
+         ;; cancellation/quiescence lifecycle.
+         (let [started (atom #{})]
+           (try
+             (doseq [particle-ctx initial-particles]
+               (start-particle! particle-ctx coordinator)
+               (swap! started conj (:fork-id particle-ctx)))
+             (catch #?(:clj Throwable :cljs :default) error
+               (when world-manager
+                 (doseq [particle-ctx initial-particles
+                         :when (not (contains? @started (:fork-id particle-ctx)))]
+                   (coord/particle-context-terminal! world-manager particle-ctx))
+                 (coord/cancel-particle-worlds! world-manager))
+               (throw
+                (ex-info
+                 "Inference failed while starting particles"
+                 (cond-> {:type ::particle-start-failed
+                          :started (count @started)
+                          :requested num-particles}
+                   world-manager
+                   (assoc :world/recovery
+                          (particle-world-recovery world-manager)))
+                 error)))))
 
-     (log/debug :kernel-infer/particles-started)
+         (log/debug :kernel-infer/particles-started)
 
-      ;; Await completion
-     (let [final-measure (await (coord/await-completion coordinator))]
+         ;; Await completion
+         (let [final-measure (await (coord/await-completion coordinator))]
 
-        ;; A particle's spin aborted: the coordinator delivered a
-        ;; failure marker instead of an EmpiricalMeasure. Re-throw so
-        ;; the calling spin / @(spin …) propagates the error to the
-        ;; agent / REPL caller, instead of returning a bogus measure.
-       (when (coord/inference-failure? final-measure)
-         (throw (ex-info "Inference failed: a particle's model threw"
-                         {:particle-id (:particle-id final-measure)}
-                         (:error final-measure))))
+           ;; A particle's spin aborted: the coordinator delivered a
+           ;; failure marker instead of an EmpiricalMeasure. Re-throw so
+           ;; the calling spin / @(spin …) propagates the error to the
+           ;; agent / REPL caller, instead of returning a bogus measure.
+           (when (coord/inference-failure? final-measure)
+             (let [world-recovery
+                   (when world-manager (particle-world-recovery world-manager))]
+               (throw (ex-info "Inference failed during particle execution"
+                               (cond-> {:type ::inference-failed
+                                        :particle-id (:particle-id final-measure)}
+                                 world-recovery
+                                 (assoc :world/recovery world-recovery))
+                               (:error final-measure)))))
 
-       (log/debug :kernel-infer/complete {:num-particles num-particles
-                                          :log-marginal (m/log-marginal final-measure)
-                                          :ess (m/effective-sample-size final-measure)})
+           (log/debug :kernel-infer/complete
+                      {:num-particles num-particles
+                       :log-marginal (m/log-marginal final-measure)
+                       :ess (m/effective-sample-size final-measure)})
 
-       final-measure))))
+           (reset! completed? true)
+           final-measure)
+         (finally
+           (when (and world-manager (not @completed?))
+             (await-finalization
+              (coord/cancel-particle-worlds! world-manager)))))))))
 
 ;; =============================================================================
 ;; Convenience Functions (Delegate to kernel-infer)
@@ -788,6 +911,12 @@
         (query measure identity)))"
   [model-task num-particles num-iterations & [opts]]
   (spin
+   (when (= :fork (:world-policy opts))
+     (throw
+      (ex-info
+       "PGAS ancestor scoring does not yet support canonical worlds"
+       {:type ::world-pgas-unsupported
+        :world-policy :fork})))
    (log/debug :pgas/start {:num-particles num-particles
                            :num-iterations num-iterations})
 

--- a/src/org/replikativ/spindel/sci/boundary.clj
+++ b/src/org/replikativ/spindel/sci/boundary.clj
@@ -22,9 +22,22 @@
 (deftype BoundaryTask [task runtime task-spin-id]
   clojure.lang.IFn
   (invoke [this resolve reject]
-    (binding [ec/*execution-context* runtime
-              ec/*spin-id* task-spin-id]
-      (task resolve reject)))
+    (let [caller-runtime (ec/current-execution-context)
+          caller-spin-id ec/*spin-id*
+          return-to-caller
+          (fn [continuation]
+            (fn [value]
+              (binding [ec/*execution-context* caller-runtime
+                        ec/*spin-id* caller-spin-id]
+                (continuation value))))]
+      ;; The task executes where it is hosted, but its result returns to the
+      ;; caller's world. Without the wrapped callbacks, awaiting a task in a
+      ;; nested child world migrates the caller's continuation into that child
+      ;; and caches the caller's result on the wrong execution context.
+      (binding [ec/*execution-context* runtime
+                ec/*spin-id* task-spin-id]
+        (task (return-to-caller resolve)
+              (return-to-caller reject)))))
 
   clojure.lang.IDeref
   (deref [this]
@@ -34,7 +47,8 @@
 (defn wrap-spin-for-sci
   "Wrap a native spin for use in SCI contexts.
 
-  Returns a BoundaryTask that establishes proper bindings when called from SCI.
+  Returns a BoundaryTask that executes in the task runtime and re-enters the
+  caller runtime for resolve/reject.
 
   Example:
     (def native-spin (spin (+ 1 2)))
@@ -43,7 +57,39 @@
     ;; In SCI:
     (wrapped resolve reject)  ; Works! Bindings established automatically"
   [task runtime]
-  (BoundaryTask. task runtime (.-spin_id task)))
+  (BoundaryTask. task runtime (spin-core/spin-id task)))
+
+(deftype AmbientBoundaryTask [task task-spin-id]
+  clojure.lang.IFn
+  (invoke [_ resolve reject]
+    (let [caller-runtime (ec/current-execution-context)
+          caller-spin-id ec/*spin-id*
+          return-to-caller
+          (fn [continuation]
+            (fn [value]
+              (binding [ec/*execution-context* caller-runtime
+                        ec/*spin-id* caller-spin-id]
+                (continuation value))))]
+      ;; Capabilities inherited by a fork belong to the selected world. Unlike
+      ;; an explicit cross-world task handle, they must not retain the runtime
+      ;; in which the interpreter was originally constructed.
+      (binding [ec/*execution-context* caller-runtime
+                ec/*spin-id* task-spin-id]
+        (task (return-to-caller resolve)
+              (return-to-caller reject)))))
+
+  clojure.lang.IDeref
+  (deref [_]
+    @task))
+
+(defn wrap-capability-for-sci
+  "Wrap an inherited native capability so it executes in the caller's world.
+
+  Use this for `:native-spins` installed in a forkable interpreter. Use
+  `wrap-spin-for-sci` instead for an explicit handle to a task hosted by a
+  particular world."
+  [task]
+  (AmbientBoundaryTask. task (spin-core/spin-id task)))
 
 ;; =============================================================================
 ;; SCI Spin Creation
@@ -108,7 +154,7 @@
          native-spins {}}}]
   (let [;; Wrap all native spins for SCI
         wrapped-natives (into {} (map (fn [[k v]]
-                                        [k (wrap-spin-for-sci v runtime)])
+                                        [k (wrap-capability-for-sci v)])
                                       native-spins))
 
         ;; Create base SCI context

--- a/src/org/replikativ/spindel/sci/macro.clj
+++ b/src/org/replikativ/spindel/sci/macro.clj
@@ -67,6 +67,10 @@
                     interrupt flag is set so timeouts and user-cancels unwind
                     the computation). Optional — omit for unbounded execution.
                     (Convenience; equivalent to `:sci-opts {:interrupt-fn …}`.)
+    :resolve-sci-context - Optional `(fn [execution-context] sci-context)` used
+                when a suspended continuation resumes in a descendant Spindel
+                world. Embeddings with forked interpreter components use this
+                to select the SCI world paired with the ambient runtime.
     :sci-opts - A map merged into the `sci/init` argument, so a consumer can set
                 ANY SCI option without spindel having to thread it through one key
                 at a time — e.g. `:load-fn` (resolve `(require …)` against the
@@ -94,17 +98,18 @@
                   x (await a)
                   y (await b)]
               (+ x y)))\"))  ; => 30"
-  [{:keys [runtime native-spins expose-track? interrupt-fn sci-opts]
+  [{:keys [runtime native-spins expose-track? interrupt-fn sci-opts resolve-sci-context]
     :or {native-spins {}
          expose-track? true
          sci-opts      {}}}]
   (let [sci-execution-context (sci/new-dynamic-var '*execution-context* runtime)
         sci-spin-id (sci/new-dynamic-var '*spin-id* nil)
         sci-in-trampoline (sci/new-dynamic-var '*in-trampoline* false)
-        ;; Wrap all native spins for SCI (BoundaryTask pattern)
+        ;; Native capabilities follow the caller's selected world. Explicit
+        ;; cross-world task handles use boundary/wrap-spin-for-sci instead.
         wrapped-natives (into {}
                               (map (fn [[k v]]
-                                     [k (boundary/wrap-spin-for-sci v runtime)])
+                                     [k (boundary/wrap-capability-for-sci v)])
                                    native-spins))
 
         ;; Build namespace map — inject native primitives SCI code needs
@@ -149,6 +154,10 @@
         sci-ctx (sci/init
                  (-> sci-opts
                      (cond-> interrupt-fn (assoc :interrupt-fn interrupt-fn))
+                     ;; Spindel captures and retargets suspended continuations;
+                     ;; SCI's direct/standard runtime deliberately does not
+                     ;; maintain the managed world needed for that operation.
+                     (assoc :runtime-mode :forkable)
                      (update :features    #(or % #{:clj}))
                      (update :classes     merge (sci-core/common-classes))
                      (update :bindings    merge wrapped-natives)
@@ -175,6 +184,8 @@
         (let [captured-ctx (ec/current-execution-context)
               captured-spin-id ec/*spin-id*
               captured-trampoline @sci-in-trampoline
+              captured-sci-context (sci/capture-continuation-context sci-ctx)
+              continuation-contexts (atom {sci-ctx captured-sci-context})
               wrap-cont
               (fn [continuation]
                 (fn [value]
@@ -183,18 +194,37 @@
                         current-ctx (if (same-world-or-descendant?
                                          ambient-ctx captured-ctx)
                                       ambient-ctx
-                                      captured-ctx)]
-                    (binding [ec/*execution-context* current-ctx
-                              ;; A Spin keeps one identity across worlds. The
-                              ;; ambient id belongs to the producer/drain that
-                              ;; happened to resume this continuation and must
-                              ;; never re-parent the consumer's next await.
-                              ec/*spin-id* captured-spin-id]
-                      (sci/with-bindings
-                        {sci-execution-context current-ctx
-                         sci-spin-id captured-spin-id
-                         sci-in-trampoline captured-trampoline}
-                        (async/invoke-continuation continuation value))))))]
+                                      captured-ctx)
+                        target-sci-ctx (if resolve-sci-context
+                                         (resolve-sci-context current-ctx)
+                                         sci-ctx)
+                        continuation-context
+                        (or (get @continuation-contexts target-sci-ctx)
+                            (let [retargeted
+                                  (sci/retarget-continuation-context
+                                   captured-sci-context target-sci-ctx)]
+                              (get (swap! continuation-contexts
+                                          #(if (contains? % target-sci-ctx)
+                                             %
+                                             (assoc % target-sci-ctx retargeted)))
+                                   target-sci-ctx)))
+                        resume
+                        (sci/continuation-context-fn
+                         continuation-context
+                         (fn [resumed-value]
+                           (binding [ec/*execution-context* current-ctx
+                                     ;; A Spin keeps one identity across worlds. The
+                                     ;; ambient id belongs to the producer/drain that
+                                     ;; happened to resume this continuation and must
+                                     ;; never re-parent the consumer's next await.
+                                     ec/*spin-id* captured-spin-id]
+                             (sci/with-bindings
+                               {sci-execution-context current-ctx
+                                sci-spin-id captured-spin-id
+                                sci-in-trampoline captured-trampoline}
+                               (async/invoke-continuation continuation
+                                                          resumed-value)))))]
+                    (resume value))))]
           (when-not captured-spin-id
             (throw (ex-info "SCI await requires an owning Spin"
                             {:type ::sci-await-outside-spin

--- a/src/org/replikativ/spindel/sci/world.clj
+++ b/src/org/replikativ/spindel/sci/world.clj
@@ -1,0 +1,54 @@
+(ns org.replikativ.spindel.sci.world
+  "SCI interpreters as ordinary fork-selected Spindel world components."
+  (:require [sci.core :as sci]
+            [org.replikativ.spindel.engine.component :as component]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.sci.macro :as macro]))
+
+(defrecord InterpreterWorld [context]
+  component/PWorldComponent
+  (realization [this] this)
+
+  rtp/PForkable
+  (fork-value [_ _fork-id _directive]
+    (->InterpreterWorld (sci/fork context))))
+
+(defn context-in
+  "Resolve interpreter `ref` in the explicit Spindel execution context."
+  [execution-context ref]
+  (:context (component/resolve-in execution-context ref)))
+
+(defn context
+  "Resolve interpreter `ref` in the currently bound execution context."
+  [ref]
+  (:context (component/resolve ref)))
+
+(defn create!
+  "Create and register a forkable SCI interpreter in `runtime`.
+
+  Options are those accepted by `create-spin-macro-context`, except `:runtime`
+  and `:resolve-sci-context`, which this component owns. Returns a stable
+  ComponentRef; resolving it in a descendant selects the forked interpreter."
+  ([runtime]
+   (create! runtime {}))
+  ([runtime opts]
+   (let [ref-holder (volatile! nil)
+         interpreter
+         (binding [ec/*execution-context* runtime]
+           (sci/with-detached-context
+             #(macro/create-spin-macro-context
+               (assoc opts
+                      :runtime runtime
+                      :resolve-sci-context
+                      (fn [execution-context]
+                        (context-in execution-context @ref-holder))))))
+         ref (binding [ec/*execution-context* runtime]
+               (component/register! (->InterpreterWorld interpreter)))]
+     (vreset! ref-holder ref)
+     ref)))
+
+(defn eval-string*
+  "Evaluate `source` in interpreter `ref` selected by the current world."
+  [ref source]
+  (sci/eval-string* (context ref) source))

--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -22,6 +22,10 @@
 (defprotocol PSpin
   (spin-id [_] "Spin id of this spin."))
 
+(defprotocol PSpinBody
+  (spin-body [_]
+    "Return the CPS body used by the engine's reactive await slow path."))
+
 ;; =============================================================================
 ;; Result Type (from spin/result.cljc)
 ;; =============================================================================
@@ -145,6 +149,17 @@
 ;; Forward declaration for error handling
 (declare abort-spin-chain!)
 
+(defn- callback-visible-in-world?
+  "Whether a callback edge explicitly permits completion from another world."
+  [ctx origin-fork-id egress-policy]
+  (or (= (:fork-id ctx) origin-fork-id)
+      (and (= :causal-follow egress-policy)
+           (loop [candidate (:parent-ctx ctx)]
+             (cond
+               (nil? candidate) false
+               (= (:fork-id candidate) origin-fork-id) true
+               :else (recur (:parent-ctx candidate)))))))
+
 ;; spin-fn now arity-2 (resolve reject) relying on dynamic bindings (*execution-context*, *spin-id*).
 ;; Spin is STATELESS - no runtime reference, uses dynamic *execution-context* binding.
 
@@ -212,6 +227,7 @@
              (ec/enqueue-event! {:type :spin-execution
                                  :id spin-id
                                  :spin this
+                                 :callback-egress-policy ec/*callback-egress-policy*
                                  :resolve-fn (fn [value]
                                                (deliver result-promise (ok value)))
                                  :reject-fn (fn [e]
@@ -222,6 +238,9 @@
 (deftype Spin [spin-id spin-fn]
   PSpin
   (spin-id [_] spin-id)
+
+  PSpinBody
+  (spin-body [_] spin-fn)
 
   #?(:clj clojure.lang.IFn :cljs IFn)
   (#?(:clj invoke :cljs -invoke) [this resolve reject]
@@ -291,7 +310,14 @@
           ;; Case 2: Cache miss - execute spin
         :else
         (let [;; Local execution state (ephemeral, not in runtime)
-              callbacks-atom (atom [{:resolve resolve :reject reject}])
+              ;; A continuation can be copied into a child world. The initiating
+              ;; callback is process-local egress owned by the world that called
+              ;; this Spin; completing the copied child must cache its child
+              ;; result without firing the parent's callback.
+              callbacks-atom (atom [{:fork-id (:fork-id runtime)
+                                     :egress-policy ec/*callback-egress-policy*
+                                     :resolve resolve
+                                     :reject reject}])
               executing? (atom true)]
 
           (log/debug :spin/start {:spin-id spin-id})
@@ -325,7 +351,11 @@
 
                                 ;; Call all pending callbacks from local state
                               (let [callbacks @callbacks-atom]
-                                (doseq [{:keys [resolve]} callbacks]
+                                (doseq [{callback-fork-id :fork-id
+                                         :keys [resolve egress-policy]} callbacks
+                                        :when (callback-visible-in-world?
+                                               current-rt callback-fork-id
+                                               egress-policy)]
                                     ;; Call resolve via resume to handle Thunk returns
                                   (resume resolve value)))
 
@@ -362,7 +392,11 @@
 
                                 ;; Call all pending callbacks from local state
                               (let [callbacks @callbacks-atom]
-                                (doseq [{:keys [reject]} callbacks]
+                                (doseq [{callback-fork-id :fork-id
+                                         :keys [reject egress-policy]} callbacks
+                                        :when (callback-visible-in-world?
+                                               _current-rt callback-fork-id
+                                               egress-policy)]
                                     ;; Call reject via resume to handle Thunk returns
                                   (resume reject err)))
 
@@ -403,6 +437,42 @@
   Object
   (toString [_this]
     (str "#<Spin " spin-id ">")))
+
+(deftype CallbackEgressSpin [task policy]
+  PSpin
+  (spin-id [_] (spin-id task))
+
+  PSpinBody
+  (spin-body [_]
+    (let [body (spin-body task)]
+      (fn [resolve reject]
+        (binding [ec/*callback-egress-policy* policy]
+          (body resolve reject)))))
+
+  #?(:clj clojure.lang.IFn :cljs IFn)
+  (#?(:clj invoke :cljs -invoke) [_ resolve reject]
+    (binding [ec/*callback-egress-policy* policy]
+      (task resolve reject)))
+
+  #?(:clj clojure.lang.IDeref :cljs IDeref)
+  (#?(:clj deref :cljs -deref) [_]
+    (binding [ec/*callback-egress-policy* policy]
+      @task))
+
+  #?@(:clj
+      [clojure.lang.IBlockingDeref
+       (deref [_ timeout-ms timeout-val]
+              (binding [ec/*callback-egress-policy* policy]
+                (deref task timeout-ms timeout-val)))])
+
+  Object
+  (toString [_]
+    (str "#<CallbackEgressSpin " (spin-id task) " " policy ">")))
+
+(defn ^:no-doc with-causal-descendant-egress
+  "Authorize a host-owned Spin callback to complete from COW descendants."
+  [task]
+  (CallbackEgressSpin. task :causal-follow))
 
 ;; =============================================================================
 ;; Spin Creation
@@ -676,13 +746,13 @@
         ;; Then arm the external-resource cancellation gate (so a later delivery on
         ;; the abandoned reader is a no-op) and drop the now-spent cont.
             :external-await
-            (do (try
-                  (binding [ec/*execution-context* ctx
-                            ec/*spin-id*          sid
-                            pcps-async/*in-trampoline* false]
-                    (when-let [rj (:reject-fn cont)] (rj err)))
-                  (catch #?(:clj Throwable :cljs :default) _ nil))
-                nil)
+            (when-not (:cancellation-shielded? cont)
+              (try
+                (binding [ec/*execution-context* ctx
+                          ec/*spin-id*          sid
+                          pcps-async/*in-trampoline* false]
+                  (when-let [rj (:reject-fn cont)] (rj err)))
+                (catch #?(:clj Throwable :cljs :default) _ nil)))
         ;; Parked awaiting a child spin (incl. a reactive aseq/PSpin): resume THIS
         ;; parent into reject directly — the cont's :reject-fn is the parent body's
         ;; raw reject continuation, so invoking it unwinds the parent's try/finally

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -938,6 +938,7 @@
 
    opts (optional): forwarded to `ctx/fork-context` —
      :mode      :following (default) | :frozen — overlay fork relation to parent
+     :executor  optional child executor (default: share the parent's executor)
      :snapshots {system-id -> snapshot-id} — pin those systems at fixed values
      :systems   :all (default) | :none | #{system-id ...} — systems visible and
        forked in the child. Excluded systems are hidden, never shared writable.

--- a/src/org/replikativ/spindel/yggdrasil.cljc
+++ b/src/org/replikativ/spindel/yggdrasil.cljc
@@ -49,6 +49,7 @@
          (d/transact! @@ydb [{:foo/bar 1}]))
        (ygg/merge-fork! fork))                       ; merge each overlay down"
   (:require [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.state-backend :as backend]
             [org.replikativ.spindel.engine.protocols :as rtp]
             [org.replikativ.spindel.engine.context :as ctx]
             [org.replikativ.spindel.engine.nodes :as nodes]
@@ -1025,7 +1026,8 @@
                                         [(:id sr) snap])))
                            s))
             state-updates (-> (or (:state-updates opts) {})
-                              (assoc registry-key selected-reg
+                              (assoc registry-key
+                                     (backend/full-replacement selected-reg)
                                      :forkable-signals selected-signal-ids)
                               (update :nodes #(merge (or % {}) attenuated-nodes)))
             fopts  (cond-> (-> opts

--- a/test/org/replikativ/spindel/engine/component_test.clj
+++ b/test/org/replikativ/spindel/engine/component_test.clj
@@ -1,0 +1,191 @@
+(ns org.replikativ.spindel.engine.component-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.engine.component :as component]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.engine.state-backend :as backend]))
+
+(defrecord ForkableBox [value]
+  component/PWorldComponent
+  (realization [this] this)
+
+  rtp/PForkable
+  (fork-value [_ fork-id directive]
+    (->ForkableBox [value fork-id directive])))
+
+(deftest component-ref-selects-the-current-world
+  (let [parent (context/create-execution-context)]
+    (try
+      (let [ref (binding [ec/*execution-context* parent]
+                  (component/register! :box (->ForkableBox :parent)))
+            child (context/fork-context parent :mode :frozen)]
+        (try
+          (is (= :parent (:value (component/resolve-in parent ref))))
+          (let [[value fork-id directive]
+                (:value (component/resolve-in child ref))]
+            (is (= :parent value))
+            (is (= (:fork-id child) fork-id))
+            (is (= {:fork :component :mode :frozen} directive)))
+          (binding [ec/*execution-context* child]
+            (is (= (:fork-id child)
+                   (second (:value (component/resolve ref))))))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest explicit-component-selection-attenuates-the-child
+  (let [parent (context/create-execution-context)]
+    (try
+      (let [kept (binding [ec/*execution-context* parent]
+                   (component/register! :kept (->ForkableBox 1)))
+            removed (binding [ec/*execution-context* parent]
+                      (component/register! :removed (->ForkableBox 2)))
+            child (context/fork-context parent :forkable-components #{:kept})]
+        (try
+          (is (some? (component/resolve-in child kept)))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"not available"
+                                (component/resolve-in child removed)))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest component-selection-cannot-be-overridden-through-state-updates
+  (let [parent (context/create-execution-context)]
+    (try
+      (binding [ec/*execution-context* parent]
+        (component/register! :kept (->ForkableBox 1)))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"owned by fork-context"
+           (context/fork-context
+            parent
+            :forkable-components #{}
+            :state-updates {:world/components {:kept (->ForkableBox :alias)}})))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest explicit-component-selection-is-normalized
+  (let [parent (context/create-execution-context)
+        fork-count (atom 0)]
+    (try
+      (binding [ec/*execution-context* parent]
+        (component/register!
+         :counted
+         (component/forkable
+          :parent
+          (fn [_ _ _]
+            (swap! fork-count inc)
+            :child))))
+      (let [child (context/fork-context
+                   parent :forkable-components [:counted :counted])]
+        (try
+          (is (= 1 @fork-count))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest registration-and-selection-fail-closed
+  (let [parent (context/create-execution-context)]
+    (try
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"explicit fork or sharing policy"
+                            (binding [ec/*execution-context* parent]
+                              (component/register! :unsafe (atom {})))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"unknown world components"
+                            (context/fork-context
+                             parent :forkable-components #{:missing})))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest sharing-a-component-is-an-explicit-declaration
+  (let [parent (context/create-execution-context)
+        mutable-value (atom [])]
+    (try
+      (let [ref (binding [ec/*execution-context* parent]
+                  (component/register! :shared
+                                       (component/shared mutable-value)))
+            child (context/fork-context parent)]
+        (try
+          (is (identical? mutable-value (component/resolve-in parent ref)))
+          (is (identical? mutable-value (component/resolve-in child ref)))
+          (binding [ec/*execution-context* parent]
+            (is (= {:shared mutable-value} (component/registered))))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest unregister-is-idempotent-and-world-local
+  (let [parent (context/create-execution-context)]
+    (try
+      (let [ref (binding [ec/*execution-context* parent]
+                  (component/register! :temporary (->ForkableBox :parent)))
+            child (context/fork-context parent :mode :frozen)]
+        (try
+          (binding [ec/*execution-context* child]
+            (component/unregister! ref)
+            (component/unregister! ref))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"not available"
+                                (component/resolve-in child ref)))
+          (is (= :parent (:value (component/resolve-in parent ref)))
+              "removing the child realization cannot mutate its parent")
+          (binding [ec/*execution-context* parent]
+            (component/unregister! ref))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"not available"
+                                (component/resolve-in parent ref)))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest materialized-forks-use-canonical-fork-invariants
+  (let [parent (context/create-execution-context)]
+    (try
+      (let [ref (binding [ec/*execution-context* parent]
+                  (component/register! :heap (->ForkableBox :parent)))]
+        (binding [ec/*execution-context* parent]
+          (ec/swap-state! [:listeners] (constantly {:host identity}))
+          (ec/swap-state! [:pending-callbacks]
+                          (constantly {:spin [{:resolve identity}]})))
+        (let [child (context/materialized-fork-context
+                     parent :clean-in-flight? false)]
+          (try
+            (is (identical? parent (:parent-ctx child)))
+            (is (identical? (:running parent) (:running child)))
+            (is (identical? (:drain-active parent) (:drain-active child)))
+            (is (= :atom (backend/backend-type (:backend child))))
+            (is (empty? (ec/get-state-in child [:listeners])))
+            (is (empty? (ec/get-state-in child [:pending-callbacks])))
+            (is (= :parent
+                   (first (:value (component/resolve-in child ref)))))
+            (finally
+              (context/close-context! child)))))
+      (binding [ec/*execution-context* parent]
+        (ec/swap-state! [:forkable-signals] (constantly #{:external})))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"cannot own external forkable signals"
+           (context/materialized-fork-context parent)))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest portable-snapshots-drop-process-local-components
+  (let [parent (context/create-execution-context)]
+    (try
+      (let [ref (binding [ec/*execution-context* parent]
+                  (component/register! :ephemeral (->ForkableBox :live)))
+            snapshot (context/snapshot-context parent)]
+        (is (= :live (:value (component/resolve-in parent ref))))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"not available"
+                              (component/resolve-in snapshot ref))))
+      (finally
+        (context/close-context! parent)))))

--- a/test/org/replikativ/spindel/engine/execution_context_test.clj
+++ b/test/org/replikativ/spindel/engine/execution_context_test.clj
@@ -110,6 +110,34 @@
         (finally
           (ctx/stop-context! parent-ctx))))))
 
+(deftest frozen-fork-pins-untouched-parent-state
+  (let [parent-ctx (ctx/create-execution-context)]
+    (try
+      (rtp/swap-state! parent-ctx [:beliefs] (constantly {:score 1}))
+      (let [following (ctx/fork-context parent-ctx)
+            frozen (ctx/fork-context parent-ctx :mode :frozen)]
+        (rtp/swap-state! parent-ctx [:beliefs :score] (constantly 2))
+        (is (= 2 (rtp/get-state following [:beliefs :score]))
+            "the default child follows untouched parent state")
+        (is (= 1 (rtp/get-state frozen [:beliefs :score]))
+            "a particle-style frozen child keeps its fork-time view")
+        (rtp/swap-state! frozen [:beliefs :score] inc)
+        (is (= 2 (rtp/get-state frozen [:beliefs :score])))
+        (is (= 2 (rtp/get-state parent-ctx [:beliefs :score]))))
+      (finally
+        (ctx/stop-context! parent-ctx)))))
+
+(deftest fork-rejects-unknown-mode
+  (let [parent-ctx (ctx/create-execution-context)]
+    (try
+      (is (= ::ctx/invalid-fork-mode
+             (:type (ex-data
+                     (try
+                       (ctx/fork-context parent-ctx :mode :eventually)
+                       (catch clojure.lang.ExceptionInfo error error))))))
+      (finally
+        (ctx/stop-context! parent-ctx)))))
+
 (deftest test-fork-local-bindings
   (testing "Fork-local bindings are stored and merged correctly"
     (let [parent-ctx (ctx/create-execution-context

--- a/test/org/replikativ/spindel/inference/world_particles_test.clj
+++ b/test/org/replikativ/spindel/inference/world_particles_test.clj
@@ -1,0 +1,698 @@
+(ns org.replikativ.spindel.inference.world-particles-test
+  "Canonical Yggdrasil worlds for effectful inference particles."
+  (:refer-clojure :exclude [await])
+  (:require [anglican.runtime :as ar]
+            [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.effects.await :refer [await]]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.executor :as executor]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.engine.state-backend :as backend]
+            [org.replikativ.spindel.inference.coordinator :as coordinator]
+            [org.replikativ.spindel.inference.effects :refer [observe]]
+            [org.replikativ.spindel.inference.inference :as inference]
+            [org.replikativ.spindel.inference.kernel :as kernel]
+            [org.replikativ.spindel.inference.measure :as measure]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [yggdrasil.convergent.gset :as g]))
+
+(defn- mem-gset [id]
+  (g/gset id {:store-config {:backend :memory :id (random-uuid)}}
+          {:sync? true}))
+
+(defn- observed-model []
+  (spin
+   (observe (ar/normal 0.0 1.0) 0.0 :id :evidence)
+   :done))
+
+(defn- await-cps [operation]
+  (let [result (promise)]
+    (operation #(deliver result [:ok %])
+               #(deliver result [:error %]))
+    (deref result 5000 ::timed-out)))
+
+(deftest smc-resamples-independent-worlds-and-discards-the-tree
+  (let [root (context/create-execution-context)
+        manager* (atom nil)
+        create-manager coordinator/create-world-manager]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [knowledge
+              (ygg/register! (-> (mem-gset "particle-kb")
+                                 (g/conj :root {:sync? true})))
+              model
+              (spin
+               (let [particle-id
+                     (rtp/get-state ec/*execution-context*
+                                    [:inference :particle-id])
+                     _ (reset! (ygg/system-signal "particle-kb")
+                               (g/conj @knowledge particle-id {:sync? true}))
+                     _ (observe (ar/normal 0.0 1.0) 0.0 :id :evidence)]
+                 (g/elements @knowledge {:sync? true})))
+              posterior
+              (with-redefs
+               [coordinator/create-world-manager
+                (fn [opts]
+                  (let [manager (create-manager opts)]
+                    (reset! manager* manager)
+                    manager))]
+                @(spin
+                  (await
+                   (inference/smc-infer
+                    model 4
+                    {:world-policy :fork
+                     ;; Force a resampling generation even with equal weights.
+                     :resample-threshold 2.0}))))
+              results
+              (mapv #(rtp/get-state % [:inference :result])
+                    (measure/get-contexts posterior))]
+          (testing "each resampled particle sees only its selected ancestry"
+            (is (= 4 (count results)))
+            (is (every? #(and (= 2 (count %))
+                              (contains? % :root))
+                        results)))
+          (testing "particle writes never contaminate the ambient world"
+            (is (= #{:root} (g/elements @knowledge {:sync? true}))))
+          (testing "the complete speculative tree is consumed after projection"
+            (is (= :discarded (:status @@manager*)))
+            (is (= 8 (count (:descriptors @@manager*)))
+                "four initial worlds plus four resampled worlds")
+            (is (empty? (:handles @@manager*))
+                "settled generations no longer pin live contexts")
+            (is (every? #(= :discarded (:fork/status %))
+                        (:descriptors @@manager*)))
+            (is (every? nil? (map :parent-ctx
+                                  (measure/get-contexts posterior)))
+                "posterior projections do not retain resampling ancestry")
+            (is (every? #(= :immutable
+                            (backend/backend-type (:backend %)))
+                        (measure/get-contexts posterior)))
+            (is (every? map?
+                        (map #(rtp/get-state
+                               % [:inference :world-descriptor])
+                             (measure/get-contexts posterior)))))))
+      (finally
+        (context/stop-context! root)))))
+
+(deftest resampling-retires-source-worlds-before-running-children
+  (let [root (context/create-execution-context
+              {:executor (executor/thread-pool-executor 4)})
+        source-count 3
+        finalized (atom [])
+        child-finally-counts (atom [])]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [model
+              (spin
+               (try
+                 (observe (ar/normal 0.0 1.0) 0.0 :id :evidence)
+                 ;; Only replacement children resume through the successful
+                 ;; side of the barrier. Every source `finally` must already
+                 ;; have run before any child is admitted here.
+                 (swap! child-finally-counts conj (count @finalized))
+                 :done
+                 (finally
+                   (swap! finalized conj
+                          (rtp/get-state ec/*execution-context*
+                                         [:inference :particle-id])))))
+              result
+              (deref
+               (spin
+                (try
+                  (await
+                   (inference/smc-infer
+                    model source-count
+                    {:world-policy :fork
+                     :executor (:executor root)
+                     :resample-threshold 2.0}))
+                  (catch Throwable error error)))
+               5000 ::timed-out)]
+          (is (not= ::timed-out result))
+          (is (not (instance? Throwable result))
+              "expected source retirement is not a global inference failure")
+          (is (= source-count (count (measure/get-contexts result))))
+          (is (= source-count (count @child-finally-counts)))
+          (is (every? #(>= % source-count) @child-finally-counts)
+              "all superseded sources unwind before replacement children run")
+          (is (= (* 2 source-count) (count @finalized))
+              "both source and replacement generations execute finally")
+          (is (= (* 2 source-count) (count (distinct @finalized)))
+              "each retired or completed particle reaches one terminal path")))
+      (finally
+        (context/close-context! root)))))
+
+(deftest cancellation-during-source-retirement-never-admits-children
+  (let [root (context/create-execution-context
+              {:executor (executor/thread-pool-executor 4)})
+        manager* (atom nil)
+        retirement-entered (promise)
+        release-retirement (promise)
+        child-entered (atom 0)
+        create-manager coordinator/create-world-manager]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [model
+              (spin
+               (try
+                 (observe (ar/normal 0.0 1.0) 0.0 :id :evidence)
+                 (swap! child-entered inc)
+                 (await (fn [_resolve _reject] nil))
+                 (finally
+                   (deliver retirement-entered true)
+                   @release-retirement)))
+              outcome
+              (future
+                (with-redefs
+                 [coordinator/create-world-manager
+                  (fn [opts]
+                    (let [manager (create-manager opts)]
+                      (reset! manager* manager)
+                      manager))]
+                  (binding [ec/*execution-context* root]
+                    (try
+                      @(inference/smc-infer
+                        model 1
+                        {:world-policy :fork
+                         :executor (:executor root)
+                         :resample-threshold 2.0})
+                      (catch Throwable error error)))))]
+          (is (= true (deref retirement-entered 5000 ::timed-out)))
+          (is (= :retiring (:generation-phase @@manager*)))
+          (let [cancelled (promise)
+                operation (coordinator/cancel-particle-worlds! @manager*)]
+            (operation #(deliver cancelled [:ok %])
+                       #(deliver cancelled [:error %]))
+            (deliver release-retirement true)
+            (is (= [:ok nil] (deref cancelled 5000 ::timed-out)))
+            (is (instance? Throwable (deref outcome 5000 ::timed-out)))
+            (is (zero? @child-entered)
+                "replacement children never run after cancellation wins")
+            (is (= :discarded (:status @@manager*)))
+            (is (empty? (:handles @@manager*))))))
+      (finally
+        (deliver release-retirement true)
+        (context/close-context! root)))))
+
+(deftest cancellation-during-resampling-fork-construction-gates-settlement
+  (let [root (context/create-execution-context
+              {:executor (executor/thread-pool-executor 4)})
+        manager* (atom nil)
+        fork-count (atom 0)
+        child-fork-entered (promise)
+        release-child-fork (promise)
+        source-finalizer-entered (promise)
+        release-source-finalizer (promise)
+        child-entered (atom 0)
+        create-manager coordinator/create-world-manager
+        fork-world coordinator/fork-particle-world!]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [model
+              (spin
+               (try
+                 (observe (ar/normal 0.0 1.0) 0.0 :id :evidence)
+                 (swap! child-entered inc)
+                 (await (fn [_resolve _reject] nil))
+                 (finally
+                   (deliver source-finalizer-entered true)
+                   @release-source-finalizer)))
+              outcome
+              (future
+                (with-redefs
+                 [coordinator/create-world-manager
+                  (fn [opts]
+                    (let [manager (create-manager opts)]
+                      (reset! manager* manager)
+                      manager))
+                  coordinator/fork-particle-world!
+                  (fn [manager source resolve reject]
+                    (if (= 2 (swap! fork-count inc))
+                      (do
+                        (deliver child-fork-entered true)
+                        (future
+                          @release-child-fork
+                          (fork-world manager source resolve reject)))
+                      (fork-world manager source resolve reject)))]
+                  (binding [ec/*execution-context* root]
+                    (try
+                      @(inference/smc-infer
+                        model 1
+                        {:world-policy :fork
+                         :executor (:executor root)
+                         :resample-threshold 2.0})
+                      (catch Throwable error error)))))]
+          (is (= true (deref child-fork-entered 5000 ::timed-out)))
+          (is (= :forking (:generation-phase @@manager*)))
+          (let [cancelled (promise)
+                operation (coordinator/cancel-particle-worlds! @manager*)]
+            (operation #(deliver cancelled [:ok %])
+                       #(deliver cancelled [:error %]))
+            (is (= true (deref source-finalizer-entered 5000 ::timed-out)))
+            (is (= :open (:status @@manager*))
+                "settlement waits for the outstanding fork callback")
+            (deliver release-child-fork true)
+            (is (= ::still-waiting
+                   (deref cancelled 100 ::still-waiting))
+                "the late fork callback cannot erase an unwinding source")
+            (is (= 1 (count (:active-contexts @@manager*))))
+            (deliver release-source-finalizer true)
+            (is (= [:ok nil] (deref cancelled 5000 ::timed-out)))
+            (is (instance? Throwable (deref outcome 5000 ::timed-out)))
+            (is (zero? @child-entered))
+            (is (= :discarded (:status @@manager*)))
+            (is (= 2 (count (:descriptors @@manager*)))
+                "the late child handle remains inside affine cleanup")
+            (is (empty? (:handles @@manager*))))))
+      (finally
+        (deliver release-child-fork true)
+        (deliver release-source-finalizer true)
+        (context/close-context! root)))))
+
+(deftest cancellation-during-initial-fork-construction-joins-late-world
+  (let [root (context/create-execution-context
+              {:executor (executor/thread-pool-executor 2)})
+        manager* (atom nil)
+        task* (atom nil)
+        fork-entered (promise)
+        release-fork (promise)
+        create-manager coordinator/create-world-manager
+        fork-world ygg/fork!]
+    (try
+      (let [outcome
+            (future
+              (with-redefs
+               [coordinator/create-world-manager
+                (fn [opts]
+                  (let [manager (create-manager opts)]
+                    (reset! manager* manager)
+                    manager))
+                ygg/fork!
+                (fn [opts]
+                  (let [operation (fork-world opts)]
+                    (fn [resolve reject]
+                      (operation
+                       (fn [handle]
+                         (deliver fork-entered true)
+                         (future @release-fork (resolve handle)))
+                       reject))))]
+                (binding [ec/*execution-context* root]
+                  (let [task (inference/smc-infer
+                              (spin :done) 1
+                              {:world-policy :fork
+                               :executor (:executor root)})]
+                    (reset! task* task)
+                    (try @task (catch Throwable error error))))))]
+        (is (= true (deref fork-entered 5000 ::timed-out)))
+        (binding [ec/*execution-context* root]
+          (spin-core/cancel-spin! @task*))
+        (is (= ::still-waiting (deref outcome 100 ::still-waiting))
+            "public cancellation waits for the outstanding affine fork")
+        (is (= 1 (:pending-forks @@manager*)))
+        (is (= :open (:status @@manager*)))
+        (deliver release-fork true)
+        (let [result (deref outcome 5000 ::timed-out)]
+          (is (instance? Throwable result))
+          (is (= spin-core/spin-cancelled (:type (ex-data result))))
+          (is (= :discarded (:status @@manager*)))
+          (is (= 1 (count (:descriptors @@manager*))))
+          (is (empty? (:handles @@manager*)))))
+      (finally
+        (deliver release-fork true)
+        (context/close-context! root)))))
+
+(deftest cancelling-public-inference-spin-cancels-and-joins-worlds
+  (let [root (context/create-execution-context
+              {:executor (executor/thread-pool-executor 4)})
+        manager* (atom nil)
+        task* (atom nil)
+        model-entered (promise)
+        model-cleaned? (atom false)
+        discard-entered (promise)
+        release-discard (promise)
+        create-manager coordinator/create-world-manager
+        discard-world ygg/discard-fork!]
+    (try
+      (let [outcome
+            (future
+              (with-redefs
+               [coordinator/create-world-manager
+                (fn [opts]
+                  (let [manager (create-manager opts)]
+                    (reset! manager* manager)
+                    manager))
+                ygg/discard-fork!
+                (fn [handle opts]
+                  (let [operation (discard-world handle opts)]
+                    (fn [resolve reject]
+                      (deliver discard-entered true)
+                      (future
+                        @release-discard
+                        (operation resolve reject)))))]
+                (binding [ec/*execution-context* root]
+                  (let [task
+                        (inference/smc-infer
+                         (spin
+                          (try
+                            (deliver model-entered true)
+                            (await (fn [_resolve _reject] nil))
+                            (finally (reset! model-cleaned? true))))
+                         1
+                         {:world-policy :fork
+                          :executor (:executor root)})]
+                    (reset! task* task)
+                    (try @task (catch Throwable error error))))))]
+        (is (= true (deref model-entered 5000 ::timed-out)))
+        (binding [ec/*execution-context* root]
+          (spin-core/cancel-spin! @task*))
+        (is (= true (deref discard-entered 5000 ::timed-out)))
+        (is (= ::still-waiting (deref outcome 100 ::still-waiting))
+            "public cancellation stays pending through asynchronous discard")
+        (is (= :discarding (:status @@manager*)))
+        (deliver release-discard true)
+        (let [result (deref outcome 5000 ::timed-out)]
+          (is (instance? Throwable result))
+          (is (= spin-core/spin-cancelled (:type (ex-data result))))
+          (is @model-cleaned?)
+          (is (= :discarded (:status @@manager*))
+              "the public Spin rejects only after manager settlement")
+          (is (empty? (:handles @@manager*)))))
+      (finally
+        (deliver release-discard true)
+        (context/close-context! root)))))
+
+(deftest canonical-worlds-reject-unsafe-pgas-scoring
+  (let [root (context/create-execution-context)]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [result
+              @(spin
+                (try
+                  (await
+                   (inference/smc-infer
+                    (spin :done) 2
+                    {:world-policy :fork
+                     :pgas-ancestor-sampling? true}))
+                  :unexpected-success
+                  (catch Throwable error error)))]
+          (is (instance? Throwable result))
+          (is (= ::inference/world-pgas-unsupported
+                 (:type (ex-data result))))))
+      (finally
+        (context/stop-context! root)))))
+
+(deftest public-pgas-rejects-worlds-before-starting-the-model
+  (let [root (context/create-execution-context)
+        invocations (atom 0)]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [result
+              @(spin
+                (try
+                  (await
+                   (inference/pgas-infer
+                    (spin (swap! invocations inc) :done)
+                    2 1 {:world-policy :fork}))
+                  :unexpected-success
+                  (catch Throwable error error)))]
+          (is (instance? Throwable result))
+          (is (= ::inference/world-pgas-unsupported
+                 (:type (ex-data result))))
+          (is (zero? @invocations)
+              "the public wrapper rejects before its initial SMC sweep")))
+      (finally
+        (context/stop-context! root)))))
+
+(deftest world-policy-is-explicit
+  (let [root (context/create-execution-context)]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [result
+              @(spin
+                (try
+                  (await (inference/smc-infer
+                          (spin :done) 1 {:world-policy :unknown}))
+                  :unexpected-success
+                  (catch Throwable error error)))]
+          (is (instance? Throwable result))
+          (is (= ::inference/invalid-world-policy
+                 (:type (ex-data result))))))
+      (finally
+        (context/stop-context! root)))))
+
+(deftest partial-initialization-failure-consumes-created-worlds
+  (let [root (context/create-execution-context)
+        manager* (atom nil)
+        fork-count (atom 0)
+        create-manager coordinator/create-world-manager
+        fork-world coordinator/fork-particle-world!]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [result
+              (with-redefs
+               [coordinator/create-world-manager
+                (fn [opts]
+                  (let [manager (create-manager opts)]
+                    (reset! manager* manager)
+                    manager))
+                coordinator/fork-particle-world!
+                (fn [manager source resolve reject]
+                  (if (= 3 (swap! fork-count inc))
+                    (reject (ex-info "synthetic fork failure" {:stage :initial}))
+                    (fork-world manager source resolve reject)))]
+                @(spin
+                  (try
+                    (await (inference/smc-infer
+                            (spin :done) 4 {:world-policy :fork}))
+                    :unexpected-success
+                    (catch Throwable error error))))]
+          (is (instance? Throwable result))
+          (is (= :discarded (:status @@manager*)))
+          (is (= 2 (count (:descriptors @@manager*))))
+          (is (empty? (:handles @@manager*)))))
+      (finally
+        (context/stop-context! root)))))
+
+(deftest read-only-cleanup-failure-can-be-retried
+  (let [root (context/create-execution-context)
+        manager (coordinator/create-world-manager {})
+        discard ygg/discard-fork!
+        attempts (atom 0)]
+    (try
+      (binding [ec/*execution-context* root]
+        (is (= :ok
+               (first
+                (await-cps
+                 (fn [resolve reject]
+                   (coordinator/fork-particle-world!
+                    manager root resolve reject))))))
+        (let [first-result
+              (with-redefs
+               [ygg/discard-fork!
+                (fn [handle opts]
+                  (if (= 1 (swap! attempts inc))
+                    (fn [_resolve reject]
+                      (reject (ex-info "synthetic preflight failure" {})))
+                    (discard handle opts)))]
+                (let [failed (await-cps
+                              (coordinator/discard-particle-worlds! manager))
+                      retried (await-cps
+                               (coordinator/discard-particle-worlds! manager))]
+                  [failed retried]))]
+          (is (= :error (ffirst first-result)))
+          (is (= [:ok nil] (second first-result)))
+          (is (= :discarded (:status @manager)))
+          (is (empty? (:handles @manager)))))
+      (finally
+        (context/stop-context! root)))))
+
+(deftest resampling-fork-failure-consumes-the-suspended-tree
+  (let [root (context/create-execution-context
+              {:executor (executor/thread-pool-executor 4)})
+        manager* (atom nil)
+        fork-count (atom 0)
+        schedules (atom 0)
+        root-executor (:executor root)
+        rejecting-cancel-executor
+        (reify executor/PExecutor
+          (execute! [_ task]
+            (if (> (swap! schedules inc) 4)
+              (throw (ex-info "synthetic cancellation scheduling rejection"
+                              {}))
+              (executor/execute! root-executor task)))
+          (execute-after! [_ delay-ms task]
+            (executor/execute-after! root-executor delay-ms task)))
+        create-manager coordinator/create-world-manager
+        fork-world coordinator/fork-particle-world!]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [result
+              (with-redefs
+               [coordinator/create-world-manager
+                (fn [opts]
+                  (let [manager (create-manager opts)]
+                    (reset! manager* manager)
+                    manager))
+                coordinator/fork-particle-world!
+                (fn [manager source resolve reject]
+                  (if (= 6 (swap! fork-count inc))
+                    (reject (ex-info "synthetic fork failure" {:stage :resampling}))
+                    (fork-world manager source resolve reject)))]
+                (deref
+                 (spin
+                  (try
+                    (await (inference/smc-infer
+                            (observed-model) 4
+                            {:world-policy :fork
+                             :executor rejecting-cancel-executor
+                             :resample-threshold 2.0}))
+                    :unexpected-success
+                    (catch Throwable error error)))
+                 5000 ::timed-out))]
+          (is (not= ::timed-out result))
+          (is (instance? Throwable result))
+          (let [recovery (:world/recovery (ex-data result))]
+            (is (map? recovery))
+            (is (= [:ok nil] (await-cps (:await-quiescent recovery))))
+            (is (= [:ok nil] (await-cps ((:discard! recovery))))))
+          (is (= :discarded (:status @@manager*)))
+          (is (= 5 (count (:descriptors @@manager*))))
+          (is (empty? (:handles @@manager*)))))
+      (finally
+        (context/close-context! root)))))
+
+(deftest partial-particle-start-failure-is-cancelled-and-recoverable
+  (let [root (context/create-execution-context
+              {:executor (executor/thread-pool-executor 4)})
+        manager* (atom nil)
+        schedules (atom 0)
+        root-executor (:executor root)
+        rejecting-executor
+        (reify executor/PExecutor
+          (execute! [_ task]
+            (if (= 2 (swap! schedules inc))
+              (throw (ex-info "synthetic executor rejection" {}))
+              (executor/execute! root-executor task)))
+          (execute-after! [_ delay-ms task]
+            (executor/execute-after! root-executor delay-ms task)))
+        create-manager coordinator/create-world-manager]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [result
+              (with-redefs
+               [coordinator/create-world-manager
+                (fn [opts]
+                  (let [manager (create-manager opts)]
+                    (reset! manager* manager)
+                    manager))]
+                @(spin
+                  (try
+                    (await
+                     (inference/smc-infer
+                      (spin (await (fn [_resolve _reject] nil)))
+                      3 {:world-policy :fork
+                         :executor rejecting-executor}))
+                    :unexpected-success
+                    (catch Throwable error error))))
+              recovery (:world/recovery (ex-data result))]
+          (is (instance? Throwable result))
+          (is (= ::inference/particle-start-failed
+                 (:type (ex-data result))))
+          (is (= 1 (:started (ex-data result))))
+          (is (= [:ok nil] (await-cps (:await-quiescent recovery))))
+          (is (= [:ok nil] (await-cps ((:discard! recovery)))))
+          (is (= :discarded (:status @@manager*)))
+          (is (= 3 (count (:descriptors @@manager*))))
+          (is (empty? (:handles @@manager*)))))
+      (finally
+        (context/close-context! root)))))
+
+(deftest iterative-particles-remain-live-until-their-final-completion
+  (let [root (context/create-execution-context
+              {:executor (executor/thread-pool-executor 4)})
+        manager* (atom nil)
+        second-pass (promise)
+        arrivals (atom 0)
+        create-manager coordinator/create-world-manager
+        iterative-kernel
+        (reify kernel/PInferenceKernel
+          (kernel-id [_] :world-lifecycle-regression)
+          (step [_ _ checkpoint _]
+            {:action :assign
+             :value (or (get-in checkpoint [:options :observe]) 0.0)})
+          (on-complete [_ particle _trace _result]
+            (rtp/swap-state! particle [:test :iterate?] (constantly true))
+            {:action :iterate :updates {}}))]
+    (try
+      (binding [ec/*execution-context* root]
+        (with-redefs
+         [coordinator/create-world-manager
+          (fn [opts]
+            (let [manager (create-manager opts)]
+              (reset! manager* manager)
+              manager))]
+          (let [model
+                (spin
+                 (observe (ar/normal 0.0 1.0) 0.0 :id :evidence)
+                 (when (rtp/get-state ec/*execution-context*
+                                      [:test :iterate?])
+                   (when (= 2 (swap! arrivals inc))
+                     (deliver second-pass true))
+                   (await (fn [_resolve _reject] nil)))
+                 :done)
+                task (inference/kernel-infer
+                      model iterative-kernel 2
+                      {:world-policy :fork :barrier-policy :none})
+                result (future
+                         (try
+                           (deref task 5000 ::timed-out)
+                           (catch Throwable error error)))]
+            (is (= true (deref second-pass 5000 ::timed-out)))
+            (is (= 2 (count (:active-contexts @@manager*)))
+                "an :iterate completion is not a terminal world callback")
+            (is (= [:ok nil]
+                   (await-cps
+                    (coordinator/cancel-particle-worlds! @manager*))))
+            (is (not= ::timed-out (deref result 5000 ::timed-out)))
+            (is (= [:ok nil]
+                   (await-cps
+                    (coordinator/discard-particle-worlds-when-quiescent!
+                     @manager*))))
+            (is (= :discarded (:status @@manager*))))))
+      (finally
+        (context/close-context! root)))))
+
+(deftest model-failure-exposes-portable-world-recovery
+  (let [root (context/create-execution-context)]
+    (try
+      (binding [ec/*execution-context* root]
+        (let [task
+              (spin
+               (try
+                 (await
+                  (inference/smc-infer
+                   (spin (throw (ex-info "model failed" {:stage :model})))
+                   3
+                   {:world-policy :fork}))
+                 :unexpected-success
+                 (catch Throwable error error)))
+              result (deref task 5000 ::timed-out)
+              recovery (:world/recovery (ex-data result))]
+          (is (not= ::timed-out result))
+          (is (instance? Throwable result))
+          (is (contains? #{:open :discarding :discarded} (:status recovery)))
+          (is (= 3 (count (:descriptors recovery))))
+          (is (every? #(and (map? %)
+                            (keyword? (:fork/id %))
+                            (= :particle (:fork/purpose %)))
+                      (:descriptors recovery)))
+          (is (instance? clojure.lang.IAtom (:manager recovery))
+              "the live recovery capability stays process-local")
+          (is (= [:ok nil] (await-cps (:await-quiescent recovery))))
+          (is (= [:ok nil] (await-cps ((:discard! recovery)))))
+          (is (= :discarded (:status @(:manager recovery))))
+          (is (empty? (:handles @(:manager recovery))))))
+      (finally
+        (context/stop-context! root)))))

--- a/test/org/replikativ/spindel/runtime_protocols_test.clj
+++ b/test/org/replikativ/spindel/runtime_protocols_test.clj
@@ -16,6 +16,8 @@
             [org.replikativ.spindel.test-async :refer [await-drain]]
             [org.replikativ.spindel.test-helpers :as th]))
 
+(defrecord TestConfig [a])
+
 ;; =============================================================================
 ;; PGraph Protocol Tests - Dependency Graph Management
 ;; =============================================================================
@@ -555,6 +557,108 @@
             (finally
               (ctx/close-context! fork-1))))
         (finally
+          (ctx/close-context! root))))))
+
+(deftest overlay-map-reads-materialize-entity-tombstones
+  (testing "a whole-state removal is absent from direct fork-local map reads"
+    (let [root (ctx/create-execution-context)
+          fork-1 (ctx/fork-context root)
+          fork-2 (ctx/fork-context fork-1)
+          fire-time 4242
+          entry {:id :delayed-test :spin-fn identity}]
+      (try
+        (rtp/swap-state! fork-2 [:engine/delayed-spins]
+                         #(assoc (or % (sorted-map)) fire-time [entry]))
+        ;; Delayed firing uses a whole-state transaction. OverlayBackend records
+        ;; the removed map entity as a sparse tombstone.
+        (rtp/swap-state! fork-2 []
+                         #(assoc % :engine/delayed-spins (sorted-map)))
+        (is (= (sorted-map)
+               (rtp/get-state fork-2 [:engine/delayed-spins])))
+        (is (nil? (rtp/get-state fork-2
+                                 [:engine/delayed-spins fire-time])))
+        (finally
+          (ctx/close-context! fork-2)
+          (ctx/close-context! fork-1)
+          (ctx/close-context! root))))))
+
+(deftest shared-overlay-map-reads-materialize-logical-state
+  (testing "shared collection reads merge inherited entities and tombstones"
+    (let [root (ctx/create-execution-context)]
+      (try
+        (rtp/swap-state! root [:nodes] (constantly {:a 1 :b 2}))
+        (let [fork-1 (ctx/fork-context root)]
+          (try
+            (rtp/swap-state! fork-1 [] #(update % :nodes dissoc :a))
+            (is (= {:b 2} (rtp/get-state fork-1 [:nodes])))
+            (is (nil? (rtp/get-state fork-1 [:nodes :a])))
+            (is (= 2 (rtp/get-state fork-1 [:nodes :b])))
+            (let [fork-2 (ctx/fork-context fork-1)]
+              (try
+                (rtp/swap-state! fork-2 []
+                                 #(-> %
+                                      (update :nodes dissoc :b)
+                                      (assoc-in [:nodes :c] 3)))
+                (is (= {:c 3} (rtp/get-state fork-2 [:nodes]))
+                    "nested overlays compose into one logical collection")
+                (is (nil? (rtp/get-state fork-2 [:nodes :a])))
+                (is (nil? (rtp/get-state fork-2 [:nodes :b])))
+                (is (= 3 (rtp/get-state fork-2 [:nodes :c])))
+                (finally
+                  (ctx/close-context! fork-2))))
+            (finally
+              (ctx/close-context! fork-1))))
+        (finally
+          (ctx/close-context! root))))))
+
+(deftest shared-depth-one-write-establishes-divergence-boundary
+  (testing "a full collection CoW does not import later parent mutations"
+    (let [root (ctx/create-execution-context)
+          fork (ctx/fork-context root)]
+      (try
+        (rtp/swap-state! root [:nodes] (constantly {:a 1}))
+        (rtp/swap-state! fork [:nodes] #(assoc % :b 2))
+        (rtp/swap-state! root [:nodes] #(assoc % :c 3))
+        (is (= {:a 1 :b 2} (rtp/get-state fork [:nodes])))
+        (is (= {:a 1 :b 2} (:nodes (rtp/get-state fork []))))
+        (is (nil? (rtp/get-state fork [:nodes :c])))
+        (finally
+          (ctx/close-context! fork)
+          (ctx/close-context! root))))))
+
+(deftest full-replacement-materializes-later-whole-state-removals
+  (testing "whole-state deletion cannot expose a tombstone through a full CoW"
+    (let [root (ctx/create-execution-context)
+          fork (ctx/fork-context root)]
+      (try
+        (rtp/swap-state! root [:nodes] (constantly {:a 1 :b 2}))
+        (rtp/swap-state! fork [:nodes] identity)
+        (rtp/swap-state! fork [] #(update % :nodes dissoc :b))
+        (is (= {:a 1} (rtp/get-state fork [:nodes])))
+        (is (= {:a 1} (:nodes (rtp/get-state fork []))))
+        (is (nil? (rtp/get-state fork [:nodes :b])))
+        (finally
+          (ctx/close-context! fork)
+          (ctx/close-context! root))))))
+
+(deftest shared-record-write-is-a-full-replacement
+  (testing "record CoW is consistent across direct, full, and nested reads"
+    (let [root (ctx/create-execution-context)
+          fork-1 (ctx/fork-context root)]
+      (try
+        (rtp/swap-state! root [:config] (constantly (->TestConfig 1)))
+        (rtp/swap-state! fork-1 [:config] identity)
+        (rtp/swap-state! root [:config] #(assoc % :later 2))
+        (is (= (->TestConfig 1) (rtp/get-state fork-1 [:config])))
+        (is (= (->TestConfig 1) (:config (rtp/get-state fork-1 []))))
+        (let [fork-2 (ctx/fork-context fork-1)]
+          (try
+            (is (= (->TestConfig 1) (rtp/get-state fork-2 [:config])))
+            (is (= (->TestConfig 1) (:config (rtp/get-state fork-2 []))))
+            (finally
+              (ctx/close-context! fork-2))))
+        (finally
+          (ctx/close-context! fork-1)
           (ctx/close-context! root))))))
 
 (deftest reactive-resume-release-preserves-absent-continuation

--- a/test/org/replikativ/spindel/sci/nested_world_test.clj
+++ b/test/org/replikativ/spindel/sci/nested_world_test.clj
@@ -1,0 +1,94 @@
+(ns org.replikativ.spindel.sci.nested-world-test
+  "Characterize recursive interpreter construction through explicit capabilities."
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.engine.context :as ctx]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.sci.boundary :as boundary]
+            [org.replikativ.spindel.sci.macro :as macro]
+            [org.replikativ.spindel.spin.core :as spin-core]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [sci.core :as sci]))
+
+(deftest sci-program-can-construct-and-run-a-spindel-sci-child-world
+  (let [root (ctx/create-execution-context)
+        nested-opts (atom nil)
+        worlds (atom {})
+        interpreters (atom {})
+        resolve-world (fn [world-id]
+                        (or (get @worlds world-id)
+                            (throw (ex-info "Unknown interpreter world"
+                                            {:world-id world-id}))))
+        world-ns
+        {'fork! (fn []
+                  (let [world-id (random-uuid)
+                        handle (ygg/fork! {:purpose :interpreter
+                                           :mode :frozen
+                                           :sync? true})]
+                    (swap! worlds assoc world-id handle)
+                    world-id))
+         'interpreter!
+         (fn [world-id]
+           (let [interpreter-id (random-uuid)
+                 interpreter
+                 (sci/with-detached-context
+                   #(macro/create-spin-macro-context
+                     {:runtime (:child-ctx (resolve-world world-id))
+                      :sci-opts @nested-opts}))]
+             (swap! interpreters assoc interpreter-id interpreter)
+             interpreter-id))
+         'eval-spin
+         (fn [world-id interpreter-id source]
+           (let [runtime (:child-ctx (resolve-world world-id))
+                 interpreter (or (get @interpreters interpreter-id)
+                                 (throw
+                                  (ex-info "Unknown nested interpreter"
+                                           {:interpreter-id interpreter-id})))
+                 task (binding [ec/*execution-context* runtime]
+                        (sci/eval-string* interpreter source))]
+             (boundary/wrap-spin-for-sci task runtime)))}
+        opts {:namespaces {'spindel.world world-ns}}
+        _ (reset! nested-opts opts)
+        outer (macro/create-spin-macro-context
+               {:runtime root :sci-opts opts})]
+    (try
+      (let [nested-source
+            "(require '[org.replikativ.spindel.spin.cps :refer [spin]]) (spin 41)"
+            outer-source
+            (str
+             "(require '[spindel.world :as world] "
+             "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+             "         '[org.replikativ.spindel.effects.await :refer [await]]) "
+             "(let [child (world/fork!) "
+             "      interpreter (world/interpreter! child) "
+             "      nested-task (world/eval-spin child interpreter "
+             (pr-str nested-source)
+             ") "
+             "      task (spin (inc (await nested-task)))] "
+             "  {:world-id child :task task :value @task})")
+            {:keys [world-id task value] :as result}
+            (binding [ec/*execution-context* root]
+              (sci/eval-string* outer outer-source))
+            world (resolve-world world-id)
+            task-id (spin-core/spin-id task)]
+        (testing "the interpreter and its computation are constructed by SCI"
+          (is (= 42 value))
+          (is (= 42 (:payload (binding [ec/*execution-context* root]
+                                (ec/spin-current-result task-id))))
+              "the nested boundary returns completion to the caller world")
+          (is (nil? (binding [ec/*execution-context* (:child-ctx world)]
+                      (ec/spin-current-result task-id)))
+              "the nested task runtime does not steal the caller's completion")
+          (is (= :interpreter
+                 (:fork/purpose (ygg/fork-descriptor world))))
+          (is (= (:fork-id root)
+                 (:fork/parent (ygg/fork-descriptor world)))))
+        (testing "the parent retains affine settlement authority"
+          (is (ygg/open-fork? world))
+          (binding [ec/*execution-context* root]
+            (is (nil? (ygg/discard-fork! world {:sync? true}))))
+          (is (not (ygg/open-fork? world))))
+        (is (= #{:world-id :task :value} (set (keys result))))
+        (is (uuid? world-id)
+            "SCI receives an opaque identifier, never the affine handle"))
+      (finally
+        (ctx/stop-context! root)))))

--- a/test/org/replikativ/spindel/sci/world_test.clj
+++ b/test/org/replikativ/spindel/sci/world_test.clj
@@ -1,0 +1,185 @@
+(ns org.replikativ.spindel.sci.world-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [sci.core :as sci]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.impl.simple :as simple]
+            [org.replikativ.spindel.inference.coordinator :as coordinator]
+            [org.replikativ.spindel.sci.world :as world]
+            [org.replikativ.spindel.spin.core :as spin-core]))
+
+(deftest inherited-native-capabilities-follow-the-selected-world
+  (let [parent (context/create-execution-context)]
+    (try
+      (binding [ec/*execution-context* parent]
+        (ec/swap-state! [:probe] (constantly [])))
+      (let [probe-tool
+            (binding [ec/*execution-context* parent]
+              (spin-core/make-spin
+               (fn [resolve _reject]
+                 (ec/swap-state!
+                  [:probe]
+                  #(conj % (:fork-id (ec/current-execution-context))))
+                 (resolve :ok))
+               :probe-tool))
+            interpreter-ref
+            (world/create! parent {:native-spins {'probe-tool probe-tool}})
+            child (context/fork-context parent :mode :frozen)]
+        (try
+          (let [task
+                (binding [ec/*execution-context* child]
+                  (world/eval-string*
+                   interpreter-ref
+                   "(require '[org.replikativ.spindel.spin.cps :refer [spin]]
+                              '[org.replikativ.spindel.effects.await :refer [await]])
+                    (spin (await probe-tool))"))]
+            (is (= :ok (binding [ec/*execution-context* child] @task)))
+            (is (= [(:fork-id child)]
+                   (binding [ec/*execution-context* child]
+                     (ec/get-state [:probe]))))
+            (is (= []
+                   (binding [ec/*execution-context* parent]
+                     (ec/get-state [:probe])))))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest causal-callback-egress-is-limited-to-descendants
+  (let [parent (context/create-execution-context)
+        unrelated (context/create-execution-context)
+        callback (atom nil)
+        result (promise)
+        worker
+        (binding [ec/*execution-context* parent]
+          (spin-core/make-spin
+           (fn [resolve _reject]
+             (reset! callback resolve)
+             spin-core/incomplete)
+           :causal-worker))]
+    (try
+      (binding [ec/*execution-context* parent
+                ec/*callback-egress-policy* :causal-follow]
+        (worker #(deliver result %) #(deliver result %)))
+      (let [child (context/fork-context parent :mode :frozen)]
+        (try
+          (binding [ec/*execution-context* unrelated]
+            (@callback :unrelated))
+          (is (= ::pending (deref result 20 ::pending)))
+          (binding [ec/*execution-context* child]
+            (@callback :descendant))
+          (is (= :descendant (deref result 1000 ::timeout)))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! unrelated)
+        (context/close-context! parent)))))
+
+(deftest suspended-sci-spin-resumes-independently-in-forked-worlds
+  (testing "the copied Spindel continuation selects the paired SCI heap"
+    (let [parent (context/create-execution-context)
+          callback (atom nil)
+          operation (fn [resolve _reject]
+                      (reset! callback resolve)
+                      spin-core/incomplete)]
+      (try
+        (let [interpreter-ref
+              (world/create!
+               parent
+               {:sci-opts {:bindings {'operation operation}}})
+              interpreter (world/context-in parent interpreter-ref)
+              worker
+              (binding [ec/*execution-context* parent]
+                (sci/eval-string*
+                 interpreter
+                 "(require '[org.replikativ.spindel.spin.cps :refer [spin]]
+                           '[org.replikativ.spindel.effects.await :refer [await]])
+                  (def state (atom []))
+                  (def ^:dynamic *scope* :root)
+                  (spin
+                    (binding [*scope* :bound]
+                      (let [value (await operation)]
+                        (swap! state conj [*scope* value])
+                        @state)))"))
+              spin-id (spin-core/spin-id worker)
+              parent-result (promise)]
+          (binding [ec/*execution-context* parent]
+            (worker #(deliver parent-result %) #(deliver parent-result %)))
+          (simple/await-drain-complete! parent :timeout-ms 2000)
+          (is (fn? @callback))
+          (let [child (context/fork-context parent :mode :frozen)
+                child-interpreter (world/context-in child interpreter-ref)]
+            (try
+              (is (not (identical? interpreter child-interpreter)))
+              (binding [ec/*execution-context* child]
+                (@callback :child))
+              (simple/await-drain-complete! child :timeout-ms 2000)
+              (is (= [[:bound :child]]
+                     (:payload
+                      (binding [ec/*execution-context* child]
+                        (ec/spin-current-result spin-id)))))
+              (is (= ::pending (deref parent-result 20 ::pending))
+                  "child completion must not fire the parent's egress callback")
+              (is (nil? (binding [ec/*execution-context* parent]
+                          (ec/spin-current-result spin-id))))
+              (is (= [[:bound :child]]
+                     (sci/eval-string* child-interpreter "@state")))
+              (is (= [] (sci/eval-string* interpreter "@state")))
+              (binding [ec/*execution-context* parent]
+                (@callback :parent))
+              (simple/await-drain-complete! parent :timeout-ms 2000)
+              (is (= [[:bound :parent]]
+                     (:payload
+                      (binding [ec/*execution-context* parent]
+                        (ec/spin-current-result spin-id)))))
+              (is (= [[:bound :parent]] @parent-result))
+              (is (= [[:bound :parent]]
+                     (sci/eval-string* interpreter "@state")))
+              (is (= [[:bound :child]]
+                     (sci/eval-string* child-interpreter "@state")))
+              (finally
+                (context/close-context! child)))))
+        (finally
+          (context/close-context! parent))))))
+
+(deftest materialized-particle-fork-retargets-sci-continuations
+  (let [parent (context/create-execution-context)
+        callback (atom nil)
+        operation (fn [resolve _reject]
+                    (reset! callback resolve)
+                    spin-core/incomplete)]
+    (try
+      (let [interpreter-ref
+            (world/create!
+             parent
+             {:sci-opts {:bindings {'operation operation}}})
+            parent-interpreter (world/context-in parent interpreter-ref)
+            worker
+            (binding [ec/*execution-context* parent]
+              (sci/eval-string*
+               parent-interpreter
+               "(require '[org.replikativ.spindel.spin.cps :refer [spin]]
+                          '[org.replikativ.spindel.effects.await :refer [await]])
+                (def samples (atom []))
+                (spin (let [x (await operation)]
+                        (swap! samples conj x)))"))
+            result (promise)]
+        (binding [ec/*execution-context* parent
+                  ec/*callback-egress-policy* :causal-follow]
+          (worker #(deliver result %) #(deliver result %)))
+        (let [particle (coordinator/fork-particle-context parent)
+              particle-interpreter (world/context-in particle interpreter-ref)]
+          (try
+            (is (= (:fork-id parent) (:fork-id (:parent-ctx particle))))
+            (is (not (identical? parent-interpreter particle-interpreter)))
+            (binding [ec/*execution-context* particle]
+              (@callback :particle))
+            (simple/await-drain-complete! particle :timeout-ms 2000)
+            (is (= [:particle]
+                   (sci/eval-string* particle-interpreter "@samples")))
+            (is (= [] (sci/eval-string* parent-interpreter "@samples")))
+            (is (= [:particle] (deref result 1000 ::timeout)))
+            (finally
+              (context/close-context! particle)))))
+      (finally
+        (context/close-context! parent)))))

--- a/test/org/replikativ/spindel/spin/gc_test.cljc
+++ b/test/org/replikativ/spindel/spin/gc_test.cljc
@@ -27,6 +27,13 @@
                  '[org.replikativ.spindel.signal :refer [signal]]
                  '[org.replikativ.spindel.test-async :refer [await-drain]]))
 
+(defn- keep-reachable!
+  "Keep test fixtures alive while manually simulating their Cleaner callbacks."
+  [& xs]
+  #?(:clj (doseq [x xs]
+            (java.lang.ref.Reference/reachabilityFence x))
+     :cljs nil))
+
 ;; =============================================================================
 ;; Cross-platform deterministic tests for full-cleanup-spin!
 ;; =============================================================================
@@ -51,6 +58,7 @@
                             (is (nil? (rtp/get-state ctx [:spins-meta sid])) "Meta should be removed")
                             (is (nil? (rtp/get-state ctx [:track-subscriptions sid])) "Track conts should be removed")
                             (is (nil? (rtp/get-state ctx [:await-conts sid])) "Await conts should be removed")
+                            (keep-reachable! s)
                             (done))
                           (fn [e] (is false (str "Spin failed: " e)) (done))))))))
 
@@ -72,6 +80,7 @@
               ;; Verify spin is removed from signal's observers
                             (let [sig-node (rtp/get-state ctx [:nodes sig-id])]
                               (is (not (contains? (:observers sig-node) sid)) "Spin should be removed from signal's observers"))
+                            (keep-reachable! s)
                             (done))
                           (fn [e] (is false (str "Spin failed: " e)) (done))))))))
 
@@ -95,6 +104,7 @@
                     ;; Verify child is removed from parent's observers
                                            (let [parent-node (rtp/get-state ctx [:nodes parent-id])]
                                              (is (not (contains? (:observers parent-node) child-id)) "Child should be removed from parent's observers"))
+                                           (keep-reachable! p c)
                                            (done))
                                          (fn [e] (is false (str "Child failed: " e)) (done)))))
                           (fn [e] (is false (str "Parent failed: " e)) (done))))))))
@@ -114,6 +124,7 @@
               ;; Spin has no observers - should be fully cleaned
                             (simple/try-gc-cleanup-spin! ctx sid)
                             (is (nil? (rtp/get-state ctx [:nodes sid])) "Spin with no observers should be fully cleaned")
+                            (keep-reachable! s)
                             (done))
                           (fn [e] (is false (str "Spin failed: " e)) (done))))))))
 
@@ -133,6 +144,7 @@
                                            (let [node (rtp/get-state ctx [:nodes parent-id])]
                                              (is (some? node) "Node should still exist (has observers)")
                                              (is (:orphaned? node) "Node should be marked orphaned"))
+                                           (keep-reachable! p c)
                                            (done))
                                          (fn [e] (is false (str "Child failed: " e)) (done)))))
                           (fn [e] (is false (str "Parent failed: " e)) (done))))))))
@@ -157,15 +169,7 @@
                                            (simple/try-gc-cleanup-spin! ctx child-id)
                                            (is (nil? (rtp/get-state ctx [:nodes child-id])) "Child should be cleaned")
                                            (is (nil? (rtp/get-state ctx [:nodes parent-id])) "Orphaned parent should be cleaned via cascade")
-                    ;; This test invokes the Cleaner callback directly while
-                    ;; still holding the corresponding Spin objects. Keep the
-                    ;; objects strongly reachable through the last assertion;
-                    ;; otherwise HotSpot may concurrently enqueue a real
-                    ;; Cleaner callback after their last source-level use and
-                    ;; race these deterministic state observations.
-                                           #?(:clj (do
-                                                     (java.lang.ref.Reference/reachabilityFence c)
-                                                     (java.lang.ref.Reference/reachabilityFence p)))
+                                           (keep-reachable! p c)
                                            (done))
                                          (fn [e] (is false (str "Child failed: " e)) (done)))))
                           (fn [e] (is false (str "Parent failed: " e)) (done))))))))
@@ -183,6 +187,7 @@
               ;; Clean again - should be a no-op, not throw
                             (simple/try-gc-cleanup-spin! ctx sid)
                             (is (nil? (rtp/get-state ctx [:nodes sid])) "Still cleaned")
+                            (keep-reachable! s)
                             (done))
                           (fn [e] (is false (str "Spin failed: " e)) (done))))))))
 

--- a/test/org/replikativ/spindel/spin/gc_test.cljc
+++ b/test/org/replikativ/spindel/spin/gc_test.cljc
@@ -157,6 +157,15 @@
                                            (simple/try-gc-cleanup-spin! ctx child-id)
                                            (is (nil? (rtp/get-state ctx [:nodes child-id])) "Child should be cleaned")
                                            (is (nil? (rtp/get-state ctx [:nodes parent-id])) "Orphaned parent should be cleaned via cascade")
+                    ;; This test invokes the Cleaner callback directly while
+                    ;; still holding the corresponding Spin objects. Keep the
+                    ;; objects strongly reachable through the last assertion;
+                    ;; otherwise HotSpot may concurrently enqueue a real
+                    ;; Cleaner callback after their last source-level use and
+                    ;; race these deterministic state observations.
+                                           #?(:clj (do
+                                                     (java.lang.ref.Reference/reachabilityFence c)
+                                                     (java.lang.ref.Reference/reachabilityFence p)))
                                            (done))
                                          (fn [e] (is false (str "Child failed: " e)) (done)))))
                           (fn [e] (is false (str "Parent failed: " e)) (done))))))))


### PR DESCRIPTION
## Summary

- materialize entity tombstones at the OverlayBackend boundary so runtime collections never expose internal deletion markers
- distinguish sparse entity deltas from authoritative depth-one replacements and preserve copy-on-write isolation through nested forks
- make map-valued initial overlays explicit and use the replacement contract for Yggdrasil system selection
- cover delayed queues, shared collections, records, full replacements, nested overlays, and selected Yggdrasil worlds

## Why

A Codex-driven Dvergr REPL benchmark exposed a nested Run-world race failure: a delayed queue read returned a raw overlay tombstone and Spindel tried to sequence a keyword. Correcting only that exact read exposed the deeper sparse-vs-full ambiguity, so this PR closes the logical overlay contract rather than special-casing the queue.

## Verification

- full suite: 982 tests, 3867 assertions, 0 failures/errors
- targeted runtime/pubsub/Yggdrasil suite: 76 tests, 652 assertions, 0 failures/errors
- cljfmt clean
- independent exact-head review: no medium-or-higher findings

Stacked on PR #45.