### PR TITLE
fix(spin): resolve already-delivered falsey deferred values

### DIFF
--- a/src/org/replikativ/spindel/spin/sync.cljc
+++ b/src/org/replikativ/spindel/spin/sync.cljc
@@ -56,29 +56,27 @@
                          (or (and spin-id (ec/spin-is-cancelled? spin-id))
                              (and cancel-token cancelled-tokens
                                   (contains? cancelled-tokens cancel-token))))
-          value-to-resolve (atom nil)
-          _result-state (swap! state-atom
-                               (fn [state]
-                                 (if (:assigned? state)
-                                 ;; Already assigned - capture value for resolution, don't modify state
-                                   (do
-                                     (reset! value-to-resolve (:value state))
-                                     state)
-                                 ;; Not assigned - prune dead readers, then add ours
-                                   (update state :pending
-                                           (fn [ps]
-                                             (conj (if ctx
-                                                     (filterv (complement dead-reader?) (or ps []))
-                                                     (or ps []))
-                                                   {:spin-id current-spin-id
-                                                    :cancel-token current-cancel-token
-                                                    :resolve resolve}))))))]
-      (if-let [value @value-to-resolve]
+          result-state (swap! state-atom
+                              (fn [state]
+                                (if (:assigned? state)
+                                ;; Already assigned - return the immutable state
+                                ;; snapshot without registering another reader.
+                                  state
+                                ;; Not assigned - prune dead readers, then add ours
+                                  (update state :pending
+                                          (fn [ps]
+                                            (conj (if ctx
+                                                    (filterv (complement dead-reader?) (or ps []))
+                                                    (or ps []))
+                                                  {:spin-id current-spin-id
+                                                   :cancel-token current-cancel-token
+                                                   :resolve resolve}))))))]
+      (if (:assigned? result-state)
        ;; Was already assigned - resolve immediately
        ;; CRITICAL: Reset *in-trampoline* to ensure Thunks from recur are trampolined
        ;; When called synchronously inside a spin's trampoline, we need a fresh trampoline
         (binding [pcps-async/*in-trampoline* false]
-          (spin-core/resume resolve value))
+          (spin-core/resume resolve (:value result-state)))
        ;; Was not assigned - added to pending
         spin-core/incomplete))))
 

--- a/src/org/replikativ/spindel/spin/sync.cljc
+++ b/src/org/replikativ/spindel/spin/sync.cljc
@@ -15,19 +15,17 @@
 
   ;; 1-arity: Assign value via event queue (SAFE)
   ;; Returns true if this call won delivery rights, false if already claimed.
-  ;; Uses atomic swap! with local flag to guarantee exactly-once delivery semantics.
+  ;; The returned state identifies the winner even when swap! retries.
   ;; Safe to call from anywhere: inside spins, futures, threads, callbacks, REPL
   (#?(:clj invoke :cljs -invoke) [_this value]
-   ;; Atomically claim delivery rights using local atom to detect winner
-    (let [i-won? (atom false)
-          _ (swap! state-atom
-                   (fn [state]
-                     (if (:delivery-claimed? state)
-                       state  ;; Already claimed - no change
-                       (do
-                         (reset! i-won? true)
-                         (assoc state :delivery-claimed? true)))))]
-      (if @i-won?
+    (let [claim-id (random-uuid)
+          claimed-state (swap! state-atom
+                               (fn [state]
+                                 (if (:delivery-claimed? state)
+                                   state
+                                   (assoc state :delivery-claimed? true
+                                          :delivery-claim-id claim-id))))]
+      (if (= claim-id (:delivery-claim-id claimed-state))
        ;; We won - enqueue delivery event and return true
         (do
           (ec/enqueue-event! {:type :deferred-delivery

--- a/test/org/replikativ/spindel/spin/deferred_test.cljc
+++ b/test/org/replikativ/spindel/spin/deferred_test.cljc
@@ -124,6 +124,44 @@
              (is (= :shared-value @reader3) "Reader 3 should get value")))))))
 
 #?(:clj
+   (deftest test-deferred-concurrent-delivery-has-one-winner
+     (testing "Only the atomic delivery claimant reports success under contention"
+       (let [context (ec/current-execution-context)
+             worker-count 16
+             attempts 32
+             executor (java.util.concurrent.Executors/newFixedThreadPool worker-count)]
+         (try
+           (dotimes [attempt attempts]
+             (let [d (sync/deferred)
+                   ready (java.util.concurrent.CountDownLatch. worker-count)
+                   start (java.util.concurrent.CountDownLatch. 1)
+                   tasks
+                   (mapv
+                    (fn [value]
+                      (.submit
+                       executor
+                       ^java.util.concurrent.Callable
+                       (reify java.util.concurrent.Callable
+                         (call [_]
+                           (binding [ec/*execution-context* context]
+                             (.countDown ready)
+                             (.await start)
+                             (d value))))))
+                    (range worker-count))]
+               (is (.await ready 2 java.util.concurrent.TimeUnit/SECONDS)
+                   (str "all contenders reached the barrier on attempt " attempt))
+               (.countDown start)
+               (let [results
+                     (mapv #(.get ^java.util.concurrent.Future %
+                                  2 java.util.concurrent.TimeUnit/SECONDS)
+                           tasks)]
+                 (is (= 1 (count (filter true? results)))
+                     (str "exactly one delivery winner on attempt " attempt)))))
+           (finally
+             (.shutdownNow executor)
+             (.awaitTermination executor 2 java.util.concurrent.TimeUnit/SECONDS)))))))
+
+#?(:clj
    (deftest test-deferred-delivery-during-await
      (testing "Delivery while await is blocked"
        (binding [ec/*execution-context* (ctx/create-execution-context)]

--- a/test/org/replikativ/spindel/spin/deferred_test.cljc
+++ b/test/org/replikativ/spindel/spin/deferred_test.cljc
@@ -8,7 +8,8 @@
             [org.replikativ.spindel.spin.sync :as sync]
             [org.replikativ.spindel.spin.cps :refer [spin]]
             [org.replikativ.spindel.effects.await :refer [await]]
-            [org.replikativ.spindel.test-helpers :refer [async with-ctx run-spin!]])
+            [org.replikativ.spindel.test-helpers :refer [async await-engine-idle!
+                                                         with-ctx run-spin!]])
   #?(:cljs (:require-macros [org.replikativ.spindel.spin.cps :refer [spin]])))
 
 ;; CLJ-only fixture
@@ -75,6 +76,31 @@
                           (fn [err]
                             (is false (str "Spin failed: " err))
                             (done))))))))
+
+(deftest test-deferred-falsey-values-after-delivery
+  (testing "Already-delivered nil and false resolve instead of looking pending"
+    (async done
+           (with-ctx [ctx]
+             (letfn [(check-values! [values]
+                       (if-let [[value & remaining] (seq values)]
+                         (let [d (sync/deferred)]
+                           (is (true? (d value)))
+                           ;; Force delivery to become durable before the reader
+                           ;; registers. This covers the fast read path rather
+                           ;; than the ordinary pending-reader delivery path.
+                           (await-engine-idle!
+                            ctx
+                            (fn []
+                              (run-spin!
+                               (spin (await d))
+                               (fn [result]
+                                 (is (= value result))
+                                 (check-values! remaining))
+                               (fn [error]
+                                 (is false (str "Spin failed: " error))
+                                 (done))))))
+                         (done)))]
+               (check-values! [nil false]))))))
 
 ;; =============================================================================
 ;; CLJ-only tests: require Thread/sleep, future, promise


### PR DESCRIPTION
## Summary

- Resolve already-delivered `nil` and `false` values through `Deferred.invoke`.
- Preserve atomic check-or-register semantics using the state returned from `swap!`.
- Make delivery claims atomic under contention: retrying `swap!` callbacks must not retain a stale winner flag.
- Cover falsey reads on JVM/ClojureScript and concurrent delivery claims on JVM.

## Root causes

An auxiliary atom initialized to `nil` and an `if-let` made an already-delivered falsey value look unassigned, leaving the awaiting Spin incomplete. Dvergr exposed this under randomized seed `947831736` when trusted preparation completed with `nil` before its result reader registered.

Pre-merge review also reproduced multiple successful delivery claimants under contention. The old winner flag was mutated inside a retriable `swap!` callback. A unique claim token in the returned state now identifies the actual winner without callback side effects.

## Verification

- Formatting passes.
- Updated focused Deferred suite: 7 tests, 80 assertions, zero failures/errors, including 32 rounds of 16 concurrent claimants with bounded waits and executor cleanup.
- Before the contention follow-up: full JVM suite 1,017 tests / 4,056 assertions; ClojureScript suite 430 tests / 1,617 assertions.
- Original Dvergr reproducer with local Spindel override: 43 tests / 268 assertions, zero failures, seed `947831736`.
- Fresh CI is required on the contention fix before merge.
