### PR TITLE
refactor(world): extract reusable affine scopes

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -36,6 +36,29 @@ all particle `ForkHandle`s are consumed newest-generation first. Construction
 and resampling failures are also cleaned up automatically because no affected
 particle is running at those boundaries.
 
+## Reusable finite world scopes
+
+The lifecycle above is not specific to probabilities. The
+`org.replikativ.spindel.world.scope` namespace owns a finite family of
+canonical forks for any bounded algorithm such as MCTS or a simulation
+campaign. A scope provides fork construction, composable activity leases,
+atomic lease exchange, quiescence, cancellation hand-back, reverse-order
+discard, and portable descriptors. Once quiescence is published, admission is
+closed permanently.
+
+The algorithm remains responsible for its computations and ends each activity
+lease only after that computation has actually stopped. A live `ForkHandle`
+never leaves the scope; fork callers receive a child execution context and a
+portable descriptor, but no settlement authority. The scope never interprets
+a particle, tree node, Run, reward, or proposal. In particular, a search policy
+may share immutable statistics for a transposition, but it must not share a
+writable context or affine `ForkHandle`.
+
+SMC now uses this generic scope through compatibility functions in its
+coordinator. This is an extraction of the existing ownership protocol, not a
+second world abstraction: Yggdrasil still owns substrate forks and settlement,
+while the execution context still owns reactive runtime state.
+
 ## Failure and recovery
 
 Model failures are fail-fast. Spindel cooperatively cancels sibling particles,

--- a/src/org/replikativ/spindel/inference/coordinator.cljc
+++ b/src/org/replikativ/spindel/inference/coordinator.cljc
@@ -32,6 +32,7 @@
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.spin.sync :as sync]
             [org.replikativ.spindel.yggdrasil :as ygg]
+            [org.replikativ.spindel.world.scope :as world-scope]
             [org.replikativ.spindel.inference.measure :as m]
             [org.replikativ.spindel.inference.kernel :as k]
             [replikativ.logging :as log]
@@ -122,25 +123,16 @@
   inference execution. Handles remain host capabilities; only their portable
   descriptors may cross a durable boundary."
   [fork-opts]
