### PR TITLE
feat(spin): observe successful spawned completion

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -408,7 +408,7 @@ Synchronization primitives.
 | `(create-mailbox ctx)` | Create with explicit context |
 | `(post! mbx msg)` | Post from external context |
 | `(never)` | Spin that never completes |
-| `(spawn! spin)` / `(spawn! spin {:on-success f :on-error g})` | Fire-and-forget execution with optional terminal observers; observer failures do not alter the Spin result |
+| `(spawn! spin)` / `(spawn! spin {:on-success f :on-error g})` | Fire-and-forget execution with optional exactly-once terminal observers; observer failures do not alter the Spin result |
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -66,7 +66,7 @@ Convenience re-export namespace. All functions below are also available from the
 | `(mailbox)` | Create FIFO message queue |
 | `(post! mbx msg)` | Post message from external context |
 | `(never)` | Spin that never completes |
-| `(spawn! spin)` / `(spawn! spin :on-error f)` | Fire-and-forget spin |
+| `(spawn! spin)` / `(spawn! spin {:on-success f :on-error g})` | Fire-and-forget spin with optional terminal observers |
 
 ### Fork-Safe Atoms
 
@@ -408,7 +408,7 @@ Synchronization primitives.
 | `(create-mailbox ctx)` | Create with explicit context |
 | `(post! mbx msg)` | Post from external context |
 | `(never)` | Spin that never completes |
-| `(spawn! spin)` / `(spawn! spin :on-error f)` | Fire-and-forget execution |
+| `(spawn! spin)` / `(spawn! spin {:on-success f :on-error g})` | Fire-and-forget execution with optional terminal observers; observer failures do not alter the Spin result |
 
 ---
 

--- a/src/org/replikativ/spindel/core.cljc
+++ b/src/org/replikativ/spindel/core.cljc
@@ -232,8 +232,9 @@
 (def spawn!
   "Fire-and-forget execution of a spin. Returns nil. Resolved values are
   reported via the optional :on-success handler (defaults to ignoring them),
-  and errors via :on-error (defaults to logging). Callback failures are
-  reported without changing the Spin's terminal result."
+  and errors via :on-error (defaults to logging). Only the first resolution or
+  rejection is observed. Callback failures are reported without changing the
+  Spin's terminal result."
   sync/spawn!)
 
 ;; =============================================================================

--- a/src/org/replikativ/spindel/core.cljc
+++ b/src/org/replikativ/spindel/core.cljc
@@ -230,8 +230,10 @@
   sync/never)
 
 (def spawn!
-  "Fire-and-forget execution of a spin. Returns nil. Errors are reported via
-  the optional :on-error handler (defaults to logging)."
+  "Fire-and-forget execution of a spin. Returns nil. Resolved values are
+  reported via the optional :on-success handler (defaults to ignoring them),
+  and errors via :on-error (defaults to logging). Callback failures are
+  reported without changing the Spin's terminal result."
   sync/spawn!)
 
 ;; =============================================================================

--- a/src/org/replikativ/spindel/spin/sync.cljc
+++ b/src/org/replikativ/spindel/spin/sync.cljc
@@ -453,9 +453,10 @@
    cleared from the resolve/reject callbacks, after which a later GC
    of the Spin object can safely clean up the now-quiescent node.
 
-   Terminal callbacks are observers of an already-decided result. Callback
-   exceptions are reported to stderr and cannot alter the Spin result or
-   invoke the other terminal callback.
+   Terminal callbacks observe only the first resolution or rejection of this
+   spawn, even if a reactive Spin later reruns. Callback exceptions are
+   reported to stderr and cannot alter the Spin result or invoke the other
+   terminal callback.
 
    Returns nil."
   ([s] (spawn! s {}))
@@ -469,18 +470,22 @@
                 :cljs (try (ec/current-execution-context)
                            (catch :default _ nil)))
          sid (when ctx (spin-core/spin-id s))
