### PR TITLE
feat: compose SCI as a forkable world component

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -42,7 +42,9 @@
                       ;; notably sci/lock_test, which pins that `common-classes`
                       ;; is locked (no `:allow :all`). Needs >= 0.14 for ADR 0007
                       ;; instance-member control (the deny direction of that test).
-                      org.babashka/sci {:mvn/version "0.15.56"}
+                      org.babashka/sci
+                      {:git/url "https://github.com/whilo/sci"
+                       :git/sha "8ef4d70c7c001709564908892e858d6d129c1740"}
                       io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts ["-m" "cognitect.test-runner"]
@@ -74,7 +76,11 @@
   :dev {:extra-paths ["test"]
         :extra-deps {org.clojure/tools.namespace {:mvn/version "1.5.0"}}}
 
-  :sci {:extra-deps {org.babashka/sci {:mvn/version "0.8.42"}}}
+  ;; Pinned to the release-candidate commit while SCI 0.15.59 is reviewed.
+  ;; Replace with {:mvn/version "0.15.59"} before publishing Spindel.
+  :sci {:extra-deps {org.babashka/sci
+                     {:git/url "https://github.com/whilo/sci"
+                      :git/sha "8ef4d70c7c001709564908892e858d6d129c1740"}}}
 
   :cljs {:extra-paths ["test"]
          :extra-deps {thheller/shadow-cljs {:mvn/version "2.28.21"}

--- a/deps.edn
+++ b/deps.edn
@@ -42,9 +42,8 @@
                       ;; notably sci/lock_test, which pins that `common-classes`
                       ;; is locked (no `:allow :all`). Needs >= 0.14 for ADR 0007
                       ;; instance-member control (the deny direction of that test).
-                      org.babashka/sci
-                      {:git/url "https://github.com/whilo/sci"
-                       :git/sha "8ef4d70c7c001709564908892e858d6d129c1740"}
+                      org.replikativ/sci
+                      {:mvn/version "0.15.59-replikativ.1"}
                       io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts ["-m" "cognitect.test-runner"]
@@ -76,11 +75,10 @@
   :dev {:extra-paths ["test"]
         :extra-deps {org.clojure/tools.namespace {:mvn/version "1.5.0"}}}
 
-  ;; Pinned to the release-candidate commit while SCI 0.15.59 is reviewed.
-  ;; Replace with {:mvn/version "0.15.59"} before publishing Spindel.
-  :sci {:extra-deps {org.babashka/sci
-                     {:git/url "https://github.com/whilo/sci"
-                      :git/sha "8ef4d70c7c001709564908892e858d6d129c1740"}}}
+  ;; Replikativ compatibility distribution of SCI with forkable interpreter
+  ;; worlds. Do not combine it with org.babashka/sci on one classpath.
+  :sci {:extra-deps {org.replikativ/sci
+                     {:mvn/version "0.15.59-replikativ.1"}}}
 
   :cljs {:extra-paths ["test"]
          :extra-deps {thheller/shadow-cljs {:mvn/version "2.28.21"}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -724,7 +724,8 @@ SCI integration — functional API. See [SCI Integration](sci-integration.md).
 | Function | Description |
 |----------|-------------|
 | `(create-spindel-sci-context opts)` | Create SCI context with spindel support |
-| `(wrap-spin-for-sci task runtime)` | Wrap native spin as BoundaryTask |
+| `(wrap-capability-for-sci task)` | Wrap an inherited capability for ambient-world execution |
+| `(wrap-spin-for-sci task runtime)` | Wrap an explicit task hosted by `runtime` |
 | `(make-spin-for-sci spin-fn id runtime)` | Create spin from SCI context |
 
 ### Options for `create-spindel-sci-context`

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -29,8 +29,42 @@ Spindel supports **O(1) copy-on-write forking** of execution contexts. Forks sha
   :metadata {:label "my-fork"}
   :process-id 42           ;; override auto-assigned process ID
   :executor executor       ;; optional; otherwise shares the parent scheduler
-  :mode :frozen)           ;; pin untouched state instead of following parent
+  :mode :frozen            ;; pin untouched state instead of following parent
+  :forkable-components #{}) ;; optional capability attenuation
 ```
+
+### Fork-selected world components
+
+Some world state is not an FRP signal and is not a mergeable substrate: an
+interpreter heap, capability table, or other process-local realization. Register
+such state with `org.replikativ.spindel.engine.component/register!`. It returns
+a stable `ComponentRef`; resolving that reference in a context selects the
+realization belonging to that world. Values implement `PForkable`, the same
+forking protocol already used by fork-aware signals.
+
+Components are fork-local and are copied automatically by `fork-context`.
+Passing `:forkable-components` explicitly selects the IDs available in the
+child, so a fork can attenuate capabilities instead of inheriting all of them.
+Components are runtime state, not settlement units: durable Yggdrasil systems
+and their merge/discard authority remain governed by `ForkHandle`. Portable
+snapshots deliberately omit components; an embedding reconstructs transient
+realizations from durable source, configuration, and capability descriptors.
+
+Component forks are restricted to rollback-free process-local values. Because
+component realization can happen before a child handle exists, it must not
+acquire a worktree, database branch, or other resource needing compensation.
+Those substrates remain Yggdrasil systems acquired and settled through
+`ForkHandle`; a component may hold the transient interpreter or client view over
+them. Registration requires an explicit forkable or shared declaration, so a
+mutable host object cannot be shared accidentally.
+
+Host callbacks are effects outside copy-on-write state and are isolated by
+default. A child completion is cached in that child but cannot fire a callback
+registered by another world. Inference coordinators deliberately attach the
+engine-only `:causal-follow` authority to callback edges that must survive
+particle resampling. The authority belongs to the edge rather than mutable world
+bindings, so interpreted code cannot promote its own egress. Engine listeners
+and duplicate pending callbacks are always fork-local.
 
 ## Isolation
 
@@ -58,7 +92,7 @@ A fork is **fully isolated from parent for its own writes** (fork→parent never
 | Parent mutates state on a *fork-local* path | Yes | No (fork has its own value or `nil`) |
 | Fork creates new state | No | Yes (in overlay) |
 
-**Fork-local paths** (full isolation, no fall-through from parent): `:continuations`, `:engine/pending`, `:engine/draining?`, `:engine/delayed-spins`, `:engine/timer-handles`, plus any path added via the OverlayBackend's `local-paths` set.
+**Fork-local paths** (full isolation, no fall-through from parent): `:continuations`, `:world/components`, `:world/forkable-components`, `:engine/pending`, `:engine/draining?`, `:engine/delayed-spins`, `:engine/timer-handles`, plus any path added via the OverlayBackend's `local-paths` set.
 
 **Shared paths** (overlay fall-through, parent-following on reads): everything else, including `:nodes`, `:subscriptions`, `:spin-tracking`, `:atoms`, and `:engine/cancelled-tokens`.
 

--- a/docs/sci-integration.md
+++ b/docs/sci-integration.md
@@ -13,6 +13,37 @@ Two APIs are provided:
 | **Functional** | `spindel.sci.boundary` | `make-spin` with CPS functions — simpler, lower overhead |
 | **Macro** | `spindel.sci.macro` | Full `spin` macro with `await`/`track` — full language support |
 
+For a forkable application world, `org.replikativ.spindel.sci.world` is the
+canonical composition layer. It registers the interpreter as a world component
+and returns a stable reference instead of making callers carry a parallel
+`{:runtime ... :sci-ctx ...}` pair.
+
+```clojure
+(require '[org.replikativ.spindel.sci.world :as sci-world])
+
+(def interpreter (sci-world/create! rt))
+
+(binding [ec/*execution-context* rt]
+  (sci-world/eval-string*
+   interpreter
+   "(def memory (atom []))"))
+
+(def child (ctx/fork-context rt :mode :frozen))
+
+;; The same reference now selects the child's forked SCI heap.
+(binding [ec/*execution-context* child]
+  (sci-world/eval-string* interpreter
+                          "(swap! memory conj :child)"))
+```
+
+Suspended `spin` continuations carry an SCI continuation-context token. When
+resumed in a descendant Spindel context, the token is retargeted to the paired
+SCI component, so dynamic bindings and interpreter state continue in that
+world. Parent and child may then resume the copied computation independently.
+The macro/world APIs enable SCI's opt-in `:forkable` runtime mode themselves;
+callers cannot accidentally construct a standard SCI runtime that lacks the
+managed continuation world.
+
 ## Setup
 
 ### Functional API (Recommended for Simple Cases)
@@ -102,7 +133,10 @@ The macro API provides the full `spin` syntax with CPS transformation:
 
 ## Exposing Native Spins to SCI
 
-Pass native spins via the `:native-spins` option. They are automatically wrapped with `BoundaryTask` to propagate runtime bindings:
+Pass native spins via the `:native-spins` option. They are installed as ambient
+capabilities: invoking one uses the caller's currently selected Spindel world,
+so an inherited capability cannot mutate the parent by retaining its creation
+runtime.
 
 ```clojure
 (require '[org.replikativ.spindel.spin.cps :refer [spin]])
@@ -132,12 +166,12 @@ Pass native spins via the `:native-spins` option. They are automatically wrapped
 
 ### Manual Wrapping
 
-You can also wrap spins manually using `wrap-spin-for-sci`:
+Use `wrap-spin-for-sci` only for an explicit cross-world task handle:
 
 ```clojure
 (def wrapped (boundary/wrap-spin-for-sci my-native-spin rt))
 ;; wrapped implements IFn and IDeref
-;; Call as: (wrapped resolve reject) — bindings established automatically
+;; The task executes in rt; callbacks re-enter their caller's world.
 ```
 
 ## Bidirectional Interop
@@ -160,44 +194,40 @@ Native code can directly invoke SCI-created spins because SCI functions implemen
 ;; => 42
 ```
 
-### SCI to Native (BoundaryTask)
+### SCI to Native
 
-SCI code calls native spins through BoundaryTask wrappers. The wrapper establishes `*execution-context*` and `*spin-id*` bindings before invoking the native spin:
+Inherited capabilities follow the ambient world. Explicit task handles retain
+their host world and restore the caller when they complete:
 
 ```
-Native Spin → wrap-spin-for-sci → BoundaryTask
-                                       ↓
-SCI code calls BoundaryTask(resolve, reject)
-                                       ↓
-BoundaryTask binds *execution-context* + *spin-id*
-                                       ↓
-Native spin executes with proper context
+:native-spins → AmbientBoundaryTask → caller's selected world
+
+explicit task → wrap-spin-for-sci → task's host world
+                                    ↓ completion
+                                caller's world
 ```
 
 ## Agent Isolation Pattern
 
-For agent systems (like ratatosk), each agent gets an isolated SCI context with a forked runtime:
+For agent systems, create the interpreter as a component before forking:
 
 ```clojure
 (require '[org.replikativ.spindel.engine.context :as ctx])
 
-(defn create-agent-context
-  "Create isolated agent environment with forked runtime and SCI sandbox."
-  [parent-ctx native-spins]
-  (let [forked-rt (ctx/fork-context parent-ctx)]
-    {:runtime forked-rt
-     :sci-ctx (macro/create-spin-macro-context
-                {:runtime forked-rt
-                 :native-spins native-spins})}))
+(def interpreter
+  (sci-world/create! rt {:native-spins {'tool-1 tool-spin-1}}))
 
 ;; Create isolated agents
-(def agent-a (create-agent-context rt {'tool-1 tool-spin-1}))
-(def agent-b (create-agent-context rt {'tool-2 tool-spin-2}))
+(def agent-a (ctx/fork-context rt :mode :frozen))
+(def agent-b (ctx/fork-context rt :mode :frozen))
 
-;; Each agent sees its own state (fork isolation)
-;; Each agent can only access its own native spins (SCI sandboxing)
-;; Parent runtime unaffected by agent mutations (COW)
+;; `interpreter` selects a distinct heap in rt, agent-a, and agent-b.
 ```
+
+Create different roots when agents need different capability sets. Within one
+root, `:forkable-components` can remove entire components from a child; SCI's
+own namespace and class allowlists govern what code can do inside an inherited
+interpreter.
 
 ### Isolation Guarantees
 

--- a/docs/sci-integration.md
+++ b/docs/sci-integration.md
@@ -2,6 +2,21 @@
 
 Spindel integrates with [SCI](https://github.com/babashka/sci) (Small Clojure Interpreter) for sandboxed execution of spindel code. This enables agent isolation, security sandboxing, and dynamic code evaluation while maintaining full access to spindel's reactive primitives.
 
+SCI support is optional and is therefore not included in Spindel's published
+POM. Applications using this integration must add the replikativ compatibility
+distribution, which provides the forkable interpreter-world APIs:
+
+```clojure
+{:deps {org.replikativ/spindel {:mvn/version "<version>"}
+        org.replikativ/sci {:mvn/version "0.15.59-replikativ.1"}}}
+```
+
+Do not put `org.replikativ/sci` and `org.babashka/sci` on the same classpath:
+they provide the same `sci.*` namespaces, while only the replikativ coordinate
+currently contains the forkable runtime required by this integration. Once
+those changes are released upstream, this guide will return to the upstream
+coordinate.
+
 ## Overview
 
 SCI provides a safe subset of Clojure that runs in an interpreter. Spindel's SCI integration bridges the gap between native and interpreted contexts using a **BoundaryTask** wrapper pattern that propagates runtime bindings across the boundary.

--- a/src/org/replikativ/spindel/effects/await.cljc
+++ b/src/org/replikativ/spindel/effects/await.cljc
@@ -16,8 +16,7 @@
             [org.replikativ.spindel.engine.effects :as eff]
             [org.replikativ.spindel.effects.track :as track]
             [replikativ.logging :as log]
-            [is.simm.partial-cps.async :as pcps-async])
-  #?(:clj (:import [org.replikativ.spindel.spin.core Spin])))
+            [is.simm.partial-cps.async :as pcps-async]))
 
 ;; =============================================================================
 ;; Public API Shim
@@ -150,7 +149,7 @@
 
   NOTE: In rebuild mode, we SKIP the fast path to ensure child spin bodies execute
   (for side effects like nested spin creation and continuation registration)."
-  [^Spin spin-ref spin-id source-loc resolve reject]
+  [spin-ref spin-id source-loc resolve reject]
   (let [awaited-spin-id (spin-core/spin-id spin-ref)
         noop (fn [& _] nil)
         ctx (ec/current-execution-context)
@@ -249,7 +248,7 @@
         ;; - reactive spins (parallel etc.) that re-complete on signal changes
         ;;   keep using the same continuation across multiple drain dispatches.
         :else
-        (let [child-spin-fn (.-spin-fn ^Spin spin-ref)
+        (let [child-spin-fn (spin-core/spin-body spin-ref)
               child-value (volatile! nil)
               child-error (volatile! nil)
               child-completed? (volatile! false)
@@ -547,9 +546,10 @@
         spin-core/incomplete))))
 
 (defn reactive-spin?
-  "Check if value is a Spin. Works across CLJ/CLJS."
+  "Check if value exposes both reactive identity and an engine Spin body."
   [x]
-  (instance? #?(:clj Spin :cljs spin-core/Spin) x))
+  (and (satisfies? spin-core/PSpin x)
+       (satisfies? spin-core/PSpinBody x)))
 
 (defn await-handler
   "Unified direct await handler - dispatches based on type.

--- a/src/org/replikativ/spindel/engine/component.cljc
+++ b/src/org/replikativ/spindel/engine/component.cljc
@@ -1,0 +1,119 @@
+(ns org.replikativ.spindel.engine.component
+  "Non-reactive, context-selected components of an execution world.
+
+  Signals represent values whose changes participate in the FRP graph. A world
+  component instead represents ambient runtime state—an interpreter heap, a
+  capability table, or another process-local resource. `ComponentRef` is stable
+  across forks; resolving it through a bound ExecutionContext selects that
+  world's realization.
+
+  Registration is fail-closed: a value must explicitly implement
+  `PWorldComponent`, or be wrapped with `forkable`/`shared`. Component forking
+  must be rollback-free and process-local. Effectful resources such as database
+  branches and worktrees use Yggdrasil ForkHandles, where acquisition can be
+  settled."
+  (:refer-clojure :exclude [resolve])
+  (:require [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.protocols :as rtp]))
+
+(defrecord ComponentRef [id])
+
+(defprotocol PWorldComponent
+  (realization [component]
+    "Return the value selected for programs running in this world."))
+
+(defrecord ForkableComponent [value fork-fn]
+  PWorldComponent
+  (realization [_] value)
+
+  rtp/PForkable
+  (fork-value [_ fork-id directive]
+    (->ForkableComponent (fork-fn value fork-id directive) fork-fn)))
+
+(defrecord SharedComponent [value]
+  PWorldComponent
+  (realization [_] value)
+
+  rtp/PForkable
+  (fork-value [this _fork-id _directive] this))
+
+(defn forkable
+  "Declare how a rollback-free process-local value is realized in a fork.
+
+  `fork-fn` must not acquire durable resources requiring explicit cleanup."
+  [value fork-fn]
+  (->ForkableComponent value fork-fn))
+
+(defn shared
+  "Explicitly declare that `value` may be shared by reference across worlds."
+  [value]
+  (->SharedComponent value))
+
+(defn component-ref?
+  [x]
+  (instance? ComponentRef x))
+
+(defn register!
+  "Register `value` in the bound ExecutionContext and return its stable ref.
+
+  `id` is optional and useful when an embedding needs deterministic addressing.
+  Registration updates the component map and fork index atomically."
+  ([value]
+   (register! (random-uuid) value))
+  ([id value]
+   (when-not (satisfies? PWorldComponent value)
+     (throw (ex-info
+             "World component requires an explicit fork or sharing policy"
+             {:type ::missing-fork-policy
+              :component/id id
+              :hint "Implement PWorldComponent and PForkable, or use component/forkable or component/shared."})))
+   (let [ref (->ComponentRef id)]
+     (ec/swap-state!
+      []
+      (fn [state]
+        (when (contains? (or (:world/components state) {}) id)
+          (throw (ex-info "World component id is already registered"
+                          {:type ::duplicate-component
+                           :component/id id})))
+        (-> state
+            (assoc-in [:world/components id] value)
+            (update :world/forkable-components (fnil conj #{}) id))))
+     ref)))
+
+(defn unregister!
+  "Remove a component reference from the bound world.
+
+   Idempotent and world-local: unregistering a component in a child hides that
+   realization without removing its parent's. Existing descendants that
+   already materialized the component retain their own realization."
+  [ref]
+  (let [id (:id ref)]
+    (ec/swap-state!
+     []
+     (fn [state]
+       (-> state
+           (update :world/components #(dissoc (or % {}) id))
+           (update :world/forkable-components #(disj (or % #{}) id))))))
+  nil)
+
+(defn resolve-in
+  "Resolve `ref` in `ctx`, returning its fork-local realization."
+  [ctx ref]
+  (let [id (:id ref)
+        components (ec/get-state-in ctx [:world/components])]
+    (if (contains? components id)
+      (realization (get components id))
+      (throw (ex-info "World component is not available in this context"
+                      {:type ::missing-component
+                       :component/id id
+                       :fork-id (:fork-id ctx)})))))
+
+(defn resolve
+  "Resolve `ref` through the currently bound ExecutionContext."
+  [ref]
+  (resolve-in (ec/current-execution-context) ref))
+
+(defn registered
+  "Return the bound world's `{component-id value}` map. Intended for inspection."
+  []
+  (update-vals (or (ec/get-state [:world/components]) {}) realization))

--- a/src/org/replikativ/spindel/engine/context.cljc
+++ b/src/org/replikativ/spindel/engine/context.cljc
@@ -253,6 +253,8 @@
                               :subscriptions {}      ; Event subscriptions (reverse index of the continuation tables)
                               :engine/retired-conts {} ; Exact edges consumed by valid continuation retirement
                               :atoms {}              ; Fork-safe execution context atoms
+                              :world/components {}   ; Non-reactive fork-selected resources
+                              :world/forkable-components #{}
                               ;; Engine state
                               :engine/pending []
                               :engine/draining? false
@@ -420,12 +422,18 @@
   - Bindings are merged (child overrides parent)
   - Process-id auto-increments for Elle compatibility"
   [parent-ctx & {:keys [state-updates bindings metadata process-id mode snapshots convergent-fork executor
-                        forkable-signals]
+                        forkable-signals forkable-components]
                  :or {state-updates {}
                       bindings {}
                       metadata nil
                       process-id nil
                       mode :following}}]
+  (when-let [reserved (seq (select-keys state-updates
+                                        [:world/components
+                                         :world/forkable-components]))]
+    (throw (ex-info "World component state is owned by fork-context"
+                    {:type ::reserved-component-state
+                     :state/keys (set (keys reserved))})))
   (when-not (#{:following :frozen} mode)
     (throw (ex-info "Invalid execution-context fork mode"
                     {:type ::invalid-fork-mode
@@ -526,11 +534,41 @@
                          (transient {})
                          forkable-ids)))
 
+        ;; Normalize explicit collections so one component is acquired once.
+        ;; Component forks are rollback-free, process-local operations;
+        ;; durable resources belong behind Yggdrasil ForkHandles.
+        component-ids (set (if (nil? forkable-components)
+                             (rtp/get-state parent-ctx [:world/forkable-components])
+                             forkable-components))
+        parent-components (or (rtp/get-state parent-ctx [:world/components]) {})
+        unknown-component-ids (seq (remove #(contains? parent-components %)
+                                           component-ids))
+        _ (when unknown-component-ids
+            (throw (ex-info "Cannot fork unknown world components"
+                            {:type ::unknown-world-components
+                             :component/ids (set unknown-component-ids)
+                             :fork/parent (:fork-id parent-ctx)})))
+        forked-components
+        (persistent!
+         (reduce
+          (fn [ret component-id]
+            (if (contains? parent-components component-id)
+              (assoc! ret component-id
+                      (rtp/fork-value
+                       (get parent-components component-id)
+                       fork-id
+                       {:fork :component :mode mode}))
+              ret))
+          (transient {})
+          component-ids))
+
         ;; Initialize fork-local state (engine state, continuations, forked nodes)
         fork-local-state (cond-> (merge
                                   {:track-subscriptions (or parent-track-subscriptions {}) ; ← Copy parent's track conts!
                                    :await-conts (or parent-await-conts {})                 ; ← Copy parent's await conts!
                                    :subscriptions (or parent-subscriptions {})             ; ← Copy their reverse index!
+                                   :world/components forked-components
+                                   :world/forkable-components (set component-ids)
                                    :engine/retired-conts {} ; retirement history is world-local
                                    :engine/pending [] ; ← NO inherited events; see the claim-undo below
                                    :engine/draining? false
@@ -832,9 +870,14 @@
                         state)
 
         ;; Remove pending events if requested
-        final-state (if-not include-pending?
-                      (assoc cleaned-state :engine/pending [])
-                      cleaned-state)
+        final-state (cond-> cleaned-state
+                      (not include-pending?) (assoc :engine/pending [])
+                      ;; Components are live, process-local realizations. A
+                      ;; portable snapshot keeps their durable substrates and
+                      ;; descriptors elsewhere, never interpreter heaps or
+                      ;; capability objects.
+                      true (assoc :world/components {}
+                                  :world/forkable-components #{}))
 
         ;; Create immutable backend
         snapshot-backend (backend/create-immutable-backend
@@ -856,6 +899,46 @@
      nil   ; No :running atom — drain-events! treats this as always-allowed
      nil)  ; No drain-active counter — no stop-context! to wait on
     ))
+
+(defn materialized-fork-context
+  "Create an independent in-process child with a fully materialized backend.
+
+  This is `fork-context` followed by backend materialization, so it preserves
+  lineage, lifecycle ownership, continuation semantics, and component forking.
+  External forkable signals are rejected: they require the affine Yggdrasil
+  ForkHandle lifecycle and therefore canonical `:world-policy :fork` inference.
+  The child starts without copied queues, callbacks, listeners, or timers."
+  [source-ctx & {:keys [clean-in-flight?]
+                 :or {clean-in-flight? true}}]
+  (let [forkable-signals
+        (set (rtp/get-state source-ctx [:forkable-signals]))]
+    (when (seq forkable-signals)
+      (throw
+       (ex-info
+        "Materialized inference forks cannot own external forkable signals"
+        {:type ::materialized-external-state
+         :signal/ids forkable-signals
+         :hint "Use inference :world-policy :fork for affine Yggdrasil settlement."})))
+    (let [child (fork-context source-ctx
+                              :mode :frozen
+                              :forkable-signals #{})
+          effective-state (backend/backend-deref (:backend child))
+          materialized-state
+          (-> (if clean-in-flight?
+                (clean-in-flight-spins effective-state)
+                effective-state)
+              (assoc :engine/pending []
+                     :engine/draining? false
+                     :engine/delayed-spins (sorted-map)
+                     :engine/timer-handles {}
+                     :engine/retired-conts {}
+                     :listeners {}
+                     :pending-callbacks {}))]
+      (-> child
+          (assoc :backend (backend/create-atom-backend materialized-state))
+          (update :metadata assoc
+                  :materialized-fork? true
+                  :source-fork-id (:fork-id source-ctx))))))
 
 (defn restore-snapshot
   "Restore a snapshot to a live execution context.

--- a/src/org/replikativ/spindel/engine/core.cljc
+++ b/src/org/replikativ/spindel/engine/core.cljc
@@ -73,6 +73,15 @@
   a require cycle with `spin/sync.cljc`."
   nil)
 
+(def ^:dynamic *callback-egress-policy*
+  "Authority attached to callbacks created by the current host invocation.
+
+  The default is world-local. Inference coordinators may bind
+  `:causal-follow` when a continuation copied into a descendant is explicitly
+  authorized to complete the coordinating callback. This authority is captured
+  on the callback edge; interpreted code cannot grant it by rebinding a world."
+  :isolated)
+
 ;; =============================================================================
 ;; CLJS Binding Registration
 ;; =============================================================================
@@ -318,6 +327,15 @@
   [path]
   (let [ctx (current-execution-context)]
     (rtp/get-state ctx path)))
+
+(defn get-state-in
+  "Read `path` from the explicit execution context `ctx`.
+
+  Most programs should use `get-state`, which follows the dynamic world. This
+  arity exists for stable world references that must resolve against a context
+  supplied by an embedding or continuation boundary."
+  [ctx path]
+  (rtp/get-state ctx path))
 
 (defn notify-listeners!
   "Fire the watch/egress listeners registered for reference `ref` (id `id`) with the

--- a/src/org/replikativ/spindel/engine/impl/simple.cljc
+++ b/src/org/replikativ/spindel/engine/impl/simple.cljc
@@ -1206,6 +1206,7 @@
           spin (:spin event)
           resolve-fn (:resolve-fn event)
           reject-fn (:reject-fn event)
+          callback-egress-policy (or (:callback-egress-policy event) :isolated)
           execution-context (:execution-context event)]  ; May be nil for normal spins
       (log/trace :engine/spin-execution {:spin-id tid})
       ;; Try to atomically claim execution
@@ -1245,6 +1246,7 @@
                               base-ctx)]
           (binding [ec/*execution-context* effective-ctx
                     ec/*spin-id* tid
+                    ec/*callback-egress-policy* callback-egress-policy
                     pcps-async/*in-trampoline* false]
             ;; Invoke spin (Spin implements IFn)
             (let [result (spin resolve-fn reject-fn)]

--- a/src/org/replikativ/spindel/engine/protocols.cljc
+++ b/src/org/replikativ/spindel/engine/protocols.cljc
@@ -159,15 +159,14 @@
 ;; ----------------------------------------------------------------------------
 
 (defprotocol PForkable
-  "Protocol for a SIGNAL VALUE that needs explicit forking when its host context
-  forks — a reference to external mutable state (a yggdrasil system) that the
-  overlay backend's copy-on-write does NOT isolate by itself, because the value
-  is a handle onto a shared store (a git repo, a datahike conn, a konserve CRDT).
+  "Protocol for a WORLD-BOUND VALUE that needs explicit forking when its host
+  context forks. This includes signal values that reference external mutable
+  state (a yggdrasil system) and non-reactive world components such as an
+  interpreter heap that the overlay backend's copy-on-write cannot isolate.
 
-  When an ExecutionContext is forked, every signal whose id is in
-  [:forkable-signals] is forked by calling `fork-value` on its current value and
-  writing the result as the fork-local signal node. Pure signal values (numbers,
-  maps, …) are NOT in that set and fall through the overlay unchanged.
+  When an ExecutionContext is forked, registered forkable signals and world
+  components call `fork-value`; their results are seated in the child context.
+  Pure values (numbers, maps, …) are not registered and fall through unchanged.
 
   Implementations should:
   - Return a NEW value representing the isolated fork (an Overlay or a branched

--- a/src/org/replikativ/spindel/engine/state_backend.cljc
+++ b/src/org/replikativ/spindel/engine/state_backend.cljc
@@ -110,8 +110,10 @@
   fork must not inherit-then-fire the parent's listener on a fork-private mutation
   (that would leak speculative state). A fork that wants to egress adds its own."
   #{:track-subscriptions :await-conts :subscriptions :engine/retired-conts
+    :world/components :world/forkable-components
     :engine/pending :engine/draining?
-    :engine/delayed-spins :engine/timer-handles :listeners})
+    :engine/delayed-spins :engine/timer-handles :listeners
+    :pending-callbacks})
 
 (def ^:private deleted ::deleted)
 (def ^:private full-replacement-key ::full-replacement)

--- a/src/org/replikativ/spindel/inference/coordinator.cljc
+++ b/src/org/replikativ/spindel/inference/coordinator.cljc
@@ -165,7 +165,12 @@
                   (when (compare-and-set! settled? false true)
                     (swap! manager update-state)
                     (try
-                      (f value)
+                      ;; Fork creation is an effect hosted by a child world,
+                      ;; but its continuation belongs to the source program.
+                      ;; Re-enter the caller explicitly so initialization does
+                      ;; not migrate the coordinating Spin into the new child.
+                      (binding [rtc/*execution-context* source-context]
+                        (f value))
                       (finally
                         (maybe-complete-particle-quiescence! manager)))))
         opts (-> fork-opts
@@ -564,24 +569,20 @@
 ;; =============================================================================
 
 (defn fork-particle-context
-  "Create independent copy of particle context using snapshot-based forking.
+  "Create an independent, fully materialized child particle context.
 
-  Uses snapshot-context + restore-snapshot instead of fork-context to avoid
-  overlay backend isolation issues (see OVERLAY_BACKEND_BUG.md).
-
-  This creates a complete independent copy with AtomBackend, ensuring no
-  shared state between particles.
+  This avoids overlay-backend coupling while retaining parent lineage and
+  independently forking live world components such as SCI interpreters. It is
+  an in-process operation, not a portable snapshot.
 
   Args:
     ctx - ExecutionContext to fork
 
   Returns: New ExecutionContext with AtomBackend (complete independent copy)"
   [ctx]
-  (let [snap (ctx/snapshot-context ctx
-                                   :clean-in-flight? false   ; Keep spin states as-is
-                                   :include-pending? false)] ; Don't include pending events
-    (ctx/restore-snapshot snap
-                          :drain-events? false)))  ; Don't drain - caller initializes state first
+  (ctx/materialized-fork-context
+   ctx
+   :clean-in-flight? false))
 
 ;; =============================================================================
 ;; Helper: Pair Checkpoints for Resampling

--- a/src/org/replikativ/spindel/inference/inference.cljc
+++ b/src/org/replikativ/spindel/inference/inference.cljc
@@ -122,6 +122,7 @@
                                :id spin-id
                                :spin task
                                :execution-context context
+                               :callback-egress-policy :causal-follow
                                :resolve-fn resolve-fn
                                :reject-fn reject-fn})
           (catch #?(:clj Throwable :cljs :default) error
@@ -143,6 +144,9 @@
    :discard!
    #(coord/discard-particle-worlds-when-quiescent! world-manager)
    :descriptors (coord/world-descriptors world-manager)})
+
+(defmacro ^:private inference-spin [& body]
+  `(spin-core/with-causal-descendant-egress (spin ~@body)))
 
 (defn kernel-infer
   "Run inference using a PInferenceKernel.
@@ -183,7 +187,7 @@
                                         {:barrier-policy :every-observe}))]
         (query measure identity)))"
   [model-task kernel num-particles & [opts]]
-  (spin
+  (inference-spin
    (log/debug :kernel-infer/start {:kernel-id (k/kernel-id kernel)
                                    :num-particles num-particles
                                    :barrier-policy (:barrier-policy opts :every-observe)})

--- a/src/org/replikativ/spindel/sci/boundary.clj
+++ b/src/org/replikativ/spindel/sci/boundary.clj
@@ -22,9 +22,22 @@
 (deftype BoundaryTask [task runtime task-spin-id]
   clojure.lang.IFn
   (invoke [this resolve reject]
-    (binding [ec/*execution-context* runtime
-              ec/*spin-id* task-spin-id]
-      (task resolve reject)))
+    (let [caller-runtime (ec/current-execution-context)
+          caller-spin-id ec/*spin-id*
+          return-to-caller
+          (fn [continuation]
+            (fn [value]
+              (binding [ec/*execution-context* caller-runtime
+                        ec/*spin-id* caller-spin-id]
+                (continuation value))))]
+      ;; The task executes where it is hosted, but its result returns to the
+      ;; caller's world. Without the wrapped callbacks, awaiting a task in a
+      ;; nested child world migrates the caller's continuation into that child
+      ;; and caches the caller's result on the wrong execution context.
+      (binding [ec/*execution-context* runtime
+                ec/*spin-id* task-spin-id]
+        (task (return-to-caller resolve)
+              (return-to-caller reject)))))
 
   clojure.lang.IDeref
   (deref [this]
@@ -34,7 +47,8 @@
 (defn wrap-spin-for-sci
   "Wrap a native spin for use in SCI contexts.
 
-  Returns a BoundaryTask that establishes proper bindings when called from SCI.
+  Returns a BoundaryTask that executes in the task runtime and re-enters the
+  caller runtime for resolve/reject.
 
   Example:
     (def native-spin (spin (+ 1 2)))
@@ -43,7 +57,39 @@
     ;; In SCI:
     (wrapped resolve reject)  ; Works! Bindings established automatically"
   [task runtime]
-  (BoundaryTask. task runtime (.-spin_id task)))
+  (BoundaryTask. task runtime (spin-core/spin-id task)))
+
+(deftype AmbientBoundaryTask [task task-spin-id]
+  clojure.lang.IFn
+  (invoke [_ resolve reject]
+    (let [caller-runtime (ec/current-execution-context)
+          caller-spin-id ec/*spin-id*
+          return-to-caller
+          (fn [continuation]
+            (fn [value]
+              (binding [ec/*execution-context* caller-runtime
+                        ec/*spin-id* caller-spin-id]
+                (continuation value))))]
+      ;; Capabilities inherited by a fork belong to the selected world. Unlike
+      ;; an explicit cross-world task handle, they must not retain the runtime
+      ;; in which the interpreter was originally constructed.
+      (binding [ec/*execution-context* caller-runtime
+                ec/*spin-id* task-spin-id]
+        (task (return-to-caller resolve)
+              (return-to-caller reject)))))
+
+  clojure.lang.IDeref
+  (deref [_]
+    @task))
+
+(defn wrap-capability-for-sci
+  "Wrap an inherited native capability so it executes in the caller's world.
+
+  Use this for `:native-spins` installed in a forkable interpreter. Use
+  `wrap-spin-for-sci` instead for an explicit handle to a task hosted by a
+  particular world."
+  [task]
+  (AmbientBoundaryTask. task (spin-core/spin-id task)))
 
 ;; =============================================================================
 ;; SCI Spin Creation
@@ -108,7 +154,7 @@
          native-spins {}}}]
   (let [;; Wrap all native spins for SCI
         wrapped-natives (into {} (map (fn [[k v]]
-                                        [k (wrap-spin-for-sci v runtime)])
+                                        [k (wrap-capability-for-sci v)])
                                       native-spins))
 
         ;; Create base SCI context

--- a/src/org/replikativ/spindel/sci/macro.clj
+++ b/src/org/replikativ/spindel/sci/macro.clj
@@ -67,6 +67,10 @@
                     interrupt flag is set so timeouts and user-cancels unwind
                     the computation). Optional — omit for unbounded execution.
                     (Convenience; equivalent to `:sci-opts {:interrupt-fn …}`.)
+    :resolve-sci-context - Optional `(fn [execution-context] sci-context)` used
+                when a suspended continuation resumes in a descendant Spindel
+                world. Embeddings with forked interpreter components use this
+                to select the SCI world paired with the ambient runtime.
     :sci-opts - A map merged into the `sci/init` argument, so a consumer can set
                 ANY SCI option without spindel having to thread it through one key
                 at a time — e.g. `:load-fn` (resolve `(require …)` against the
@@ -94,17 +98,18 @@
                   x (await a)
                   y (await b)]
               (+ x y)))\"))  ; => 30"
-  [{:keys [runtime native-spins expose-track? interrupt-fn sci-opts]
+  [{:keys [runtime native-spins expose-track? interrupt-fn sci-opts resolve-sci-context]
     :or {native-spins {}
          expose-track? true
          sci-opts      {}}}]
   (let [sci-execution-context (sci/new-dynamic-var '*execution-context* runtime)
         sci-spin-id (sci/new-dynamic-var '*spin-id* nil)
         sci-in-trampoline (sci/new-dynamic-var '*in-trampoline* false)
-        ;; Wrap all native spins for SCI (BoundaryTask pattern)
+        ;; Native capabilities follow the caller's selected world. Explicit
+        ;; cross-world task handles use boundary/wrap-spin-for-sci instead.
         wrapped-natives (into {}
                               (map (fn [[k v]]
-                                     [k (boundary/wrap-spin-for-sci v runtime)])
+                                     [k (boundary/wrap-capability-for-sci v)])
                                    native-spins))
 
         ;; Build namespace map — inject native primitives SCI code needs
@@ -149,6 +154,10 @@
         sci-ctx (sci/init
                  (-> sci-opts
                      (cond-> interrupt-fn (assoc :interrupt-fn interrupt-fn))
+                     ;; Spindel captures and retargets suspended continuations;
+                     ;; SCI's direct/standard runtime deliberately does not
+                     ;; maintain the managed world needed for that operation.
+                     (assoc :runtime-mode :forkable)
                      (update :features    #(or % #{:clj}))
                      (update :classes     merge (sci-core/common-classes))
                      (update :bindings    merge wrapped-natives)
@@ -175,6 +184,8 @@
         (let [captured-ctx (ec/current-execution-context)
               captured-spin-id ec/*spin-id*
               captured-trampoline @sci-in-trampoline
+              captured-sci-context (sci/capture-continuation-context sci-ctx)
+              continuation-contexts (atom {sci-ctx captured-sci-context})
               wrap-cont
               (fn [continuation]
                 (fn [value]
@@ -183,18 +194,37 @@
                         current-ctx (if (same-world-or-descendant?
                                          ambient-ctx captured-ctx)
                                       ambient-ctx
-                                      captured-ctx)]
-                    (binding [ec/*execution-context* current-ctx
-                              ;; A Spin keeps one identity across worlds. The
-                              ;; ambient id belongs to the producer/drain that
-                              ;; happened to resume this continuation and must
-                              ;; never re-parent the consumer's next await.
-                              ec/*spin-id* captured-spin-id]
-                      (sci/with-bindings
-                        {sci-execution-context current-ctx
-                         sci-spin-id captured-spin-id
-                         sci-in-trampoline captured-trampoline}
-                        (async/invoke-continuation continuation value))))))]
+                                      captured-ctx)
+                        target-sci-ctx (if resolve-sci-context
+                                         (resolve-sci-context current-ctx)
+                                         sci-ctx)
+                        continuation-context
+                        (or (get @continuation-contexts target-sci-ctx)
+                            (let [retargeted
+                                  (sci/retarget-continuation-context
+                                   captured-sci-context target-sci-ctx)]
+                              (get (swap! continuation-contexts
+                                          #(if (contains? % target-sci-ctx)
+                                             %
+                                             (assoc % target-sci-ctx retargeted)))
+                                   target-sci-ctx)))
+                        resume
+                        (sci/continuation-context-fn
+                         continuation-context
+                         (fn [resumed-value]
+                           (binding [ec/*execution-context* current-ctx
+                                     ;; A Spin keeps one identity across worlds. The
+                                     ;; ambient id belongs to the producer/drain that
+                                     ;; happened to resume this continuation and must
+                                     ;; never re-parent the consumer's next await.
+                                     ec/*spin-id* captured-spin-id]
+                             (sci/with-bindings
+                               {sci-execution-context current-ctx
+                                sci-spin-id captured-spin-id
+                                sci-in-trampoline captured-trampoline}
+                               (async/invoke-continuation continuation
+                                                          resumed-value)))))]
+                    (resume value))))]
           (when-not captured-spin-id
             (throw (ex-info "SCI await requires an owning Spin"
                             {:type ::sci-await-outside-spin

--- a/src/org/replikativ/spindel/sci/world.clj
+++ b/src/org/replikativ/spindel/sci/world.clj
@@ -1,0 +1,54 @@
+(ns org.replikativ.spindel.sci.world
+  "SCI interpreters as ordinary fork-selected Spindel world components."
+  (:require [sci.core :as sci]
+            [org.replikativ.spindel.engine.component :as component]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.sci.macro :as macro]))
+
+(defrecord InterpreterWorld [context]
+  component/PWorldComponent
+  (realization [this] this)
+
+  rtp/PForkable
+  (fork-value [_ _fork-id _directive]
+    (->InterpreterWorld (sci/fork context))))
+
+(defn context-in
+  "Resolve interpreter `ref` in the explicit Spindel execution context."
+  [execution-context ref]
+  (:context (component/resolve-in execution-context ref)))
+
+(defn context
+  "Resolve interpreter `ref` in the currently bound execution context."
+  [ref]
+  (:context (component/resolve ref)))
+
+(defn create!
+  "Create and register a forkable SCI interpreter in `runtime`.
+
+  Options are those accepted by `create-spin-macro-context`, except `:runtime`
+  and `:resolve-sci-context`, which this component owns. Returns a stable
+  ComponentRef; resolving it in a descendant selects the forked interpreter."
+  ([runtime]
+   (create! runtime {}))
+  ([runtime opts]
+   (let [ref-holder (volatile! nil)
+         interpreter
+         (binding [ec/*execution-context* runtime]
+           (sci/with-detached-context
+             #(macro/create-spin-macro-context
+               (assoc opts
+                      :runtime runtime
+                      :resolve-sci-context
+                      (fn [execution-context]
+                        (context-in execution-context @ref-holder))))))
+         ref (binding [ec/*execution-context* runtime]
+               (component/register! (->InterpreterWorld interpreter)))]
+     (vreset! ref-holder ref)
+     ref)))
+
+(defn eval-string*
+  "Evaluate `source` in interpreter `ref` selected by the current world."
+  [ref source]
+  (sci/eval-string* (context ref) source))

--- a/src/org/replikativ/spindel/spin/core.cljc
+++ b/src/org/replikativ/spindel/spin/core.cljc
@@ -22,6 +22,10 @@
 (defprotocol PSpin
   (spin-id [_] "Spin id of this spin."))
 
+(defprotocol PSpinBody
+  (spin-body [_]
+    "Return the CPS body used by the engine's reactive await slow path."))
+
 ;; =============================================================================
 ;; Result Type (from spin/result.cljc)
 ;; =============================================================================
@@ -145,6 +149,17 @@
 ;; Forward declaration for error handling
 (declare abort-spin-chain!)
 
+(defn- callback-visible-in-world?
+  "Whether a callback edge explicitly permits completion from another world."
+  [ctx origin-fork-id egress-policy]
+  (or (= (:fork-id ctx) origin-fork-id)
+      (and (= :causal-follow egress-policy)
+           (loop [candidate (:parent-ctx ctx)]
+             (cond
+               (nil? candidate) false
+               (= (:fork-id candidate) origin-fork-id) true
+               :else (recur (:parent-ctx candidate)))))))
+
 ;; spin-fn now arity-2 (resolve reject) relying on dynamic bindings (*execution-context*, *spin-id*).
 ;; Spin is STATELESS - no runtime reference, uses dynamic *execution-context* binding.
 
@@ -212,6 +227,7 @@
              (ec/enqueue-event! {:type :spin-execution
                                  :id spin-id
                                  :spin this
+                                 :callback-egress-policy ec/*callback-egress-policy*
                                  :resolve-fn (fn [value]
                                                (deliver result-promise (ok value)))
                                  :reject-fn (fn [e]
@@ -222,6 +238,9 @@
 (deftype Spin [spin-id spin-fn]
   PSpin
   (spin-id [_] spin-id)
+
+  PSpinBody
+  (spin-body [_] spin-fn)
 
   #?(:clj clojure.lang.IFn :cljs IFn)
   (#?(:clj invoke :cljs -invoke) [this resolve reject]
@@ -291,7 +310,14 @@
           ;; Case 2: Cache miss - execute spin
         :else
         (let [;; Local execution state (ephemeral, not in runtime)
-              callbacks-atom (atom [{:resolve resolve :reject reject}])
+              ;; A continuation can be copied into a child world. The initiating
+              ;; callback is process-local egress owned by the world that called
+              ;; this Spin; completing the copied child must cache its child
+              ;; result without firing the parent's callback.
+              callbacks-atom (atom [{:fork-id (:fork-id runtime)
+                                     :egress-policy ec/*callback-egress-policy*
+                                     :resolve resolve
+                                     :reject reject}])
               executing? (atom true)]
 
           (log/debug :spin/start {:spin-id spin-id})
@@ -325,7 +351,11 @@
 
                                 ;; Call all pending callbacks from local state
                               (let [callbacks @callbacks-atom]
-                                (doseq [{:keys [resolve]} callbacks]
+                                (doseq [{callback-fork-id :fork-id
+                                         :keys [resolve egress-policy]} callbacks
+                                        :when (callback-visible-in-world?
+                                               current-rt callback-fork-id
+                                               egress-policy)]
                                     ;; Call resolve via resume to handle Thunk returns
                                   (resume resolve value)))
 
@@ -362,7 +392,11 @@
 
                                 ;; Call all pending callbacks from local state
                               (let [callbacks @callbacks-atom]
-                                (doseq [{:keys [reject]} callbacks]
+                                (doseq [{callback-fork-id :fork-id
+                                         :keys [reject egress-policy]} callbacks
+                                        :when (callback-visible-in-world?
+                                               _current-rt callback-fork-id
+                                               egress-policy)]
                                     ;; Call reject via resume to handle Thunk returns
                                   (resume reject err)))
 
@@ -403,6 +437,42 @@
   Object
   (toString [_this]
     (str "#<Spin " spin-id ">")))
+
+(deftype CallbackEgressSpin [task policy]
+  PSpin
+  (spin-id [_] (spin-id task))
+
+  PSpinBody
+  (spin-body [_]
+    (let [body (spin-body task)]
+      (fn [resolve reject]
+        (binding [ec/*callback-egress-policy* policy]
+          (body resolve reject)))))
+
+  #?(:clj clojure.lang.IFn :cljs IFn)
+  (#?(:clj invoke :cljs -invoke) [_ resolve reject]
+    (binding [ec/*callback-egress-policy* policy]
+      (task resolve reject)))
+
+  #?(:clj clojure.lang.IDeref :cljs IDeref)
+  (#?(:clj deref :cljs -deref) [_]
+    (binding [ec/*callback-egress-policy* policy]
+      @task))
+
+  #?@(:clj
+      [clojure.lang.IBlockingDeref
+       (deref [_ timeout-ms timeout-val]
+              (binding [ec/*callback-egress-policy* policy]
+                (deref task timeout-ms timeout-val)))])
+
+  Object
+  (toString [_]
+    (str "#<CallbackEgressSpin " (spin-id task) " " policy ">")))
+
+(defn ^:no-doc with-causal-descendant-egress
+  "Authorize a host-owned Spin callback to complete from COW descendants."
+  [task]
+  (CallbackEgressSpin. task :causal-follow))
 
 ;; =============================================================================
 ;; Spin Creation

--- a/test/org/replikativ/spindel/engine/component_test.clj
+++ b/test/org/replikativ/spindel/engine/component_test.clj
@@ -1,0 +1,191 @@
+(ns org.replikativ.spindel.engine.component-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.engine.component :as component]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.protocols :as rtp]
+            [org.replikativ.spindel.engine.state-backend :as backend]))
+
+(defrecord ForkableBox [value]
+  component/PWorldComponent
+  (realization [this] this)
+
+  rtp/PForkable
+  (fork-value [_ fork-id directive]
+    (->ForkableBox [value fork-id directive])))
+
+(deftest component-ref-selects-the-current-world
+  (let [parent (context/create-execution-context)]
+    (try
+      (let [ref (binding [ec/*execution-context* parent]
+                  (component/register! :box (->ForkableBox :parent)))
+            child (context/fork-context parent :mode :frozen)]
+        (try
+          (is (= :parent (:value (component/resolve-in parent ref))))
+          (let [[value fork-id directive]
+                (:value (component/resolve-in child ref))]
+            (is (= :parent value))
+            (is (= (:fork-id child) fork-id))
+            (is (= {:fork :component :mode :frozen} directive)))
+          (binding [ec/*execution-context* child]
+            (is (= (:fork-id child)
+                   (second (:value (component/resolve ref))))))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest explicit-component-selection-attenuates-the-child
+  (let [parent (context/create-execution-context)]
+    (try
+      (let [kept (binding [ec/*execution-context* parent]
+                   (component/register! :kept (->ForkableBox 1)))
+            removed (binding [ec/*execution-context* parent]
+                      (component/register! :removed (->ForkableBox 2)))
+            child (context/fork-context parent :forkable-components #{:kept})]
+        (try
+          (is (some? (component/resolve-in child kept)))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"not available"
+                                (component/resolve-in child removed)))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest component-selection-cannot-be-overridden-through-state-updates
+  (let [parent (context/create-execution-context)]
+    (try
+      (binding [ec/*execution-context* parent]
+        (component/register! :kept (->ForkableBox 1)))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"owned by fork-context"
+           (context/fork-context
+            parent
+            :forkable-components #{}
+            :state-updates {:world/components {:kept (->ForkableBox :alias)}})))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest explicit-component-selection-is-normalized
+  (let [parent (context/create-execution-context)
+        fork-count (atom 0)]
+    (try
+      (binding [ec/*execution-context* parent]
+        (component/register!
+         :counted
+         (component/forkable
+          :parent
+          (fn [_ _ _]
+            (swap! fork-count inc)
+            :child))))
+      (let [child (context/fork-context
+                   parent :forkable-components [:counted :counted])]
+        (try
+          (is (= 1 @fork-count))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest registration-and-selection-fail-closed
+  (let [parent (context/create-execution-context)]
+    (try
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"explicit fork or sharing policy"
+                            (binding [ec/*execution-context* parent]
+                              (component/register! :unsafe (atom {})))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"unknown world components"
+                            (context/fork-context
+                             parent :forkable-components #{:missing})))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest sharing-a-component-is-an-explicit-declaration
+  (let [parent (context/create-execution-context)
+        mutable-value (atom [])]
+    (try
+      (let [ref (binding [ec/*execution-context* parent]
+                  (component/register! :shared
+                                       (component/shared mutable-value)))
+            child (context/fork-context parent)]
+        (try
+          (is (identical? mutable-value (component/resolve-in parent ref)))
+          (is (identical? mutable-value (component/resolve-in child ref)))
+          (binding [ec/*execution-context* parent]
+            (is (= {:shared mutable-value} (component/registered))))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest unregister-is-idempotent-and-world-local
+  (let [parent (context/create-execution-context)]
+    (try
+      (let [ref (binding [ec/*execution-context* parent]
+                  (component/register! :temporary (->ForkableBox :parent)))
+            child (context/fork-context parent :mode :frozen)]
+        (try
+          (binding [ec/*execution-context* child]
+            (component/unregister! ref)
+            (component/unregister! ref))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"not available"
+                                (component/resolve-in child ref)))
+          (is (= :parent (:value (component/resolve-in parent ref)))
+              "removing the child realization cannot mutate its parent")
+          (binding [ec/*execution-context* parent]
+            (component/unregister! ref))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"not available"
+                                (component/resolve-in parent ref)))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest materialized-forks-use-canonical-fork-invariants
+  (let [parent (context/create-execution-context)]
+    (try
+      (let [ref (binding [ec/*execution-context* parent]
+                  (component/register! :heap (->ForkableBox :parent)))]
+        (binding [ec/*execution-context* parent]
+          (ec/swap-state! [:listeners] (constantly {:host identity}))
+          (ec/swap-state! [:pending-callbacks]
+                          (constantly {:spin [{:resolve identity}]})))
+        (let [child (context/materialized-fork-context
+                     parent :clean-in-flight? false)]
+          (try
+            (is (identical? parent (:parent-ctx child)))
+            (is (identical? (:running parent) (:running child)))
+            (is (identical? (:drain-active parent) (:drain-active child)))
+            (is (= :atom (backend/backend-type (:backend child))))
+            (is (empty? (ec/get-state-in child [:listeners])))
+            (is (empty? (ec/get-state-in child [:pending-callbacks])))
+            (is (= :parent
+                   (first (:value (component/resolve-in child ref)))))
+            (finally
+              (context/close-context! child)))))
+      (binding [ec/*execution-context* parent]
+        (ec/swap-state! [:forkable-signals] (constantly #{:external})))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"cannot own external forkable signals"
+           (context/materialized-fork-context parent)))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest portable-snapshots-drop-process-local-components
+  (let [parent (context/create-execution-context)]
+    (try
+      (let [ref (binding [ec/*execution-context* parent]
+                  (component/register! :ephemeral (->ForkableBox :live)))
+            snapshot (context/snapshot-context parent)]
+        (is (= :live (:value (component/resolve-in parent ref))))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"not available"
+                              (component/resolve-in snapshot ref))))
+      (finally
+        (context/close-context! parent)))))

--- a/test/org/replikativ/spindel/sci/nested_world_test.clj
+++ b/test/org/replikativ/spindel/sci/nested_world_test.clj
@@ -5,6 +5,7 @@
             [org.replikativ.spindel.engine.core :as ec]
             [org.replikativ.spindel.sci.boundary :as boundary]
             [org.replikativ.spindel.sci.macro :as macro]
+            [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.yggdrasil :as ygg]
             [sci.core :as sci]))
 
@@ -21,6 +22,7 @@
         {'fork! (fn []
                   (let [world-id (random-uuid)
                         handle (ygg/fork! {:purpose :interpreter
+                                           :mode :frozen
                                            :sync? true})]
                     (swap! worlds assoc world-id handle)
                     world-id))
@@ -28,9 +30,10 @@
          (fn [world-id]
            (let [interpreter-id (random-uuid)
                  interpreter
-                 (macro/create-spin-macro-context
-                  {:runtime (:child-ctx (resolve-world world-id))
-                   :sci-opts @nested-opts})]
+                 (sci/with-detached-context
+                   #(macro/create-spin-macro-context
+                     {:runtime (:child-ctx (resolve-world world-id))
+                      :sci-opts @nested-opts}))]
              (swap! interpreters assoc interpreter-id interpreter)
              interpreter-id))
          'eval-spin
@@ -48,23 +51,33 @@
         outer (macro/create-spin-macro-context
                {:runtime root :sci-opts opts})]
     (try
-      (let [{:keys [world-id value] :as result}
+      (let [nested-source
+            "(require '[org.replikativ.spindel.spin.cps :refer [spin]]) (spin 41)"
+            outer-source
+            (str
+             "(require '[spindel.world :as world] "
+             "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
+             "         '[org.replikativ.spindel.effects.await :refer [await]]) "
+             "(let [child (world/fork!) "
+             "      interpreter (world/interpreter! child) "
+             "      nested-task (world/eval-spin child interpreter "
+             (pr-str nested-source)
+             ") "
+             "      task (spin (inc (await nested-task)))] "
+             "  {:world-id child :task task :value @task})")
+            {:keys [world-id task value] :as result}
             (binding [ec/*execution-context* root]
-              (sci/eval-string*
-               outer
-               (str
-                "(require '[spindel.world :as world] "
-                "         '[org.replikativ.spindel.spin.cps :refer [spin]] "
-                "         '[org.replikativ.spindel.effects.await :refer [await]]) "
-                "(let [child (world/fork!) "
-                "      interpreter (world/interpreter! child) "
-                "      task (world/eval-spin "
-                "            child interpreter "
-                "            \"(require '[org.replikativ.spindel.spin.cps :refer [spin]]) (spin 41)\")] "
-                "  {:world-id child :value @(spin (inc (await task)))})")))
-            world (resolve-world world-id)]
+              (sci/eval-string* outer outer-source))
+            world (resolve-world world-id)
+            task-id (spin-core/spin-id task)]
         (testing "the interpreter and its computation are constructed by SCI"
           (is (= 42 value))
+          (is (= 42 (:payload (binding [ec/*execution-context* root]
+                                (ec/spin-current-result task-id))))
+              "the nested boundary returns completion to the caller world")
+          (is (nil? (binding [ec/*execution-context* (:child-ctx world)]
+                      (ec/spin-current-result task-id)))
+              "the nested task runtime does not steal the caller's completion")
           (is (= :interpreter
                  (:fork/purpose (ygg/fork-descriptor world))))
           (is (= (:fork-id root)
@@ -74,7 +87,7 @@
           (binding [ec/*execution-context* root]
             (is (nil? (ygg/discard-fork! world {:sync? true}))))
           (is (not (ygg/open-fork? world))))
-        (is (= #{:world-id :value} (set (keys result))))
+        (is (= #{:world-id :task :value} (set (keys result))))
         (is (uuid? world-id)
             "SCI receives an opaque identifier, never the affine handle"))
       (finally

--- a/test/org/replikativ/spindel/sci/world_test.clj
+++ b/test/org/replikativ/spindel/sci/world_test.clj
@@ -1,0 +1,185 @@
+(ns org.replikativ.spindel.sci.world-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [sci.core :as sci]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.engine.impl.simple :as simple]
+            [org.replikativ.spindel.inference.coordinator :as coordinator]
+            [org.replikativ.spindel.sci.world :as world]
+            [org.replikativ.spindel.spin.core :as spin-core]))
+
+(deftest inherited-native-capabilities-follow-the-selected-world
+  (let [parent (context/create-execution-context)]
+    (try
+      (binding [ec/*execution-context* parent]
+        (ec/swap-state! [:probe] (constantly [])))
+      (let [probe-tool
+            (binding [ec/*execution-context* parent]
+              (spin-core/make-spin
+               (fn [resolve _reject]
+                 (ec/swap-state!
+                  [:probe]
+                  #(conj % (:fork-id (ec/current-execution-context))))
+                 (resolve :ok))
+               :probe-tool))
+            interpreter-ref
+            (world/create! parent {:native-spins {'probe-tool probe-tool}})
+            child (context/fork-context parent :mode :frozen)]
+        (try
+          (let [task
+                (binding [ec/*execution-context* child]
+                  (world/eval-string*
+                   interpreter-ref
+                   "(require '[org.replikativ.spindel.spin.cps :refer [spin]]
+                              '[org.replikativ.spindel.effects.await :refer [await]])
+                    (spin (await probe-tool))"))]
+            (is (= :ok (binding [ec/*execution-context* child] @task)))
+            (is (= [(:fork-id child)]
+                   (binding [ec/*execution-context* child]
+                     (ec/get-state [:probe]))))
+            (is (= []
+                   (binding [ec/*execution-context* parent]
+                     (ec/get-state [:probe])))))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! parent)))))
+
+(deftest causal-callback-egress-is-limited-to-descendants
+  (let [parent (context/create-execution-context)
+        unrelated (context/create-execution-context)
+        callback (atom nil)
+        result (promise)
+        worker
+        (binding [ec/*execution-context* parent]
+          (spin-core/make-spin
+           (fn [resolve _reject]
+             (reset! callback resolve)
+             spin-core/incomplete)
+           :causal-worker))]
+    (try
+      (binding [ec/*execution-context* parent
+                ec/*callback-egress-policy* :causal-follow]
+        (worker #(deliver result %) #(deliver result %)))
+      (let [child (context/fork-context parent :mode :frozen)]
+        (try
+          (binding [ec/*execution-context* unrelated]
+            (@callback :unrelated))
+          (is (= ::pending (deref result 20 ::pending)))
+          (binding [ec/*execution-context* child]
+            (@callback :descendant))
+          (is (= :descendant (deref result 1000 ::timeout)))
+          (finally
+            (context/close-context! child))))
+      (finally
+        (context/close-context! unrelated)
+        (context/close-context! parent)))))
+
+(deftest suspended-sci-spin-resumes-independently-in-forked-worlds
+  (testing "the copied Spindel continuation selects the paired SCI heap"
+    (let [parent (context/create-execution-context)
+          callback (atom nil)
+          operation (fn [resolve _reject]
+                      (reset! callback resolve)
+                      spin-core/incomplete)]
+      (try
+        (let [interpreter-ref
+              (world/create!
+               parent
+               {:sci-opts {:bindings {'operation operation}}})
+              interpreter (world/context-in parent interpreter-ref)
+              worker
+              (binding [ec/*execution-context* parent]
+                (sci/eval-string*
+                 interpreter
+                 "(require '[org.replikativ.spindel.spin.cps :refer [spin]]
+                           '[org.replikativ.spindel.effects.await :refer [await]])
+                  (def state (atom []))
+                  (def ^:dynamic *scope* :root)
+                  (spin
+                    (binding [*scope* :bound]
+                      (let [value (await operation)]
+                        (swap! state conj [*scope* value])
+                        @state)))"))
+              spin-id (spin-core/spin-id worker)
+              parent-result (promise)]
+          (binding [ec/*execution-context* parent]
+            (worker #(deliver parent-result %) #(deliver parent-result %)))
+          (simple/await-drain-complete! parent :timeout-ms 2000)
+          (is (fn? @callback))
+          (let [child (context/fork-context parent :mode :frozen)
+                child-interpreter (world/context-in child interpreter-ref)]
+            (try
+              (is (not (identical? interpreter child-interpreter)))
+              (binding [ec/*execution-context* child]
+                (@callback :child))
+              (simple/await-drain-complete! child :timeout-ms 2000)
+              (is (= [[:bound :child]]
+                     (:payload
+                      (binding [ec/*execution-context* child]
+                        (ec/spin-current-result spin-id)))))
+              (is (= ::pending (deref parent-result 20 ::pending))
+                  "child completion must not fire the parent's egress callback")
+              (is (nil? (binding [ec/*execution-context* parent]
+                          (ec/spin-current-result spin-id))))
+              (is (= [[:bound :child]]
+                     (sci/eval-string* child-interpreter "@state")))
+              (is (= [] (sci/eval-string* interpreter "@state")))
+              (binding [ec/*execution-context* parent]
+                (@callback :parent))
+              (simple/await-drain-complete! parent :timeout-ms 2000)
+              (is (= [[:bound :parent]]
+                     (:payload
+                      (binding [ec/*execution-context* parent]
+                        (ec/spin-current-result spin-id)))))
+              (is (= [[:bound :parent]] @parent-result))
+              (is (= [[:bound :parent]]
+                     (sci/eval-string* interpreter "@state")))
+              (is (= [[:bound :child]]
+                     (sci/eval-string* child-interpreter "@state")))
+              (finally
+                (context/close-context! child)))))
+        (finally
+          (context/close-context! parent))))))
+
+(deftest materialized-particle-fork-retargets-sci-continuations
+  (let [parent (context/create-execution-context)
+        callback (atom nil)
+        operation (fn [resolve _reject]
+                    (reset! callback resolve)
+                    spin-core/incomplete)]
+    (try
+      (let [interpreter-ref
+            (world/create!
+             parent
+             {:sci-opts {:bindings {'operation operation}}})
+            parent-interpreter (world/context-in parent interpreter-ref)
+            worker
+            (binding [ec/*execution-context* parent]
+              (sci/eval-string*
+               parent-interpreter
+               "(require '[org.replikativ.spindel.spin.cps :refer [spin]]
+                          '[org.replikativ.spindel.effects.await :refer [await]])
+                (def samples (atom []))
+                (spin (let [x (await operation)]
+                        (swap! samples conj x)))"))
+            result (promise)]
+        (binding [ec/*execution-context* parent
+                  ec/*callback-egress-policy* :causal-follow]
+          (worker #(deliver result %) #(deliver result %)))
+        (let [particle (coordinator/fork-particle-context parent)
+              particle-interpreter (world/context-in particle interpreter-ref)]
+          (try
+            (is (= (:fork-id parent) (:fork-id (:parent-ctx particle))))
+            (is (not (identical? parent-interpreter particle-interpreter)))
+            (binding [ec/*execution-context* particle]
+              (@callback :particle))
+            (simple/await-drain-complete! particle :timeout-ms 2000)
+            (is (= [:particle]
+                   (sci/eval-string* particle-interpreter "@samples")))
+            (is (= [] (sci/eval-string* parent-interpreter "@samples")))
+            (is (= [:particle] (deref result 1000 ::timeout)))
+            (finally
+              (context/close-context! particle)))))
+      (finally
+        (context/close-context! parent)))))


### PR DESCRIPTION
## Summary

- add typed forkable/shared world components selected through stable references
- compose forkable SCI interpreters into Spindel execution worlds
- retarget SCI continuation contexts with their owning world
- document and test nested SCI-inside-SCI world construction

## Dependency

This is stacked on #47. It currently pins the reviewed SCI forkability commit `8ef4d70`; before marking ready, replace both pins with `org.babashka/sci 0.15.59` after whilo/sci#2 is merged and published.

## Verification

- full JVM suite: 1015 tests, 4047 assertions, 0 failures/errors
- formatting and diff checks clean
- independent review: no medium/high findings
- Dvergr integration suite against this branch: 547 tests, 2359 assertions, 0 failures