-  (atom {:id (random-uuid)
-         :status :open
-         :fork-opts (or fork-opts {})
-         :handles []
-         :pending-forks 0
-         :active-contexts {}
-         :cancel-requested? false
-         :generation-phase nil
-         :cleanup-started? false
-         :quiescence (atom {:status :pending :readers []})
-         :cleanup (atom {:status :pending :readers []})}))
+  (doto (world-scope/create {:purpose :particle
+                             :fork-opts (or fork-opts {})})
+    (swap! assoc :generation-phase nil :generation-activity nil)))
 
 (declare maybe-complete-particle-quiescence!)
 
 (defn world-descriptors
   "Return the portable projections retained by a particle-world manager."
   [manager]
-  (let [{:keys [descriptors handles]} @manager]
-    (or descriptors (mapv ygg/fork-descriptor handles))))
+  (world-scope/descriptors manager))
 
 (defn- invoke-result!
   "Invoke a value-or-CPS result without assuming a JVM synchronous substrate."
@@ -154,257 +146,87 @@
 
 (defn fork-particle-world!
   "Fork `source-context` through the canonical Yggdrasil bridge and deliver its
-  ForkHandle. Particle forks are frozen at their source checkpoint: ordinary
-  execution state reads from the fork-time view and every registered external
-  system is independently forked through PForkable."
+  non-settleable world reference. Particle forks are frozen at their source
+  checkpoint: ordinary execution state reads from the fork-time view and every
+  registered external system is independently forked through PForkable."
   [manager source-context resolve reject]
-  (swap! manager update :pending-forks inc)
-  (let [{:keys [id fork-opts]} @manager
-        settled? (atom false)
-        finish! (fn [update-state f value]
-                  (when (compare-and-set! settled? false true)
-                    (swap! manager update-state)
-                    (try
-                      ;; Fork creation is an effect hosted by a child world,
-                      ;; but its continuation belongs to the source program.
-                      ;; Re-enter the caller explicitly so initialization does
-                      ;; not migrate the coordinating Spin into the new child.
-                      (binding [rtc/*execution-context* source-context]
-                        (f value))
-                      (finally
-                        (maybe-complete-particle-quiescence! manager)))))
-        opts (-> fork-opts
-                 (assoc :mode :frozen
-                        :purpose :particle
-                        :owner id
-                        :sync? false))]
-    (letfn [(succeed! [handle]
-              (finish! (fn [state]
-                         (-> state
-                             (update :handles conj handle)
-                             (update :pending-forks dec)))
-                       resolve handle))
-            (fail! [error]
-              (finish! #(update % :pending-forks dec) reject error))]
-      (binding [rtc/*execution-context* source-context
-                pcps-async/*in-trampoline* false]
-        (try
-          (invoke-result! (ygg/fork! opts) succeed! fail!)
-          (catch #?(:clj Throwable :cljs :default) error
-            (fail! error)))))))
+  (world-scope/fork! manager source-context resolve reject))
 
 (defn discard-particle-worlds!
-  "Discard all worlds owned by `manager`, newest generation first. Returns a
-  CPS operation and is idempotent after successful cleanup."
+  "Discard all worlds owned by manager, newest generation first."
   [manager]
-  (fn [resolve reject]
-    (let [cleanup (:cleanup @manager)
-          immediate (volatile! nil)]
-      ;; A read-only settlement preflight reopens its ForkHandle. Retrying gets
-      ;; a fresh subscriber generation; mutating/incomplete failures remain
-      ;; terminal in the manager and keep their memoized rejection.
-      (loop []
-        (let [state @cleanup]
-          (when (and (= :failed (:status state))
-                     (= :open (:status @manager))
-                     (not (compare-and-set!
-                           cleanup state {:status :pending :readers []})))
-            (recur))))
-      ;; Subscribe before trying to become the cleanup owner. Completion and
-      ;; subscription linearize on this atom, so concurrent callers neither
-      ;; hang nor execute settlement twice.
-      (swap! cleanup
-             (fn [state]
-               (if (= :pending (:status state))
-                 (update state :readers conj {:resolve resolve :reject reject})
-                 (do (vreset! immediate state) state))))
-      (when-let [{:keys [status value error]} @immediate]
-        (if (= :done status) (resolve value) (reject error)))
-      (letfn [(complete! [status payload]
-                (let [readers (volatile! [])]
-                  (swap! cleanup
-                         (fn [state]
-                           (if (= :pending (:status state))
-                             (do
-                               (vreset! readers (:readers state))
-                               (cond-> {:status status :readers []}
-                                 (= status :done) (assoc :value payload)
-                                 (= status :failed) (assoc :error payload)))
-                             state)))
-                  (doseq [{:keys [resolve reject]} @readers]
-                    ((if (= status :done) resolve reject) payload))))
-              (fail! [handle error]
-                (swap! manager assoc
-                       :status (if (ygg/open-fork? handle) :open :failed)
-                       :error error)
-                (complete! :failed error))
-              (step [handles]
-                (if-let [handle (first handles)]
-                  (if (ygg/open-fork? handle)
-                    (binding [rtc/*execution-context* (:parent-ctx handle)
-                              pcps-async/*in-trampoline* false]
-                      (invoke-result!
-                       (ygg/discard-fork! handle {:sync? false})
-                       (fn [_] (step (next handles)))
-                       (fn [error] (fail! handle error))))
-                    (step (next handles)))
-                  (do
-                    ;; Replace process-local affine capabilities with portable
-                    ;; audit projections. This releases every superseded
-                    ;; generation once the final measure no longer needs it.
-                    (swap! manager
-                           (fn [state]
-                             (-> state
-                                 (assoc :status :discarded
-                                        :descriptors
-                                        (mapv ygg/fork-descriptor
-                                              (:handles state))
-                                        :handles [])
-                                 (dissoc :coordinator))))
-                    (complete! :done nil))))
-              (claim! []
-                (let [state @manager]
-                  (case (:status state)
-                    :open
-                    (if (compare-and-set! manager state
-                                          (assoc state :status :discarding))
-                      (step (reverse (:handles state)))
-                      (recur))
-
-                    :discarded (complete! :done nil)
-                    :failed (complete! :failed (:error state))
-                    ;; Another caller owns :discarding; this caller is already
-                    ;; subscribed to the shared cleanup outcome.
-                    :discarding nil
-                    nil)))]
-        (when-not @immediate (claim!))))))
+  (world-scope/discard! manager))
 
 (defn await-particle-world-quiescence
   "Return a CPS operation resolved when no particle context is still running."
   [manager]
-  (fn [resolve _reject]
-    (let [quiescence (:quiescence @manager)
-          immediate? (volatile! false)]
-      (swap! quiescence
-             (fn [state]
-               (if (= :done (:status state))
-                 (do (vreset! immediate? true) state)
-                 (update state :readers conj resolve))))
-      (when @immediate? (resolve nil)))))
+  (world-scope/await-quiescence manager))
 
 (defn discard-particle-worlds-when-quiescent!
-  "Return a CPS operation that waits for terminal particle callbacks before
-  consuming world settlement authority."
+  "Wait for terminal particle callbacks before consuming world authority."
   [manager]
-  (fn [resolve reject]
-    ((await-particle-world-quiescence manager)
-     (fn [_]
-       (invoke-result! (discard-particle-worlds! manager) resolve reject))
-     reject)))
-
-(defn register-particle-contexts!
-  "Replace the live particle generation tracked by a world manager."
-  [manager contexts]
-  (swap! manager assoc
-         :active-contexts (into {} (map (juxt :fork-id identity)) contexts))
-  nil)
+  (world-scope/discard-when-quiescent! manager))
 
 (defn begin-particle-generation-transition!
-  "Keep quiescence closed while replacement worlds are constructed and their
-  superseded source generation unwinds."
+  "Keep quiescence closed during construction and source retirement."
   [manager]
-  (swap! manager assoc
-         :generation-transition? true
-         :generation-phase :forking)
-  nil)
+  (let [activity (world-scope/begin-activity! manager :particle-generation)]
+    (swap! manager assoc
+           :generation-activity activity
+           :generation-phase :forking)
+    nil))
 
-(defn- claim-particle-generation-retirement!
-  "Linearize source retirement against cancellation during child construction.
-  True means retirement owns the source checkpoints; false means cancellation
-  already owns them and the never-started children must not be admitted."
-  [manager]
+(defn- claim-particle-generation-retirement! [manager]
   (let [claimed? (volatile! false)]
     (swap! manager
            (fn [state]
              (if (and (= :forking (:generation-phase state))
                       (not (:cancel-requested? state)))
                (do (vreset! claimed? true)
-                   (assoc state :generation-phase :retiring))
+                   (assoc state
+                          :generation-phase :retiring
+                          :retiring-context-ids
+                          (->> (:activities state)
+                               (keep (fn [[activity-id activity]]
+                                       (when (= :particle-context
+                                                (:kind activity))
+                                         activity-id)))
+                               set)))
                state)))
     @claimed?))
 
 (defn complete-particle-generation-transition!
-  "Atomically admit `contexts` unless cancellation won the transition.
-
-  Returns false only when cancellation rejects a non-empty replacement. An
-  empty replacement closes a failed transition without erasing source contexts
-  that still owe terminal callbacks; callers route the failure separately."
+  "Admit replacement contexts unless cancellation won the transition."
   [manager contexts]
-  (let [contexts (vec contexts)
-        admitted? (volatile! false)]
-    (swap! manager
-           (fn [state]
-             (let [admit? (or (empty? contexts)
-                              (not (:cancel-requested? state)))]
-               (vreset! admitted? admit?)
-               (assoc state
-                      ;; Empty/cancelled replacements were never admitted.
-                      ;; Preserve any source contexts still unwinding so their
-                      ;; terminal callbacks remain the quiescence proof.
-                      :active-contexts
-                      (if (and (seq contexts) admit?)
-                        (into {} (map (juxt :fork-id identity)) contexts)
-                        (:active-contexts state))
-                      :generation-transition? false
-                      :generation-phase nil))))
-    (maybe-complete-particle-quiescence! manager)
-    @admitted?))
+  (if-let [activity (:generation-activity @manager)]
+    (let [exchange
+          (world-scope/exchange-activity!
+           manager activity
+           (mapv (fn [context]
+                   {:id (:fork-id context)
+                    :kind :particle-context
+                    :value context})
+                 contexts))]
+      (swap! manager dissoc
+             :generation-activity :generation-phase :retiring-context-ids)
+      (:admitted? exchange))
+    ;; Error unwinding closes a transition defensively after the rejecting
+    ;; completion may already have consumed its lease.
+    (if (empty? contexts)
+      true
+      (throw (ex-info "Particle generation transition is not active"
+                      {:type ::missing-generation-transition})))))
 
 (defn- maybe-clean-cancelled-worlds! [manager]
-  (loop []
-    (let [state @manager]
-      (when (and (:cancel-requested? state)
-                 (empty? (:active-contexts state))
-                 (not (:generation-transition? state))
-                 (zero? (:pending-forks state))
-                 (not (:cleanup-started? state)))
-        (if (compare-and-set! manager state (assoc state :cleanup-started? true))
-          (invoke-result!
-           (discard-particle-worlds! manager)
-           (constantly nil)
-           (fn [error]
-             (log/error :inference/particle-world-cleanup-failed
-                        {:error error})))
-          (recur))))))
+  (world-scope/maybe-complete-quiescence! manager))
 
 (defn- maybe-complete-particle-quiescence! [manager]
-  (let [{:keys [active-contexts generation-transition? pending-forks]} @manager]
-    (when (and (empty? active-contexts)
-               (not generation-transition?)
-               (zero? pending-forks))
-      (let [readers (volatile! [])
-            quiescence (:quiescence @manager)]
-        (swap! quiescence
-               (fn [state]
-                 (if (= :done (:status state))
-                   state
-                   (do (vreset! readers (:readers state))
-                       {:status :done :readers []}))))
-        (doseq [reader @readers] (reader nil))
-        (maybe-clean-cancelled-worlds! manager)))))
+  (world-scope/maybe-complete-quiescence! manager))
 
 (defn particle-context-terminal!
-  "Mark one particle context quiescent and trigger deferred failure cleanup."
+  "Mark one particle context quiescent and trigger deferred cleanup."
   [manager context]
-  (let [remaining (volatile! nil)]
-    (swap! manager
-           (fn [state]
-             (let [active (dissoc (:active-contexts state) (:fork-id context))]
-               (vreset! remaining active)
-               (assoc state :active-contexts active))))
-    (when (empty? @remaining)
-      (maybe-complete-particle-quiescence! manager))
-    nil))
+  (world-scope/end-activity! manager (:fork-id context)))
 
 (defn- cancellation-error []
   (ex-info "Inference particle cancelled"
@@ -543,24 +365,21 @@
   "Cooperatively cancel every live particle. Cleanup begins automatically once
   their resolve/reject callbacks prove quiescence."
   [manager]
-  (let [{:keys [active-contexts coordinator generation-phase]}
-        (swap! manager assoc :cancel-requested? true)
-        contexts (vals active-contexts)]
-    ;; During :retiring, retirement owns the source checkpoint rejection and
-    ;; will observe :cancel-requested? before admitting children. Cancelling the
-    ;; same continuations here would race/double-resume them. During :forking,
-    ;; cancellation owns the still-current sources; the transition gate keeps
-    ;; cleanup from consuming handles while child construction unwinds.
-    (when-not (= :retiring generation-phase)
-      (doseq [context contexts]
-        (when-let [task (rtp/get-state context [:inference :task])]
-          (try
-            (binding [rtc/*execution-context* context]
-              (spin-core/cancel-spin! task))
-            (catch #?(:clj Throwable :cljs :default) error
-              (log/error :inference/particle-cancel-failed
-                         {:fork-id (:fork-id context) :error error})))))
-      (cancel-kernel-checkpoints! coordinator))
+  (let [{:keys [client retiring-context-ids]}
+        (world-scope/request-cancel! manager)
+        contexts (world-scope/activity-values manager :particle-context)]
+    ;; Retirement owns only the captured source checkpoints. Replacement
+    ;; contexts admitted concurrently are not in that set and must be cancelled.
+    (doseq [context contexts
+            :when (not (contains? retiring-context-ids (:fork-id context)))]
+      (when-let [task (rtp/get-state context [:inference :task])]
+        (try
+          (binding [rtc/*execution-context* context]
+            (spin-core/cancel-spin! task))
+          (catch #?(:clj Throwable :cljs :default) error
+            (log/error :inference/particle-cancel-failed
+                       {:fork-id (:fork-id context) :error error})))))
+    (cancel-kernel-checkpoints! client)
     (maybe-clean-cancelled-worlds! manager)
     (discard-particle-worlds-when-quiescent! manager)))
 
@@ -1248,8 +1067,6 @@
 (defn- resume-resampled-contexts!
   [coordinator particles-state particles-ordered should-resample?
    is-pgibbs? is-pgas? ancestor-idx contexts-with-checkpoints]
-  (when-let [manager (:world-manager coordinator)]
-    (register-particle-contexts! manager (mapv :context contexts-with-checkpoints)))
   ;; Reset weights if we resampled.
   (when should-resample?
     (doseq [{:keys [context]} contexts-with-checkpoints]
@@ -1310,13 +1127,16 @@
 (defn- project-settled-particle-context
   "Create a parentless immutable posterior context. Returning the settled
   execution context itself would retain its complete resampling ancestry."
-  [context]
+  [context descriptors-by-id]
   (let [inference-state (rtp/get-state context [:inference])
+        creation-descriptor (some-> inference-state :world :descriptor)
+        settled-descriptor (get descriptors-by-id
+                                (:fork/id creation-descriptor)
+                                creation-descriptor)
         projected (cond-> (select-keys inference-state
                                        projected-inference-keys)
                     (:world inference-state)
-                    (assoc :world-descriptor
-                           (ygg/fork-descriptor (:world inference-state))))]
+                    (assoc :world-descriptor settled-descriptor))]
     (assoc context
            :backend (backend/create-immutable-backend
                      {:inference projected}
@@ -1477,11 +1297,16 @@
               (invoke-result!
                (discard-particle-worlds! manager)
                (fn [_]
-                 (deliver!
-                  (m/empirical
-                   (mapv vector
-                         (mapv project-settled-particle-context contexts)
-                         log-weights))))
+                 (let [descriptors-by-id
+                       (into {} (map (juxt :fork/id identity))
+                             (world-descriptors manager))]
+                   (deliver!
+                    (m/empirical
+                     (mapv vector
+                           (mapv #(project-settled-particle-context
+                                   % descriptors-by-id)
+                                 contexts)
+                           log-weights)))))
                (fn [error]
                  (deliver! (->InferenceFailure :particle-world-cleanup
                                                error))))

--- a/src/org/replikativ/spindel/inference/coordinator.cljc
+++ b/src/org/replikativ/spindel/inference/coordinator.cljc
@@ -177,23 +177,26 @@
     nil))
 
 (defn- claim-particle-generation-retirement! [manager]
-  (let [claimed? (volatile! false)]
-    (swap! manager
-           (fn [state]
-             (if (and (= :forking (:generation-phase state))
-                      (not (:cancel-requested? state)))
-               (do (vreset! claimed? true)
-                   (assoc state
-                          :generation-phase :retiring
-                          :retiring-context-ids
-                          (->> (:activities state)
-                               (keep (fn [[activity-id activity]]
-                                       (when (= :particle-context
-                                                (:kind activity))
-                                         activity-id)))
-                               set)))
-               state)))
-    @claimed?))
+  ;; A volatile written from inside swap! cannot prove that its invocation won:
+  ;; the function may have observed :forking on an abandoned CAS attempt. The
+  ;; old value returned by swap-vals! is from the committed transition itself.
+  (let [[before _after]
+        (swap-vals!
+         manager
+         (fn [state]
+           (if (and (= :forking (:generation-phase state))
+                    (not (:cancel-requested? state)))
+             (assoc state
+                    :generation-phase :retiring
+                    :retiring-context-ids
+                    (->> (:activities state)
+                         (keep (fn [[activity-id activity]]
+                                 (when (= :particle-context (:kind activity))
+                                   activity-id)))
+                         set))
+             state)))]
+    (and (= :forking (:generation-phase before))
+         (not (:cancel-requested? before)))))
 
 (defn complete-particle-generation-transition!
   "Admit replacement contexts unless cancellation won the transition."
@@ -257,15 +260,12 @@
 (defn- take-retirement!
   "Atomically claim a source context's expected retirement callback."
   [coordinator context]
-  (let [claimed (volatile! nil)
-        fork-id (:fork-id context)]
-    (swap! (:retiring-contexts coordinator)
-           (fn [retiring]
-             (if-let [entry (get retiring fork-id)]
-               (do (vreset! claimed entry)
-                   (dissoc retiring fork-id))
-               retiring)))
-    @claimed))
+  (let [fork-id (:fork-id context)
+        ;; This is a plain process-local atom, so swap-vals! gives us the entry
+        ;; from the CAS-winning prior state without a retry-sensitive capture.
+        [before _after]
+        (swap-vals! (:retiring-contexts coordinator) dissoc fork-id)]
+    (get before fork-id)))
 
 (defn- retirement-entry [coordinator context]
   (get @(:retiring-contexts coordinator) (:fork-id context)))
@@ -332,24 +332,31 @@
   status first prevents a concurrent cancellation from rejecting the same CPS
   slice twice. Terminal accounting still happens only through the particle's
   top-level reject callback."
-  [coordinator]
+  [coordinator retiring-context-ids]
   (when-let [particles (:particles coordinator)]
-    (let [claimed (volatile! [])
+    (let [retiring-context-ids (or retiring-context-ids #{})
+          eligible? (fn [state]
+                      (and (= :checkpoint (:status state))
+                           (not (contains? retiring-context-ids
+                                           (get-in state [:context :fork-id])))))
+          ;; As with retirement callback claims, derive ownership from the
+          ;; CAS-winning old state. A volatile populated inside swap! can retain
+          ;; entries from an abandoned retry and reject one checkpoint twice.
+          [before _after]
+          (swap-vals! particles
+                      (fn [states]
+                        (reduce-kv
+                         (fn [next-states particle-id state]
+                           (assoc next-states particle-id
+                                  (if (eligible? state)
+                                    (assoc state :status :cancelling)
+                                    state)))
+                         {}
+                         states)))
+          claimed (into [] (comp (map val) (filter eligible?)) before)
           error (ex-info "Inference particle cancelled"
                          {:type spin-core/spin-cancelled})]
-      (swap! particles
-             (fn [states]
-               (reduce-kv
-                (fn [next-states particle-id state]
-                  (if (= :checkpoint (:status state))
-                    (do
-                      (vswap! claimed conj state)
-                      (assoc next-states particle-id
-                             (assoc state :status :cancelling)))
-                    (assoc next-states particle-id state)))
-                {}
-                states)))
-      (doseq [{:keys [context checkpoint]} @claimed]
+      (doseq [{:keys [context checkpoint]} claimed]
         (try
           (resume-checkpoint-reject! context checkpoint error)
           (catch #?(:clj Throwable :cljs :default) unwind-error
@@ -379,7 +386,11 @@
           (catch #?(:clj Throwable :cljs :default) error
             (log/error :inference/particle-cancel-failed
                        {:fork-id (:fork-id context) :error error})))))
-    (cancel-kernel-checkpoints! client)
+    ;; The manager transition atomically publishes the source contexts owned by
+    ;; generation retirement before cancellation can win. Their checkpoints
+    ;; remain retirement's responsibility even during the short interval before
+    ;; retire-particle-generation! changes their particle statuses to :retiring.
+    (cancel-kernel-checkpoints! client retiring-context-ids)
     (maybe-clean-cancelled-worlds! manager)
     (discard-particle-worlds-when-quiescent! manager)))
 

--- a/src/org/replikativ/spindel/inference/inference.cljc
+++ b/src/org/replikativ/spindel/inference/inference.cljc
@@ -225,7 +225,7 @@
                       num-particles
                       (assoc opts :world-manager world-manager))
          _ (when world-manager
-             (swap! world-manager assoc :coordinator coordinator))
+             (swap! world-manager assoc :client coordinator))
 
           ;; PGIBBS: Check if we have a retained trace (for conditional SMC)
          pgibbs-retained-trace (:pgibbs-retained-trace opts)

--- a/src/org/replikativ/spindel/world/scope.cljc
+++ b/src/org/replikativ/spindel/world/scope.cljc
@@ -1,0 +1,338 @@
+(ns org.replikativ.spindel.world.scope
+  "Process-local affine ownership for a finite family of canonical worlds.
+
+   A WorldScope is algorithm-neutral. SMC particles, MCTS nodes, simulations,
+   and other bounded searches may fork worlds through it. The scope owns every
+   ForkHandle, tracks live contexts and in-flight fork construction, and
+   consumes settlement authority only after quiescence.
+
+   Live handles never cross a durable boundary. descriptors is the portable
+   audit projection retained after successful cleanup."
+  (:require [is.simm.partial-cps.async :as pcps-async]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.yggdrasil :as ygg]
+            [replikativ.logging :as log]))
+
+(declare maybe-complete-quiescence!)
+
+(defn create
+  "Create a finite world-ownership scope from optional purpose and fork-opts.
+   Lifecycle keys are scope-owned and override values in fork-opts."
+  [{:keys [purpose fork-opts]
+    :or {purpose :simulation fork-opts {}}}]
+  (atom {:id (random-uuid)
+         :status :open
+         :purpose purpose
+         :fork-opts fork-opts
+         :handles []
+         :pending-forks 0
+         :activities {}
+         :cancel-requested? false
+         :cleanup-started? false
+         :quiescent? false
+         :quiescence-readers []
+         :cleanup (atom {:status :pending :readers []})}))
+
+(defn descriptors [scope]
+  (let [{:keys [descriptors handles]} @scope]
+    (or descriptors (mapv ygg/fork-descriptor handles))))
+
+(defn- scope-error [scope type message]
+  (ex-info message
+           {:type type
+            :scope/id (:id @scope)
+            :scope/status (:status @scope)}))
+
+(defn- claim-fork! [scope]
+  (loop []
+    (let [state @scope]
+      (cond
+        (or (not= :open (:status state)) (:quiescent? state))
+        (scope-error scope ::scope-consumed
+                     "Cannot fork through a consumed world scope")
+
+        (:cancel-requested? state)
+        (scope-error scope ::scope-cancelled
+                     "Cannot fork through a cancelled world scope")
+
+        (compare-and-set! scope state (update state :pending-forks inc))
+        nil
+
+        :else (recur)))))
+
+(defn- invoke-once! [operation resolve reject]
+  (let [delivered? (atom false)
+        deliver! (fn [callback value]
+                   (when (compare-and-set! delivered? false true)
+                     (callback value)))]
+    (try
+      (if (fn? operation)
+        (operation #(deliver! resolve %) #(deliver! reject %))
+        (deliver! resolve operation))
+      (catch #?(:clj Throwable :cljs :default) error
+        ;; Exceptions before delivery reject the operation. Exceptions from a
+        ;; claimed continuation belong to its executor/error boundary.
+        (if @delivered? (throw error) (deliver! reject error))))))
+
+(defn fork!
+  "Fork source-context into a frozen canonical child owned by scope.
+
+   Resolves a non-settleable world reference containing :child-ctx and a
+   portable :descriptor. The affine ForkHandle remains private to scope."
+  [scope source-context resolve reject]
+  (if-let [claim-error (claim-fork! scope)]
+    (reject claim-error)
+    (let [{:keys [id purpose fork-opts]} @scope
+          settled? (atom false)
+          finish! (fn [update-state callback value]
+                    (when (compare-and-set! settled? false true)
+                      (swap! scope update-state)
+                      (try
+                        (binding [ec/*execution-context* source-context]
+                          (callback value))
+                        (finally (maybe-complete-quiescence! scope)))))
+          opts (-> fork-opts
+                   (assoc :mode :frozen :purpose purpose :owner id :sync? false))]
+      (letfn [(succeed! [handle]
+                (finish! (fn [state]
+                           (-> state
+                               (update :handles conj handle)
+                               (update :pending-forks dec)))
+                         resolve {:child-ctx (:child-ctx handle)
+                                  :descriptor (ygg/fork-descriptor handle)}))
+              (fail! [error]
+                (finish! #(update % :pending-forks dec) reject error))]
+        (binding [ec/*execution-context* source-context
+                  pcps-async/*in-trampoline* false]
+          (try
+            (let [operation (ygg/fork! opts)]
+              (if (fn? operation)
+                (operation succeed! fail!)
+                (succeed! operation)))
+            (catch #?(:clj Throwable :cljs :default) error
+              ;; A successful callback owns its continuation exception. Do not
+              ;; reinterpret it as a second rejection and silently swallow it.
+              (if @settled? (throw error) (fail! error)))))))))
+
+(defn discard!
+  "Discard all owned worlds newest first. Returns a shared CPS operation."
+  [scope]
+  (fn [resolve reject]
+    (let [cleanup (:cleanup @scope)
+          immediate (volatile! nil)]
+      (loop []
+        (let [state @cleanup]
+          (when (and (= :failed (:status state))
+                     (= :open (:status @scope))
+                     (not (compare-and-set!
+                           cleanup state {:status :pending :readers []})))
+            (recur))))
+      (swap! cleanup
+             (fn [state]
+               (if (= :pending (:status state))
+                 (update state :readers conj {:resolve resolve :reject reject})
+                 (do (vreset! immediate state) state))))
+      (when-let [{:keys [status value error]} @immediate]
+        (if (= :done status) (resolve value) (reject error)))
+      (letfn [(complete! [status payload]
+                (let [readers (volatile! [])]
+                  (swap! cleanup
+                         (fn [state]
+                           (if (= :pending (:status state))
+                             (do
+                               (vreset! readers (:readers state))
+                               (cond-> {:status status :readers []}
+                                 (= status :done) (assoc :value payload)
+                                 (= status :failed) (assoc :error payload)))
+                             state)))
+                  (let [callback-error (volatile! nil)]
+                    (doseq [{:keys [resolve reject]} @readers]
+                      (try
+                        ((if (= status :done) resolve reject) payload)
+                        (catch #?(:clj Throwable :cljs :default) error
+                          (when-not @callback-error
+                            (vreset! callback-error error)))))
+                    (when-let [error @callback-error]
+                      (throw error)))))
+              (fail! [handle error]
+                (swap! scope assoc
+                       :status (if (ygg/open-fork? handle) :open :failed)
+                       :error error)
+                (complete! :failed error))
+              (step [handles]
+                (if-let [handle (first handles)]
+                  (if (ygg/open-fork? handle)
+                    (binding [ec/*execution-context* (:parent-ctx handle)
+                              pcps-async/*in-trampoline* false]
+                      (invoke-once!
+                       (ygg/discard-fork! handle {:sync? false})
+                       (fn [_] (step (next handles)))
+                       (fn [error] (fail! handle error))))
+                    (step (next handles)))
+                  (do
+                    (swap! scope
+                           (fn [state]
+                             (-> state
+                                 (assoc :status :discarded
+                                        :descriptors
+                                        (mapv ygg/fork-descriptor
+                                              (:handles state))
+                                        :handles [])
+                                 (dissoc :client))))
+                    (complete! :done nil))))
+              (claim! []
+                (let [state @scope]
+                  (case (:status state)
+                    :open
+                    (if (or (pos? (:pending-forks state))
+                            (seq (:activities state)))
+                      (complete!
+                       :failed
+                       (scope-error scope ::scope-busy
+                                    "Cannot discard a world scope while forks are in flight"))
+                      (if (compare-and-set! scope state
+                                            (assoc state :status :discarding))
+                        (step (reverse (:handles state)))
+                        (recur)))
+                    :discarded (complete! :done nil)
+                    :failed (complete! :failed (:error state))
+                    :discarding nil
+                    nil)))]
+        (when-not @immediate (claim!))))))
+
+(defn await-quiescence [scope]
+  (fn [resolve _reject]
+    (let [immediate? (volatile! false)]
+      (swap! scope
+             (fn [state]
+               (if (or (:quiescent? state)
+                       (and (empty? (:activities state))
+                            (zero? (:pending-forks state))))
+                 (do (vreset! immediate? true)
+                     (assoc state :quiescent? true))
+                 (update state :quiescence-readers conj resolve))))
+      (when @immediate? (resolve nil)))))
+
+(defn discard-when-quiescent! [scope]
+  (fn [resolve reject]
+    ((await-quiescence scope)
+     (fn [_] (invoke-once! (discard! scope) resolve reject))
+     reject)))
+
+(defn begin-activity!
+  "Acquire a process-local activity lease. New work is rejected after
+   cancellation or once quiescence has been published."
+  ([scope kind] (begin-activity! scope kind nil))
+  ([scope kind value]
+   (let [activity-id (random-uuid)
+         error* (volatile! nil)]
+     (swap! scope
+            (fn [state]
+              (cond
+                (not= :open (:status state))
+                (do (vreset! error* (scope-error scope ::scope-consumed
+                                                 "Cannot enter a consumed world scope"))
+                    state)
+
+                (or (:cancel-requested? state) (:quiescent? state))
+                (do (vreset! error* (scope-error scope ::scope-cancelled
+                                                 "Cannot enter a closed world scope"))
+                    state)
+
+                :else
+                (assoc-in state [:activities activity-id]
+                          {:kind kind :value value}))))
+     (if-let [error @error*] (throw error) activity-id))))
+
+(defn activity-values
+  "Return process-local activity values of kind."
+  [scope kind]
+  (->> (:activities @scope)
+       vals
+       (keep #(when (= kind (:kind %)) (:value %)))
+       vec))
+
+(defn exchange-activity!
+  "Atomically retire activity-id and admit replacement activity specs.
+
+   Each spec is {:id optional-id :kind keyword :value process-local-value}.
+   Returns {:admitted? boolean :activity-ids [...]} so generated IDs remain
+   releasable. Cancellation rejects non-empty replacements."
+  [scope activity-id activity-specs]
+  (let [specs (mapv #(update % :id (fn [id] (or id (random-uuid))))
+                    activity-specs)
+        ids (mapv :id specs)
+        result* (volatile! nil)
+        error* (volatile! nil)]
+    (swap! scope
+           (fn [state]
+             (let [remaining (dissoc (:activities state) activity-id)
+                   duplicate-ids? (not= (count ids) (count (set ids)))
+                   collisions (seq (filter #(contains? remaining %) ids))]
+               (cond
+                 (not (contains? (:activities state) activity-id))
+                 (do (vreset! error* (scope-error scope ::unknown-activity
+                                                  "World-scope activity is not live"))
+                     state)
+
+                 (or duplicate-ids? collisions)
+                 (do (vreset! error* (scope-error scope ::activity-id-collision
+                                                  "Replacement activity IDs must be unique"))
+                     state)
+
+                 :else
+                 (let [admit? (or (empty? specs)
+                                  (not (:cancel-requested? state)))
+                       replacements
+                       (if admit?
+                         (into {}
+                               (map (fn [{:keys [id kind value]}]
+                                      [id {:kind kind :value value}]))
+                               specs)
+                         {})]
+                   (vreset! result* {:admitted? admit?
+                                     :activity-ids (if admit? ids [])})
+                   (assoc state :activities (merge remaining replacements)))))))
+    (when-let [error @error*] (throw error))
+    (maybe-complete-quiescence! scope)
+    @result*))
+
+(defn end-activity! [scope activity-id]
+  (swap! scope update :activities dissoc activity-id)
+  (maybe-complete-quiescence! scope)
+  nil)
+
+(defn- maybe-clean-cancelled! [scope]
+  (loop []
+    (let [state @scope]
+      (when (and (:cancel-requested? state)
+                 (empty? (:activities state))
+                 (zero? (:pending-forks state))
+                 (not (:cleanup-started? state)))
+        (if (compare-and-set! scope state (assoc state :cleanup-started? true))
+          (invoke-once!
+           (discard! scope)
+           (constantly nil)
+           (fn [error]
+             (log/error :world-scope/cleanup-failed
+                        {:scope/id (:id state) :error error})))
+          (recur))))))
+
+(defn maybe-complete-quiescence! [scope]
+  (let [readers (volatile! [])]
+    (swap! scope
+           (fn [state]
+             (if (and (empty? (:activities state))
+                      (zero? (:pending-forks state)))
+               (do (vreset! readers (:quiescence-readers state))
+                   (assoc state :quiescent? true :quiescence-readers []))
+               state)))
+    (doseq [reader @readers] (reader nil))
+    (maybe-clean-cancelled! scope)))
+
+(defn request-cancel!
+  "Request cleanup after client-owned computation cancellation and quiescence."
+  [scope]
+  (let [state (swap! scope assoc :cancel-requested? true)]
+    (maybe-clean-cancelled! scope)
+    state))

--- a/src/org/replikativ/spindel/world/scope.cljc
+++ b/src/org/replikativ/spindel/world/scope.cljc
@@ -15,6 +15,16 @@
 
 (declare maybe-complete-quiescence!)
 
+(defn- transition!
+  "Commit a pure [next-state result] transition; expose only its winning result."
+  [state-atom f]
+  (loop []
+    (let [before @state-atom
+          [after result] (f before)]
+      (if (compare-and-set! state-atom before after)
+        result
+        (recur)))))
+
 (defn create
   "Create a finite world-ownership scope from optional purpose and fork-opts.
    Lifecycle keys are scope-owned and override values in fork-opts."
@@ -30,8 +40,7 @@
          :cancel-requested? false
          :cleanup-started? false
          :quiescent? false
-         :quiescence-readers []
-         :cleanup (atom {:status :pending :readers []})}))
+         :quiescence-readers []}))
 
 (defn descriptors [scope]
   (let [{:keys [descriptors handles]} @scope]
@@ -118,100 +127,111 @@
   "Discard all owned worlds newest first. Returns a shared CPS operation."
   [scope]
   (fn [resolve reject]
-    (let [cleanup (:cleanup @scope)
-          immediate (volatile! nil)]
-      (loop []
-        (let [state @cleanup]
-          (when (and (= :failed (:status state))
-                     (= :open (:status @scope))
-                     (not (compare-and-set!
-                           cleanup state {:status :pending :readers []})))
-            (recur))))
-      (swap! cleanup
-             (fn [state]
-               (if (= :pending (:status state))
-                 (update state :readers conj {:resolve resolve :reject reject})
-                 (do (vreset! immediate state) state))))
-      (when-let [{:keys [status value error]} @immediate]
+    (let [reader {:resolve resolve :reject reject}
+          {:keys [handles immediate]}
+          (transition!
+           scope
+           (fn [state]
+             (case (:status state)
+               :open
+               (if (or (pos? (:pending-forks state))
+                       (seq (:activities state)))
+                 [state
+                  {:immediate
+                   {:status :failed
+                    :error
+                    (ex-info
+                     "Cannot discard a world scope while forks are in flight"
+                     {:type ::scope-busy
+                      :scope/id (:id state)
+                      :scope/status (:status state)})}}]
+                 [(assoc state
+                         :status :discarding
+                         :discard-readers [reader])
+                  {:handles (reverse (:handles state))}])
+
+               :discarding
+               [(update state :discard-readers (fnil conj []) reader) {}]
+
+               :discarded
+               [state {:immediate {:status :done :value nil}}]
+
+               :failed
+               [state {:immediate {:status :failed :error (:error state)}}]
+
+               [state {:immediate
+                       {:status :failed
+                        :error
+                        (ex-info
+                         "Cannot discard a consumed world scope"
+                         {:type ::scope-consumed
+                          :scope/id (:id state)
+                          :scope/status (:status state)})}}])))
+          notify!
+          (fn [readers status payload]
+            (let [callback-error (volatile! nil)]
+              (doseq [{:keys [resolve reject]} readers]
+                (try
+                  ((if (= status :done) resolve reject) payload)
+                  (catch #?(:clj Throwable :cljs :default) error
+                    (when-not @callback-error
+                      (vreset! callback-error error)))))
+              (when-let [error @callback-error]
+                (throw error))))
+          complete!
+          (fn [status payload update-state]
+            (let [readers
+                  (transition!
+                   scope
+                   (fn [state]
+                     (if (= :discarding (:status state))
+                       [(-> (update-state state)
+                            (dissoc :discard-readers))
+                        (:discard-readers state)]
+                       [state []])))]
+              (notify! readers status payload)))]
+      (when-let [{:keys [status value error]} immediate]
         (if (= :done status) (resolve value) (reject error)))
-      (letfn [(complete! [status payload]
-                (let [readers (volatile! [])]
-                  (swap! cleanup
-                         (fn [state]
-                           (if (= :pending (:status state))
-                             (do
-                               (vreset! readers (:readers state))
-                               (cond-> {:status status :readers []}
-                                 (= status :done) (assoc :value payload)
-                                 (= status :failed) (assoc :error payload)))
-                             state)))
-                  (let [callback-error (volatile! nil)]
-                    (doseq [{:keys [resolve reject]} @readers]
-                      (try
-                        ((if (= status :done) resolve reject) payload)
-                        (catch #?(:clj Throwable :cljs :default) error
-                          (when-not @callback-error
-                            (vreset! callback-error error)))))
-                    (when-let [error @callback-error]
-                      (throw error)))))
-              (fail! [handle error]
-                (swap! scope assoc
-                       :status (if (ygg/open-fork? handle) :open :failed)
-                       :error error)
-                (complete! :failed error))
-              (step [handles]
-                (if-let [handle (first handles)]
-                  (if (ygg/open-fork? handle)
-                    (binding [ec/*execution-context* (:parent-ctx handle)
-                              pcps-async/*in-trampoline* false]
-                      (invoke-once!
-                       (ygg/discard-fork! handle {:sync? false})
-                       (fn [_] (step (next handles)))
-                       (fn [error] (fail! handle error))))
-                    (step (next handles)))
-                  (do
-                    (swap! scope
-                           (fn [state]
-                             (-> state
-                                 (assoc :status :discarded
-                                        :descriptors
-                                        (mapv ygg/fork-descriptor
-                                              (:handles state))
-                                        :handles [])
-                                 (dissoc :client))))
-                    (complete! :done nil))))
-              (claim! []
-                (let [state @scope]
-                  (case (:status state)
-                    :open
-                    (if (or (pos? (:pending-forks state))
-                            (seq (:activities state)))
+      (when handles
+        (letfn [(fail! [handle error]
+                  (complete!
+                   :failed error
+                   #(assoc %
+                           :status (if (ygg/open-fork? handle) :open :failed)
+                           :error error)))
+                (step [remaining]
+                  (if-let [handle (first remaining)]
+                    (if (ygg/open-fork? handle)
+                      (binding [ec/*execution-context* (:parent-ctx handle)
+                                pcps-async/*in-trampoline* false]
+                        (invoke-once!
+                         (ygg/discard-fork! handle {:sync? false})
+                         (fn [_] (step (next remaining)))
+                         (fn [error] (fail! handle error))))
+                      (step (next remaining)))
+                    (let [descriptors
+                          (mapv ygg/fork-descriptor (:handles @scope))]
                       (complete!
-                       :failed
-                       (scope-error scope ::scope-busy
-                                    "Cannot discard a world scope while forks are in flight"))
-                      (if (compare-and-set! scope state
-                                            (assoc state :status :discarding))
-                        (step (reverse (:handles state)))
-                        (recur)))
-                    :discarded (complete! :done nil)
-                    :failed (complete! :failed (:error state))
-                    :discarding nil
-                    nil)))]
-        (when-not @immediate (claim!))))))
+                       :done nil
+                       #(-> %
+                            (assoc :status :discarded
+                                   :descriptors descriptors
+                                   :handles [])
+                            (dissoc :client :error))))))]
+          (step handles))))))
 
 (defn await-quiescence [scope]
   (fn [resolve _reject]
-    (let [immediate? (volatile! false)]
-      (swap! scope
-             (fn [state]
-               (if (or (:quiescent? state)
-                       (and (empty? (:activities state))
-                            (zero? (:pending-forks state))))
-                 (do (vreset! immediate? true)
-                     (assoc state :quiescent? true))
-                 (update state :quiescence-readers conj resolve))))
-      (when @immediate? (resolve nil)))))
+    (let [immediate?
+          (transition! scope
+                       (fn [state]
+                         (if (or (:quiescent? state)
+                                 (and (empty? (:activities state))
+                                      (zero? (:pending-forks state))))
+                           [(assoc state :quiescent? true) true]
+                           [(update state :quiescence-readers conj resolve)
+                            false])))]
+      (when immediate? (resolve nil)))))
 
 (defn discard-when-quiescent! [scope]
   (fn [resolve reject]
@@ -225,24 +245,21 @@
   ([scope kind] (begin-activity! scope kind nil))
   ([scope kind value]
    (let [activity-id (random-uuid)
-         error* (volatile! nil)]
-     (swap! scope
-            (fn [state]
-              (cond
-                (not= :open (:status state))
-                (do (vreset! error* (scope-error scope ::scope-consumed
-                                                 "Cannot enter a consumed world scope"))
-                    state)
+         error (transition! scope
+                            (fn [state]
+                              (cond
+                                (not= :open (:status state))
+                                [state (scope-error scope ::scope-consumed
+                                                    "Cannot enter a consumed world scope")]
 
-                (or (:cancel-requested? state) (:quiescent? state))
-                (do (vreset! error* (scope-error scope ::scope-cancelled
-                                                 "Cannot enter a closed world scope"))
-                    state)
+                                (or (:cancel-requested? state) (:quiescent? state))
+                                [state (scope-error scope ::scope-cancelled
+                                                    "Cannot enter a closed world scope")]
 
-                :else
-                (assoc-in state [:activities activity-id]
-                          {:kind kind :value value}))))
-     (if-let [error @error*] (throw error) activity-id))))
+                                :else
+                                [(assoc-in state [:activities activity-id]
+                                           {:kind kind :value value}) nil])))]
+     (if error (throw error) activity-id))))
 
 (defn activity-values
   "Return process-local activity values of kind."
@@ -262,40 +279,36 @@
   (let [specs (mapv #(update % :id (fn [id] (or id (random-uuid))))
                     activity-specs)
         ids (mapv :id specs)
-        result* (volatile! nil)
-        error* (volatile! nil)]
-    (swap! scope
-           (fn [state]
-             (let [remaining (dissoc (:activities state) activity-id)
-                   duplicate-ids? (not= (count ids) (count (set ids)))
-                   collisions (seq (filter #(contains? remaining %) ids))]
-               (cond
-                 (not (contains? (:activities state) activity-id))
-                 (do (vreset! error* (scope-error scope ::unknown-activity
-                                                  "World-scope activity is not live"))
-                     state)
+        result (transition! scope
+                            (fn [state]
+                              (let [remaining (dissoc (:activities state) activity-id)
+                                    duplicate-ids? (not= (count ids) (count (set ids)))
+                                    collisions (seq (filter #(contains? remaining %) ids))]
+                                (cond
+                                  (not (contains? (:activities state) activity-id))
+                                  [state {:error (scope-error scope ::unknown-activity
+                                                              "World-scope activity is not live")}]
 
-                 (or duplicate-ids? collisions)
-                 (do (vreset! error* (scope-error scope ::activity-id-collision
-                                                  "Replacement activity IDs must be unique"))
-                     state)
+                                  (or duplicate-ids? collisions)
+                                  [state {:error (scope-error scope ::activity-id-collision
+                                                              "Replacement activity IDs must be unique")}]
 
-                 :else
-                 (let [admit? (or (empty? specs)
-                                  (not (:cancel-requested? state)))
-                       replacements
-                       (if admit?
-                         (into {}
-                               (map (fn [{:keys [id kind value]}]
-                                      [id {:kind kind :value value}]))
-                               specs)
-                         {})]
-                   (vreset! result* {:admitted? admit?
-                                     :activity-ids (if admit? ids [])})
-                   (assoc state :activities (merge remaining replacements)))))))
-    (when-let [error @error*] (throw error))
+                                  :else
+                                  (let [admit? (or (empty? specs)
+                                                   (not (:cancel-requested? state)))
+                                        replacements
+                                        (if admit?
+                                          (into {}
+                                                (map (fn [{:keys [id kind value]}]
+                                                       [id {:kind kind :value value}]))
+                                                specs)
+                                          {})]
+                                    [(assoc state :activities (merge remaining replacements))
+                                     {:admitted? admit?
+                                      :activity-ids (if admit? ids [])}])))))]
+    (when-let [error (:error result)] (throw error))
     (maybe-complete-quiescence! scope)
-    @result*))
+    result))
 
 (defn end-activity! [scope activity-id]
   (swap! scope update :activities dissoc activity-id)
@@ -319,16 +332,25 @@
           (recur))))))
 
 (defn maybe-complete-quiescence! [scope]
-  (let [readers (volatile! [])]
-    (swap! scope
-           (fn [state]
-             (if (and (empty? (:activities state))
-                      (zero? (:pending-forks state)))
-               (do (vreset! readers (:quiescence-readers state))
-                   (assoc state :quiescent? true :quiescence-readers []))
-               state)))
-    (doseq [reader @readers] (reader nil))
-    (maybe-clean-cancelled! scope)))
+  (let [readers (transition! scope
+                             (fn [state]
+                               (if (and (empty? (:activities state))
+                                        (zero? (:pending-forks state)))
+                                 [(assoc state :quiescent? true :quiescence-readers [])
+                                  (:quiescence-readers state)]
+                                 [state []])))]
+    (try
+      (let [callback-error (volatile! nil)]
+        (doseq [reader readers]
+          (try
+            (reader nil)
+            (catch #?(:clj Throwable :cljs :default) error
+              (when-not @callback-error
+                (vreset! callback-error error)))))
+        (when-let [error @callback-error]
+          (throw error)))
+      (finally
+        (maybe-clean-cancelled! scope)))))
 
 (defn request-cancel!
   "Request cleanup after client-owned computation cancellation and quiescence."

--- a/test/org/replikativ/spindel/inference/world_particles_test.clj
+++ b/test/org/replikativ/spindel/inference/world_particles_test.clj
@@ -35,6 +35,104 @@
                #(deliver result [:error %]))
     (deref result 5000 ::timed-out)))
 
+(defn- coordinator-private [symbol]
+  (ns-resolve 'org.replikativ.spindel.inference.coordinator symbol))
+
+(deftest generation-retirement-claim-uses-the-committed-state
+  (let [manager (coordinator/create-world-manager {})
+        claim! (coordinator-private 'claim-particle-generation-retirement!)
+        real-swap-vals! swap-vals!]
+    (coordinator/begin-particle-generation-transition! manager)
+    (let [claimed?
+          (with-redefs
+           [clojure.core/swap-vals!
+            (fn [target f & args]
+              (when (identical? target manager)
+                ;; Evaluate and abandon this contender's transition, then let
+                ;; a competing retirement claim commit before its retry.
+                (apply f @target args)
+                (swap! target assoc
+                       :generation-phase :retiring
+                       :retiring-context-ids #{:competitor}))
+              (apply real-swap-vals! target f args))]
+            (claim! manager))]
+      (is (false? claimed?)
+          "observing :forking before a lost transition does not grant ownership")
+      (is (= #{:competitor} (:retiring-context-ids @manager))))
+    (coordinator/complete-particle-generation-transition! manager [])))
+
+(deftest retirement-callback-claim-uses-the-committed-prior-state
+  (let [retiring (atom {:source {:finish! identity}})
+        client {:retiring-contexts retiring}
+        context {:fork-id :source}
+        take! (coordinator-private 'take-retirement!)
+        real-swap-vals! swap-vals!
+        claimed
+        (with-redefs
+         [clojure.core/swap-vals!
+          (fn [target f & args]
+            (when (identical? target retiring)
+              ;; Evaluate and abandon this take, then let another terminal
+              ;; callback remove the entry before the retry commits.
+              (apply f @target args)
+              (swap! target dissoc :source))
+            (apply real-swap-vals! target f args))]
+          (take! client context))]
+    (is (nil? claimed)
+        "only the callback that removed the entry owns its finish function")))
+
+(deftest checkpoint-cancellation-claim-uses-the-committed-prior-state
+  (let [rejected (atom 0)
+        particles (atom {:particle
+                         {:context
+                          {:fork-id :particle
+                           :executor (executor/synchronous-executor)}
+                          :checkpoint
+                          {:reject (fn [_error] (swap! rejected inc))}
+                          :status :checkpoint}})
+        client {:particles particles}
+        cancel! (coordinator-private 'cancel-kernel-checkpoints!)
+        real-swap-vals! swap-vals!]
+    (with-redefs
+     [clojure.core/swap-vals!
+      (fn [target f & args]
+        (when (identical? target particles)
+          ;; Evaluate and abandon this checkpoint claim, then let a competing
+          ;; cancellation take ownership before the retry commits.
+          (apply f @target args)
+          (swap! target assoc-in [:particle :status] :cancelling))
+        (apply real-swap-vals! target f args))]
+      (cancel! client #{}))
+    (is (zero? @rejected)
+        "a checkpoint seen only by an abandoned attempt is not rejected twice")
+    (is (= :cancelling (get-in @particles [:particle :status])))))
+
+(deftest cancellation-does-not-claim-a-retiring-generation-checkpoint
+  (let [source-id :retiring-source
+        rejected (atom 0)
+        source-context {:fork-id source-id
+                        :executor (executor/synchronous-executor)}
+        particles (atom {:source {:context source-context
+                                  :checkpoint
+                                  {:reject (fn [_error] (swap! rejected inc))}
+                                  :status :checkpoint}})
+        client {:particles particles}
+        manager (coordinator/create-world-manager {})]
+    ;; This is the intentional hand-off interval: the manager has published
+    ;; retirement ownership, while the coordinator has not yet changed the
+    ;; source particle's status from :checkpoint to :retiring.
+    (swap! manager assoc
+           :client client
+           :generation-phase :retiring
+           :retiring-context-ids #{source-id}
+           :activities {source-id {:kind :particle-context
+                                   :value source-context}})
+    (coordinator/cancel-particle-worlds! manager)
+    (is (zero? @rejected)
+        "manager cancellation must not reject retirement-owned CPS slices")
+    (is (= :checkpoint (get-in @particles [:source :status])))
+    (is (:cancel-requested? @manager))))
+
 (deftest smc-resamples-independent-worlds-and-discards-the-tree
   (let [root (context/create-execution-context)
         manager* (atom nil)

--- a/test/org/replikativ/spindel/inference/world_particles_test.clj
+++ b/test/org/replikativ/spindel/inference/world_particles_test.clj
@@ -16,6 +16,7 @@
             [org.replikativ.spindel.inference.measure :as measure]
             [org.replikativ.spindel.spin.core :as spin-core]
             [org.replikativ.spindel.spin.cps :refer [spin]]
+            [org.replikativ.spindel.world.scope :as world-scope]
             [org.replikativ.spindel.yggdrasil :as ygg]
             [yggdrasil.convergent.gset :as g]))
 
@@ -93,7 +94,13 @@
             (is (every? map?
                         (map #(rtp/get-state
                                % [:inference :world-descriptor])
-                             (measure/get-contexts posterior)))))))
+                             (measure/get-contexts posterior))))
+            (is (every? #(= :discarded
+                            (:fork/status
+                             (rtp/get-state
+                              % [:inference :world-descriptor])))
+                        (measure/get-contexts posterior))
+                "posterior descriptors reflect final settlement"))))
       (finally
         (context/stop-context! root)))))
 
@@ -257,14 +264,15 @@
             (is (= ::still-waiting
                    (deref cancelled 100 ::still-waiting))
                 "the late fork callback cannot erase an unwinding source")
-            (is (= 1 (count (:active-contexts @@manager*))))
+            (is (= 1 (count (world-scope/activity-values
+                             @manager* :particle-context))))
             (deliver release-source-finalizer true)
             (is (= [:ok nil] (deref cancelled 5000 ::timed-out)))
             (is (instance? Throwable (deref outcome 5000 ::timed-out)))
             (is (zero? @child-entered))
             (is (= :discarded (:status @@manager*)))
-            (is (= 2 (count (:descriptors @@manager*)))
-                "the late child handle remains inside affine cleanup")
+            (is (= 1 (count (:descriptors @@manager*)))
+                "work not admitted before cancellation cannot create a world")
             (is (empty? (:handles @@manager*))))))
       (finally
         (deliver release-child-fork true)
@@ -650,7 +658,8 @@
                            (deref task 5000 ::timed-out)
                            (catch Throwable error error)))]
             (is (= true (deref second-pass 5000 ::timed-out)))
-            (is (= 2 (count (:active-contexts @@manager*)))
+            (is (= 2 (count (world-scope/activity-values
+                             @manager* :particle-context)))
                 "an :iterate completion is not a terminal world callback")
             (is (= [:ok nil]
                    (await-cps

--- a/test/org/replikativ/spindel/world/scope_retry_test.clj
+++ b/test/org/replikativ/spindel/world/scope_retry_test.clj
@@ -1,0 +1,103 @@
+(ns org.replikativ.spindel.world.scope-retry-test
+  (:require [clojure.test :refer [deftest is]]
+            [org.replikativ.spindel.world.scope :as scope]
+            [org.replikativ.spindel.yggdrasil :as ygg]))
+
+(defn- start-discard [world-scope]
+  (let [result (promise)
+        worker (future
+                 ((scope/discard! world-scope)
+                  #(deliver result [:ok %])
+                  #(deliver result [:error %])))]
+    {:result result :worker worker}))
+
+(defn- await-result [{:keys [result worker]}]
+  (let [outcome (deref result 5000 ::timeout)]
+    (is (not= ::timeout outcome))
+    (is (not= ::timeout (deref worker 5000 ::timeout)))
+    outcome))
+
+(defn- wait-until [pred timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (cond
+        (pred) true
+        (< (System/currentTimeMillis) deadline)
+        (do (Thread/sleep 5) (recur))
+        :else false))))
+
+(deftest failed-discard-closes-its-cleanup-generation-before-retry
+  (let [world-scope (scope/create {:purpose :retry-test})
+        token (random-uuid)
+        handle (ygg/->ForkHandle nil nil (random-uuid) {:fork/id :test}
+                                 (atom {:status :open :token token}) token)
+        failure (ex-info "first discard failed" {})
+        transition-entered (promise)
+        release-transition (promise)
+        block-first-failure? (atom true)
+        discard-calls (atom 0)
+        second-discard-invoked (promise)]
+    (swap! world-scope assoc :handles [handle])
+    (set-validator!
+     world-scope
+     (fn [state]
+       (when (and (= :open (:status state))
+                  (identical? failure (:error state))
+                  (compare-and-set! block-first-failure? true false))
+         (deliver transition-entered true)
+         @release-transition)
+       true))
+    (try
+      (with-redefs [ygg/discard-fork!
+                    (fn [_handle _opts]
+                      (let [call (swap! discard-calls inc)]
+                        (fn [resolve reject]
+                          (if (= 1 call)
+                            (reject failure)
+                            (do
+                              (deliver second-discard-invoked true)
+                              (resolve nil))))))]
+        (let [first-attempt (start-discard world-scope)]
+          (is (= true (deref transition-entered 5000 ::timeout)))
+          (let [joined-attempt (start-discard world-scope)]
+            (is (= ::pending
+                   (deref second-discard-invoked 100 ::pending))
+                "a retry cannot start while the failed generation is unpublished")
+            (deliver release-transition true)
+            (is (= [:error failure] (await-result first-attempt)))
+            (is (= [:error failure] (await-result joined-attempt)))
+            (is (= 1 @discard-calls))
+            (is (= :open (:status @world-scope)))
+            (is (= [:ok nil]
+                   (await-result (start-discard world-scope))))
+            (is (= true
+                   (deref second-discard-invoked 5000 ::timeout)))
+            (is (= 2 @discard-calls))
+            (is (= :discarded (:status @world-scope))))))
+      (finally
+        (deliver release-transition true)
+        (set-validator! world-scope nil)))))
+
+(deftest busy-discard-does-not-create-a-shared-cleanup-generation
+  (let [world-scope (scope/create {:purpose :busy-retry-test})
+        activity (scope/begin-activity! world-scope :work)
+        [status error] (await-result (start-discard world-scope))]
+    (is (= :error status))
+    (is (= ::scope/scope-busy (:type (ex-data error))))
+    (is (= :open (:status @world-scope)))
+    (is (not (contains? @world-scope :discard-readers)))
+    (scope/end-activity! world-scope activity)
+    (is (= [:ok nil] (await-result (start-discard world-scope))))
+    (is (= :discarded (:status @world-scope)))))
+
+(deftest cancellation-after-a-busy-attempt-remains-live
+  (let [world-scope (scope/create {:purpose :cancel-retry-test})
+        activity (scope/begin-activity! world-scope :work)
+        [status error] (await-result (start-discard world-scope))]
+    (is (= :error status))
+    (is (= ::scope/scope-busy (:type (ex-data error))))
+    (scope/end-activity! world-scope activity)
+    (scope/request-cancel! world-scope)
+    (is (wait-until #(= :discarded (:status @world-scope)) 5000))
+    (is (true? (:cancel-requested? @world-scope)))
+    (is (empty? (:handles @world-scope)))))

--- a/test/org/replikativ/spindel/world/scope_test.clj
+++ b/test/org/replikativ/spindel/world/scope_test.clj
@@ -148,3 +148,166 @@
           (fn [error] (throw error)))))
     (is (= :discarded (:status @world-scope)))
     (is (nil? (await-cps (scope/discard! world-scope))))))
+
+(deftest quiescence-readers-are-released-only-by-a-committed-transition
+  (let [world-scope (scope/create {:purpose :search})
+        old-activity (scope/begin-activity! world-scope :old)
+        quiescent (promise)
+        transition-entered (promise)
+        release-transition (promise)
+        armed? (atom false)]
+    ((scope/await-quiescence world-scope)
+     #(deliver quiescent [:ok %])
+     #(deliver quiescent [:error %]))
+    ;; Atom validators run after swap!'s function has selected a candidate but
+    ;; before compare-and-set. Hold the empty/quiescent candidate while another
+    ;; activity wins the CAS, forcing the completion function to retry.
+    (set-validator!
+     world-scope
+     (fn [state]
+       (when (and @armed? (:quiescent? state))
+         (deliver transition-entered true)
+         @release-transition)
+       true))
+    (reset! armed? true)
+    (let [ending (future (scope/end-activity! world-scope old-activity))]
+      (is (= true (deref transition-entered 5000 ::timeout)))
+      (let [new-activity (scope/begin-activity! world-scope :new)]
+        (deliver release-transition true)
+        (is (nil? (deref ending 5000 ::timeout)))
+        (is (= ::pending (deref quiescent 50 ::pending))
+            "a failed quiescence CAS must not release captured readers")
+        (scope/end-activity! world-scope new-activity)
+        (is (= [:ok nil] (deref quiescent 5000 ::timeout)))))))
+
+(deftest quiescence-reader-failure-does-not-orphan-other-readers
+  (let [world-scope (scope/create {:purpose :search})
+        activity (scope/begin-activity! world-scope :work)
+        callback-error (ex-info "quiescence callback failed" {})
+        second-reader (promise)]
+    ((scope/await-quiescence world-scope)
+     (fn [_] (throw callback-error))
+     (fn [error] (throw error)))
+    ((scope/await-quiescence world-scope)
+     #(deliver second-reader [:ok %])
+     #(deliver second-reader [:error %]))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"quiescence callback failed"
+         (scope/end-activity! world-scope activity)))
+    (is (= [:ok nil] (deref second-reader 5000 ::timeout))
+        "one continuation exception must not strand later subscribers")
+    (is (nil? (await-cps (scope/discard! world-scope))))))
+
+(deftest concurrent-discard-completes-each-subscriber-once
+  (let [world-scope (scope/create {:purpose :search})
+        token (random-uuid)
+        handle (ygg/->ForkHandle nil nil (random-uuid) {:fork/id :test}
+                                 (atom {:status :open :token token}) token)
+        physical-callbacks (promise)
+        callback-counts (atom [0 0])
+        invoke (fn [idx]
+                 ((scope/discard! world-scope)
+                  (fn [_] (swap! callback-counts update idx inc))
+                  (fn [_] (swap! callback-counts update idx inc))))]
+    (swap! world-scope assoc :handles [handle])
+    (with-redefs [ygg/discard-fork!
+                  (fn [_handle _opts]
+                    (fn [resolve reject]
+                      (deliver physical-callbacks [resolve reject])))]
+      (invoke 0)
+      (is (= :discarding (:status @world-scope)))
+      (invoke 1)
+      (let [[resolve _reject] (deref physical-callbacks 5000 ::timeout)]
+        (is (fn? resolve))
+        (resolve nil))
+      (is (= [1 1] @callback-counts)
+          "one physical cleanup completes every subscriber exactly once")
+      (is (= :discarded (:status @world-scope)))
+      (is (nil? (await-cps (scope/discard! world-scope)))))))
+
+(deftest activity-results-agree-with-the-committed-scope-state-after-retry
+  (testing "begin neither loses a committed lease ID nor reports a phantom lease"
+    (let [world-scope (scope/create {:purpose :search})
+          entered (promise)
+          release-transition (promise)
+          armed? (atom false)]
+      (swap! world-scope assoc :status :discarding)
+      (set-validator!
+       world-scope
+       (fn [state]
+         (when (and @armed? (= :discarding (:status state)))
+           (deliver entered true)
+           @release-transition)
+         true))
+      (reset! armed? true)
+      (let [outcome (future
+                      (try
+                        [:ok (scope/begin-activity! world-scope :work)]
+                        (catch Throwable error [:error error])))]
+        ;; A pure CAS implementation may reject without proposing the unchanged
+        ;; state. The old retry-side-effect implementation enters the validator;
+        ;; reopen it to make that stale error observable after its successful retry.
+        (when (= true (deref entered 200 ::not-entered))
+          (swap! world-scope assoc :status :open)
+          (deliver release-transition true))
+        (when-not (realized? release-transition)
+          (swap! world-scope assoc :status :open)
+          (deliver release-transition true))
+        (let [completed (deref outcome 5000 ::timeout)
+              _ (is (not= ::timeout completed))
+              [status value] (when (vector? completed) completed)
+              work-ids (->> (:activities @world-scope)
+                            (keep (fn [[id activity]]
+                                    (when (= :work (:kind activity)) id)))
+                            set)]
+          (if (= :ok status)
+            (is (contains? work-ids value))
+            (is (empty? work-ids)
+                "a rejected begin must not have committed an unreachable lease"))
+          (doseq [id work-ids] (scope/end-activity! world-scope id))
+          (is (nil? (await-cps (scope/discard! world-scope))))))))
+
+  (testing "exchange cannot commit replacements and then throw a stale collision"
+    (let [world-scope (scope/create {:purpose :search})
+          source (scope/begin-activity! world-scope :source)
+          collision (scope/begin-activity! world-scope :collision)
+          entered (promise)
+          release-transition (promise)
+          armed? (atom false)]
+      (set-validator!
+       world-scope
+       (fn [state]
+         (when (and @armed?
+                    (contains? (:activities state) source)
+                    (contains? (:activities state) collision))
+           (deliver entered true)
+           @release-transition)
+         true))
+      (reset! armed? true)
+      (let [outcome (future
+                      (try
+                        [:ok (scope/exchange-activity!
+                              world-scope source
+                              [{:id collision :kind :replacement}])]
+                        (catch Throwable error [:error error])))]
+        (when (= true (deref entered 200 ::not-entered))
+          (scope/end-activity! world-scope collision)
+          (deliver release-transition true))
+        (when-not (realized? release-transition)
+          (deliver release-transition true))
+        (let [completed (deref outcome 5000 ::timeout)
+              _ (is (not= ::timeout completed))
+              [status value] (when (vector? completed) completed)
+              replacement? (= :replacement
+                              (get-in @world-scope
+                                      [:activities collision :kind]))]
+          (if (= :ok status)
+            (do
+              (is (:admitted? value))
+              (is replacement?))
+            (is (not replacement?)
+                "a rejected exchange must not commit replacement leases"))
+          (doseq [id (keys (:activities @world-scope))]
+            (scope/end-activity! world-scope id))
+          (is (nil? (await-cps (scope/discard! world-scope)))))))))

--- a/test/org/replikativ/spindel/world/scope_test.clj
+++ b/test/org/replikativ/spindel/world/scope_test.clj
@@ -1,0 +1,150 @@
+(ns org.replikativ.spindel.world.scope-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [org.replikativ.spindel.engine.context :as context]
+            [org.replikativ.spindel.engine.core :as ec]
+            [org.replikativ.spindel.world.scope :as scope]
+            [org.replikativ.spindel.yggdrasil :as ygg]))
+
+(defn- await-cps [operation]
+  (let [result (promise)]
+    (operation #(deliver result [:ok %])
+               #(deliver result [:error %]))
+    (let [[status value :as outcome] (deref result 5000 ::timeout)]
+      (when (= ::timeout outcome)
+        (throw (ex-info "CPS operation timed out" {})))
+      (if (= :ok status) value (throw value)))))
+
+(defn- fork! [world-scope source]
+  (let [result (promise)]
+    (scope/fork! world-scope source
+                 #(deliver result [:ok %])
+                 #(deliver result [:error %]))
+    (let [[status value :as outcome] (deref result 5000 ::timeout)]
+      (when (= ::timeout outcome)
+        (throw (ex-info "World fork timed out" {})))
+      (if (= :ok status) value (throw value)))))
+
+(deftest generic-scope-owns-quiescence-and-affine-discard
+  (let [root (context/create-execution-context)
+        world-scope (scope/create {:purpose :search
+                                   :fork-opts {:systems :none}})
+        generation (scope/begin-activity! world-scope :generation)
+        world (binding [ec/*execution-context* root]
+                (fork! world-scope root))
+        handle (first (:handles @world-scope))
+        child (:child-ctx world)
+        quiescent (promise)]
+    (try
+      (is (:admitted?
+           (scope/exchange-activity!
+            world-scope generation
+            [{:id (:fork-id child) :kind :context :value child}])))
+      ((scope/await-quiescence world-scope)
+       #(deliver quiescent %)
+       #(deliver quiescent %))
+      (is (= ::pending (deref quiescent 20 ::pending)))
+      (is (= :search (:fork/purpose (:descriptor world))))
+
+      (testing "cancellation is only a request until the client proves quiescence"
+        (scope/request-cancel! world-scope)
+        (is (ygg/open-fork? handle))
+        (scope/end-activity! world-scope (:fork-id child))
+        (is (nil? (deref quiescent 5000 ::timeout)))
+        (await-cps (scope/discard-when-quiescent! world-scope)))
+
+      (is (= :discarded (:status @world-scope)))
+      (is (empty? (:handles @world-scope)))
+      (is (= 1 (count (scope/descriptors world-scope))))
+      (is (= :search (:fork/purpose (first (scope/descriptors world-scope)))))
+      (is (not (ygg/open-fork? handle)))
+
+      (testing "a consumed scope cannot leak a later fork"
+        (let [outcome (try
+                        (binding [ec/*execution-context* root]
+                          (fork! world-scope root))
+                        :unexpected-success
+                        (catch Throwable error error))]
+          (is (= ::scope/scope-consumed (:type (ex-data outcome))))
+          (is (empty? (:handles @world-scope)))))
+      (finally
+        (when (ygg/open-fork? handle)
+          (binding [ec/*execution-context* root]
+            (ygg/discard-fork! handle)))
+        (context/stop-context! child)
+        (context/stop-context! root)))))
+
+(deftest quiescence-closes-admission-atomically
+  (let [world-scope (scope/create {:purpose :search})]
+    (is (nil? (await-cps (scope/await-quiescence world-scope))))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"closed world scope"
+         (scope/begin-activity! world-scope :late-work)))))
+
+(deftest discard-rejects-live-activity-without-consuming-the-scope
+  (let [world-scope (scope/create {:purpose :search})
+        activity (scope/begin-activity! world-scope :evaluation)
+        outcome (try
+                  (await-cps (scope/discard! world-scope))
+                  :unexpected-success
+                  (catch Throwable error error))]
+    (is (= ::scope/scope-busy (:type (ex-data outcome))))
+    (is (= :open (:status @world-scope)))
+    (scope/end-activity! world-scope activity)
+    (is (nil? (await-cps (scope/discard! world-scope))))
+    (is (= :discarded (:status @world-scope)))))
+
+(deftest successful-callback-exceptions-are-not-reinterpreted-as-rejections
+  (let [root (context/create-execution-context)
+        child (context/create-execution-context)
+        world-scope (scope/create {:purpose :search})
+        activity (scope/begin-activity! world-scope :construction)
+        callback-error (ex-info "callback failed" {:stage :continuation})]
+    (try
+      (with-redefs [ygg/fork! (fn [_opts]
+                                (fn [resolve _reject]
+                                  (resolve {:child-ctx child})))
+                    ygg/fork-descriptor (constantly {:fork/id :synthetic})]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"callback failed"
+             (binding [ec/*execution-context* root]
+               (scope/fork! world-scope root
+                            (fn [_] (throw callback-error))
+                            (fn [error] (throw error)))))))
+      (finally
+        ;; The synthetic handle carries no settlement authority.
+        (swap! world-scope assoc :handles [])
+        (scope/end-activity! world-scope activity)
+        (context/stop-context! child)
+        (context/stop-context! root)))))
+
+(deftest activity-exchange-cannot-overwrite-another-lease
+  (let [world-scope (scope/create {:purpose :search})
+        source (scope/begin-activity! world-scope :source)
+        existing (scope/begin-activity! world-scope :existing)
+        outcome (try
+                  (scope/exchange-activity!
+                   world-scope source
+                   [{:id existing :kind :replacement}])
+                  :unexpected-success
+                  (catch Throwable error error))]
+    (is (= ::scope/activity-id-collision (:type (ex-data outcome))))
+    (is (= 2 (count (:activities @world-scope))))
+    (scope/end-activity! world-scope source)
+    (scope/end-activity! world-scope existing)
+    (is (nil? (await-cps (scope/discard! world-scope))))))
+
+(deftest discard-callback-exceptions-do-not-corrupt-settlement
+  (let [world-scope (scope/create {:purpose :search})
+        activity (scope/begin-activity! world-scope :work)
+        callback-error (ex-info "discard callback failed" {})]
+    (scope/end-activity! world-scope activity)
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"discard callback failed"
+         ((scope/discard! world-scope)
+          (fn [_] (throw callback-error))
+          (fn [error] (throw error)))))
+    (is (= :discarded (:status @world-scope)))
+    (is (nil? (await-cps (scope/discard! world-scope))))))


### PR DESCRIPTION
## Summary

- extract SMC's canonical-world ownership lifecycle into an algorithm-neutral WorldScope
- model live computation with composable activity leases and atomic one-to-many lease exchange
- close admission and publish quiescence in one state machine
- keep ForkHandles private; callers receive only child contexts and portable descriptors
- retain SMC compatibility while centralizing async fork construction, cancellation hand-back, and reverse-order affine discard

## Why

SMC, MCTS, and nested bounded simulations need one ownership protocol for Yggdrasil worlds. Yggdrasil remains the substrate settlement layer; the scope owns live ForkHandles; algorithm clients own computation leases. This avoids inventing a second fork abstraction in Dvergr and avoids baking SMC generation semantics into the generic layer.

## Independent review fixes

- reject fork admission after cancellation, quiescence, or settlement
- make discard lose atomically to pending forks and live activities
- publish quiescence atomically with closed admission
- propagate fork and discard continuation exceptions without corrupting settlement
- remove raw ForkHandle authority from fork results
- replace singleton generation flags with composable activity leases
- cancel newly exchanged particles without double-cancelling retiring sources
- resolve posterior descriptors against terminal settlement state
- reject duplicate/colliding activity IDs

Independent final re-review: clean, no remaining medium-or-higher findings.

## Verification

- scope and canonical-world JVM suite: 21 tests, 128 assertions, green
- CLJS compile green; 431 tests, 1,619 assertions, green
- formatter and diff check green
- initial full JVM run reached 1,020 tests; unrelated async timeouts under system memory pressure pass in isolation

## Stack

Depends on #49, which depends on #50. Restack onto main after those releases.