+         settled? (atom false)
          release! (fn []
                     (when ctx
                       (binding [ec/*execution-context* ctx]
                         (ec/swap-state! [:engine/spawned]
-                                        (fn [m] (dissoc m sid))))))]
+                                        (fn [m] (dissoc m sid))))))
+         settle! (fn [callback f value]
+                   ;; A reactive Spin may resolve again after invalidation.
+                   ;; spawn! observes only the first terminal outcome of this
+                   ;; particular invocation.
+                   (when (compare-and-set! settled? false true)
+                     (release!)
+                     (invoke-spawn-callback! callback f value)))]
      (when ctx
        (binding [ec/*execution-context* ctx]
          (ec/swap-state! [:engine/spawned] (fn [m] (assoc m sid s)))))
-     (s (fn [value]
-          (release!)
-          (invoke-spawn-callback! :on-success on-success value))
-        (fn [e]
-          (release!)
-          (invoke-spawn-callback! :on-error on-error e))))
-   nil))
+     (s (fn [value] (settle! :on-success on-success value))
+        (fn [e] (settle! :on-error on-error e)))
+     nil)))

--- a/src/org/replikativ/spindel/spin/sync.cljc
+++ b/src/org/replikativ/spindel/spin/sync.cljc
@@ -412,14 +412,32 @@
 ;; Spawn
 ;; ============================================================================
 
+(defn- report-spawn-callback-error! [callback error]
+  ;; Terminal callbacks observe an already-decided Spin result. Their own
+  ;; failures must never re-enter the CPS body and reclassify that result.
+  (try
+    (binding [#?(:clj *out* :cljs *print-fn*)
+              #?(:clj *err* :cljs *print-err-fn*)]
+      (println "Error in spawn!" (name callback) "callback:" error))
+    (catch #?(:clj Throwable :cljs :default) _
+      nil)))
+
+(defn- invoke-spawn-callback! [callback f value]
+  (try
+    (f value)
+    (catch #?(:clj Throwable :cljs :default) error
+      (report-spawn-callback-error! callback error))))
+
 (defn spawn!
   "Start a spin as fire-and-forget. The spin runs asynchronously;
-   errors are passed to `on-error` (default: prints to stderr).
+   values are passed to `on-success` (default: ignored), and errors are
+   passed to `on-error` (default: prints to stderr).
 
    Works both inside and outside spins. Does not block.
 
    Usage:
      (spawn! (spin (do-work)))
+     (spawn! (spin (do-work)) {:on-success consume-result})
      (spawn! (spin (do-work)) {:on-error my-handler})
 
    GC contract: `spawn!` registers the Spin instance in the context's
@@ -435,10 +453,15 @@
    cleared from the resolve/reject callbacks, after which a later GC
    of the Spin object can safely clean up the now-quiescent node.
 
+   Terminal callbacks are observers of an already-decided result. Callback
+   exceptions are reported to stderr and cannot alter the Spin result or
+   invoke the other terminal callback.
+
    Returns nil."
   ([s] (spawn! s {}))
-  ([s {:keys [on-error]
-       :or {on-error (fn [e] (binding [#?(:clj *out* :cljs *print-fn*)
+  ([s {:keys [on-success on-error]
+       :or {on-success (fn [_])
+            on-error (fn [e] (binding [#?(:clj *out* :cljs *print-fn*)
                                        #?(:clj *err* :cljs *print-err-fn*)]
                                (println "Error in spawned spin:" e)))}}]
    (let [ctx #?(:clj (try (ec/current-execution-context)
@@ -454,6 +477,10 @@
      (when ctx
        (binding [ec/*execution-context* ctx]
          (ec/swap-state! [:engine/spawned] (fn [m] (assoc m sid s)))))
-     (s (fn [_] (release!))
-        (fn [e] (release!) (on-error e))))
+     (s (fn [value]
+          (release!)
+          (invoke-spawn-callback! :on-success on-success value))
+        (fn [e]
+          (release!)
+          (invoke-spawn-callback! :on-error on-error e))))
    nil))

--- a/test/org/replikativ/spindel/spin/gc_test.cljc
+++ b/test/org/replikativ/spindel/spin/gc_test.cljc
@@ -250,8 +250,9 @@
            (binding [ec/*execution-context* ctx]
              (let [d (sync/create-deferred ctx)
                    s (spin (await d))
-                   sid (spin-core/spin-id s)]
-               (sync/spawn! s)
+                   sid (spin-core/spin-id s)
+                   successes (atom [])]
+               (sync/spawn! s {:on-success #(swap! successes conj %)})
                ;; Body suspends on the deferred await. The spin's instance MUST
                ;; be held in the engine's spawned-registry — otherwise GC could
                ;; reap it mid-await.
@@ -260,10 +261,101 @@
                ;; Deliver the deferred → body resumes → resolves → release should fire.
                (d :delivered)
                (simple/await-drain-complete! ctx)
+               (is (= [:delivered] @successes)
+                   "spawn! must pass the resolved value to on-success exactly once")
                (is (nil? (get (rtp/get-state ctx [:engine/spawned]) sid))
                    "spawn! must release the Spin from [:engine/spawned spin-id] after body resolves")))
            (finally
              (ctx/stop-context! ctx)))))))
+
+#?(:clj
+   (deftest test-spawn-terminal-callbacks-release-on-reject-and-pre-start-cancel
+     (let [ctx (ctx/create-execution-context)]
+       (try
+         (binding [ec/*execution-context* ctx]
+           (testing "rejection calls on-error exactly once and releases the GC pin"
+             (let [failure (ex-info "spawn rejected" {:test true})
+                   successes (atom [])
+                   errors (atom [])
+                   s (spin (throw failure))
+                   sid (spin-core/spin-id s)]
+               (sync/spawn! s {:on-success #(swap! successes conj %)
+                               :on-error #(swap! errors conj %)})
+               (simple/await-drain-complete! ctx)
+               (is (empty? @successes))
+               (is (= [failure] @errors))
+               (is (nil? (get (rtp/get-state ctx [:engine/spawned]) sid)))))
+
+           (testing "cancellation before spawn rejects once without running the body"
+             (let [body-runs (atom 0)
+                   successes (atom [])
+                   errors (atom [])
+                   s (spin (do (swap! body-runs inc) :unexpected))
+                   sid (spin-core/spin-id s)]
+               (spin-core/cancel-spin! s)
+               (sync/spawn! s {:on-success #(swap! successes conj %)
+                               :on-error #(swap! errors conj %)})
+               (simple/await-drain-complete! ctx)
+               (is (zero? @body-runs))
+               (is (empty? @successes))
+               (is (= 1 (count @errors)))
+               (is (= spin-core/spin-cancelled
+                      (:type (ex-data (first @errors)))))
+               (is (nil? (get (rtp/get-state ctx [:engine/spawned]) sid)))))
+
+           (testing "in-flight cancellation rejects exactly once and releases the GC pin"
+             (let [d (sync/create-deferred ctx)
+                   successes (atom [])
+                   errors (atom [])
+                   s (spin (await d))
+                   sid (spin-core/spin-id s)]
+               (sync/spawn! s {:on-success #(swap! successes conj %)
+                               :on-error #(swap! errors conj %)})
+               (is (identical? s (get (rtp/get-state ctx [:engine/spawned]) sid)))
+               (spin-core/cancel-spin! s)
+               (simple/await-drain-complete! ctx)
+               (is (empty? @successes))
+               (is (= 1 (count @errors)))
+               (is (= spin-core/spin-cancelled
+                      (:type (ex-data (first @errors)))))
+               (is (nil? (get (rtp/get-state ctx [:engine/spawned]) sid)))))
+
+           (testing "throwing terminal observers cannot reclassify the Spin result"
+             (let [success-callbacks (atom [])
+                   error-callbacks (atom [])
+                   success-spin (spin :value)
+                   success-id (spin-core/spin-id success-spin)]
+               (sync/spawn!
+                success-spin
+                {:on-success (fn [value]
+                               (swap! success-callbacks conj value)
+                               (throw (ex-info "success observer failed" {})))
+                 :on-error #(swap! error-callbacks conj %)})
+               (simple/await-drain-complete! ctx)
+               (let [cached (ec/spin-current-result success-id)]
+                 (is (= [:value] @success-callbacks))
+                 (is (empty? @error-callbacks))
+                 (is (spin-core/ok? cached))
+                 (is (= :value (spin-core/unwrap cached)))
+                 (is (nil? (get (rtp/get-state ctx [:engine/spawned]) success-id)))))
+
+             (let [body-failure (ex-info "body failed" {:body true})
+                   error-callbacks (atom [])
+                   failure-spin (spin (throw body-failure))
+                   failure-id (spin-core/spin-id failure-spin)]
+               (sync/spawn!
+                failure-spin
+                {:on-error (fn [error]
+                             (swap! error-callbacks conj error)
+                             (throw (ex-info "error observer failed" {})))})
+               (simple/await-drain-complete! ctx)
+               (let [cached (ec/spin-current-result failure-id)]
+                 (is (= [body-failure] @error-callbacks))
+                 (is (spin-core/error? cached))
+                 (is (= body-failure (:payload cached)))
+                 (is (nil? (get (rtp/get-state ctx [:engine/spawned]) failure-id)))))))
+         (finally
+           (ctx/stop-context! ctx))))))
 
 #?(:clj
    (deftest test-spawn-survives-gc-mid-await-jvm

--- a/test/org/replikativ/spindel/spin/gc_test.cljc
+++ b/test/org/replikativ/spindel/spin/gc_test.cljc
@@ -19,7 +19,8 @@
             [org.replikativ.spindel.effects.await :refer [await]]
             [org.replikativ.spindel.effects.track :refer [track]]
             [org.replikativ.spindel.spin.sync :as sync]
-            [org.replikativ.spindel.test-helpers :refer [async with-ctx run-spin!]])
+            [org.replikativ.spindel.test-helpers :refer [async await-engine-idle!
+                                                         with-ctx run-spin!]])
   #?(:cljs (:require-macros [org.replikativ.spindel.spin.cps :refer [spin]]
                             [org.replikativ.spindel.signal :refer [signal]])))
 
@@ -267,6 +268,27 @@
                    "spawn! must release the Spin from [:engine/spawned spin-id] after body resolves")))
            (finally
              (ctx/stop-context! ctx)))))))
+
+(deftest test-spawn-terminal-callback-runs-once-for-reactive-spin
+  (testing "spawn! observes the first result, not later reactive reruns"
+    (async done
+           (with-ctx [ctx]
+             (let [source (signal 0)
+                   callbacks (atom [])
+                   s (spin (let [{:keys [new]} (track source)] new))]
+               (sync/spawn! s {:on-success #(swap! callbacks conj %)})
+               (await-engine-idle!
+                ctx
+                (fn []
+                  (is (= [0] @callbacks))
+                  (reset! source 1)
+                  (await-engine-idle!
+                   ctx
+                   (fn []
+                     (is (= [0] @callbacks)
+                         "reactive invalidation must not settle the same spawn twice")
+                     (keep-reachable! s)
+                     (done))))))))))
 
 #?(:clj
    (deftest test-spawn-terminal-callbacks-release-on-reject-and-pre-start-cancel


### PR DESCRIPTION
## Summary

- add an optional `:on-success` callback to public `spawn!`
- release the execution-context GC pin before invoking either terminal callback
- document the callback through both `spin.sync` and the public facade
- cover successful resolution, rejection, pre-start cancellation, exactly-once callbacks, and pin release

This lets downstream runtimes observe physical Spin termination through a public primitive instead of duplicating Spindel's private `[:engine/spawned]` rooting protocol.

## Verification

- `clojure -M:test -n org.replikativ.spindel.spin.gc-test` — 15 tests, 57 assertions, green
- `clojure -M:test -n org.replikativ.spindel.distributed.cross-system-sync-test` — 1 test, 10 assertions, green
- `clojure -M:format` — green
- CircleCI setup, format, JVM tests, ClojureScript tests, and build — green
- independent review — no remaining medium-or-higher findings
- downstream Dvergr lifecycle regressions against this source override — 5 tests, 25 assertions, green

The first full-suite pass encountered one timeout in the existing cross-system distributed sync test and then retained a stale PTY after visible work completed. The distributed namespace passed immediately in isolation; no changed code is on that path.
